### PR TITLE
Remplacement de l'attibut title sur balises de liens

### DIFF
--- a/lemarche/templates/cms/article_item.html
+++ b/lemarche/templates/cms/article_item.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     <div class="card-footer text-right">
-        <a href="{{ article.url }}" class="btn btn-link btn-ico stretched-link" title="Lire la suite de l'article : {{ article.title }}">
+        <a href="{{ article.url }}" class="btn btn-link btn-ico stretched-link" aria-label="Lire la suite de l'article : {{ article.title }}">
             <span>Lire la suite </span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>

--- a/lemarche/templates/dashboard/_aides_territoires_section.html
+++ b/lemarche/templates/dashboard/_aides_territoires_section.html
@@ -15,7 +15,7 @@
                         <p class="h3 mb-2">Trouver des aides financières sur votre territoire pour faciliter votre développement.</p>
                         <p>Venez découvrir plus de 2900 aides répertoriées sur tout le territoire.</p>
                         <p class="mb-0 text-right">
-                            <a href="https://aides-territoires.beta.gouv.fr/" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary btn-ico" title="Aides-territoires | Aides publiques pour les collectivités">
+                            <a href="https://aides-territoires.beta.gouv.fr/" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary btn-ico" aria-label="Aides-territoires | Aides publiques pour les collectivités">
                                 <span>Aides-territoires</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>

--- a/lemarche/templates/dashboard/profile_favorite_list.html
+++ b/lemarche/templates/dashboard/profile_favorite_list.html
@@ -59,7 +59,7 @@
                     <ul class="list-group">
                     {% for favorite_list in favorite_lists.all %}
                         <li class="list-group-item">
-                            <a href="{% url 'dashboard:profile_favorite_list_detail' favorite_list.slug %}" class="d-flex justify-content-between align-items-center text-decoration-none" title="Voir la liste">
+                            <a href="{% url 'dashboard:profile_favorite_list_detail' favorite_list.slug %}" class="d-flex justify-content-between align-items-center text-decoration-none" aria-label="Voir la liste">
                                 <span>{{ favorite_list.name }} <span class="ml-2 fs-xs badge badge-marche-light badge-pill">{{ favorite_list.siaes.count }}</span></span>
                                 <i class="ri-eye-line ri-lg"></i>
                             </a>
@@ -68,7 +68,7 @@
                     </ul>
                 {% else %}
                     <p class="text-danger font-weight-bold">Vous n'avez pas encore créé de listes !</p>
-                {% endif %}                
+                {% endif %}
             </div>
         </div>
 

--- a/lemarche/templates/dashboard/profile_favorite_list_detail.html
+++ b/lemarche/templates/dashboard/profile_favorite_list_detail.html
@@ -30,10 +30,10 @@
                 <h1 class="h1 mb-3 mb-lg-5 d-flex justify-content-between">
                     <strong>{{ favorite_list.name }}</strong>
                     <div class="btn-group" role="group" aria-label="Actions sur la liste de favoris">
-                        <button class="btn btn-link btn-ico text-decoration-none" data-toggle="modal" data-target="#favorite_list_edit_modal" title="Editer la liste">
+                        <button class="btn btn-link btn-ico text-decoration-none" data-toggle="modal" data-target="#favorite_list_edit_modal" aria-label="Editer la liste">
                             <i class="ri-pencil-fill ri-lg font-weight-light"></i>
                         </button>
-                        <button class="btn btn-link btn-ico text-decoration-none" data-toggle="modal" data-target="#favorite_list_delete_modal" title="Supprimer la liste">
+                        <button class="btn btn-link btn-ico text-decoration-none" data-toggle="modal" data-target="#favorite_list_delete_modal" aria-label="Supprimer la liste">
                             <i class="ri-delete-bin-6-line ri-lg font-weight-light"></i>
                         </button>
                     </div>

--- a/lemarche/templates/dashboard/profile_network_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_list.html
@@ -28,7 +28,7 @@
             <div class="col-12">
                 <h1 class="h1 mb-3 mb-lg-5">
                     <strong>Mon réseau : {{ network }}</strong>
-                    <span class="badge badge-pill badge-marche-light fs-xs" style="vertical-align:middle;" title="{{ network.siaes.count }} adhérent{{ network.siaes.count|pluralize }}">{{ network.siaes.count }}</span>
+                    <span class="badge badge-pill badge-marche-light fs-xs" style="vertical-align:middle;" aria-label="{{ network.siaes.count }} adhérent{{ network.siaes.count|pluralize }}">{{ network.siaes.count }}</span>
                 </h1>
             </div>
         </div>
@@ -66,7 +66,7 @@
                 <h2>
                     Statistiques : toutes les demandes de devis, appel d'offres et sourcing
                     {% if siaes.count != network.siaes.count %}
-                        <span class="badge badge-pill fs-xs" style="vertical-align:middle;" title="{{ siaes.count }} structure{{ siaes.count|pluralize }} trouvée{{ siaes.count|pluralize }}">{{ siaes.count }}</span>
+                        <span class="badge badge-pill fs-xs" style="vertical-align:middle;" aria-label="{{ siaes.count }} structure{{ siaes.count|pluralize }} trouvée{{ siaes.count|pluralize }}">{{ siaes.count }}</span>
                     {% endif %}
                 </h2>
                 <table class="table table-striped table-bordred">
@@ -86,21 +86,21 @@
                                 </td>
                                 <td>
                                     {% if siae.tender_email_send_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les besoins concernés">{{ siae.tender_email_send_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" aria-label="Voir les besoins concernés">{{ siae.tender_email_send_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_display_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les besoins concernés">{{ siae.tender_detail_display_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" aria-label="Voir les besoins concernés">{{ siae.tender_detail_display_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_contact_click_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les besoins concernés">{{ siae.tender_detail_contact_click_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" aria-label="Voir les besoins concernés">{{ siae.tender_detail_contact_click_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}

--- a/lemarche/templates/dashboard/siae_edit_info.html
+++ b/lemarche/templates/dashboard/siae_edit_info.html
@@ -154,19 +154,19 @@
                 </div>
                 <div class="row">
                     <div class="col-12 col-md-6">
-                        <div class="row" title="{% get_verbose_name siae 'siret' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'siret' %}">
                             <div class="col-12 mb-3">
                                 <i class="ri-profile-line"></i>
                                 <span>{{ siae.siret_display }}</span>
                             </div>
                         </div>
-                        <div class="row" title="{% get_verbose_name siae 'kind' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'kind' %}">
                             <div class="col-12 mb-3">
                                 <i class="ri-building-4-line"></i>
                                 <span>{{ siae.get_kind_display }}</span>
                             </div>
                         </div>
-                        <div class="row" title="{% get_verbose_name siae 'address' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'address' %}">
                             <div class="col-12 mb-3">
                                 <i class="ri-map-pin-line"></i>
                                 <span>{{ siae.address }},</span>
@@ -178,19 +178,19 @@
                         </div>
                     </div>
                     <div class="col-12 col-md-6">
-                        <div class="row" title="{% get_verbose_name siae 'api_entreprise_date_constitution' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'api_entreprise_date_constitution' %}">
                             <div class="col-12 mb-3">
                                 <span>Année de création :</span>
                                 <span>{{ siae.api_entreprise_date_constitution|date:"Y"|default:"" }}</span>
                             </div>
                         </div>
-                        <div class="row" title="{% get_verbose_name siae 'api_entreprise_employees' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'api_entreprise_employees' %}">
                             <div class="col-12 mb-3">
                                 <span>{% if siae.kind == 'SEP' %}Travailleurs détenus{% else %}Salariés{% endif %} :</span>
                                 <span>{{ siae.api_entreprise_employees|default:"non disponible" }}</span>
                             </div>
                         </div>
-                        <div class="row" title="{% get_verbose_name siae 'api_entreprise_ca' %}">
+                        <div class="row" aria-label="{% get_verbose_name siae 'api_entreprise_ca' %}">
                             <div class="col-12 mb-3">
                                 <span>Chiffre d'affaire :</span>
                                 <span>{{ siae.api_entreprise_ca|default:"non disponible" }}</span>
@@ -202,14 +202,14 @@
                     <div class="row">
                         <div class="col-12 col-md-6">
                             {% if siae.is_qpv %}
-                                <div class="row" title="{% get_verbose_name siae 'is_qpv' %}">
+                                <div class="row" aria-label="{% get_verbose_name siae 'is_qpv' %}">
                                     <div class="col-12 mb-3">
                                         <span>QPV : {{ siae.qpv_name }} ({{ siae.qpv_code }})</span>
                                     </div>
                                 </div>
                             {% endif %}
                             {% if siae.is_zrr %}
-                                <div class="row" title="{% get_verbose_name siae 'is_zrr' %}">
+                                <div class="row" aria-label="{% get_verbose_name siae 'is_zrr' %}">
                                     <div class="col-12 mb-3">
                                         <span>ZRR : {{ siae.zrr_name }} ({{ siae.zrr_code }})</span>
                                     </div>

--- a/lemarche/templates/dashboard/siae_edit_offer.html
+++ b/lemarche/templates/dashboard/siae_edit_offer.html
@@ -10,7 +10,7 @@
     {% csrf_token %}
 
     {% bootstrap_form_errors form type="all" %}
-        
+
     <div class="row mb-3 mb-lg-5">
         <div class="col-12 col-lg-8">
             <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
@@ -46,7 +46,7 @@
             </div>
         </div>
     </div>
-    
+
     <div class="row mb-3 mb-lg-5">
         <div class="col-12 col-lg-8">
             <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
@@ -95,13 +95,13 @@
                     <div id="client-reference-formset-empty-form" class="d-none">
                         <div class="form-group">
                             <label for="id_client_references-__prefix__-name">Nom</label>
-                            <input type="text" name="client_references-__prefix__-name" maxlength="255" class="form-control" title="" id="id_client_references-__prefix__-name">
+                            <input type="text" name="client_references-__prefix__-name" maxlength="255" class="form-control" aria-label="" id="id_client_references-__prefix__-name">
                         </div>
                         <div class="row">
                             <div class="col-12 col-sm-6">
                                 <div class="form-group">
                                     <!-- <label for="id_client_references-__prefix__-logo_url">Lien vers le logo</label> -->
-                                    <input type="hidden" name="client_references-__prefix__-logo_url" maxlength="500" class="form-control" title="" id="id_client_references-__prefix__-logo_url">
+                                    <input type="hidden" name="client_references-__prefix__-logo_url" maxlength="500" class="form-control" aria-label="" id="id_client_references-__prefix__-logo_url">
                                     <label for="id_client_references-__prefix__-logo_form" class="js-display-if-javascript-enabled">Logo</label>
                                     {% include "storage/s3_upload_form.html" with dropzone_form_id="id_client_references-__prefix__-logo_form" %}
                                 </div>
@@ -187,13 +187,13 @@
                     <div id="image-formset-empty-form" class="d-none">
                         <div class="form-group">
                             <label for="id_images-__prefix__-name">Nom</label>
-                            <input type="text" name="images-__prefix__-name" maxlength="255" class="form-control" title="" id="id_images-__prefix__-name">
+                            <input type="text" name="images-__prefix__-name" maxlength="255" class="form-control" aria-label="" id="id_images-__prefix__-name">
                         </div>
                         <div class="row">
                             <div class="col-12 col-sm-6">
                                 <div class="form-group">
                                     <!-- <label for="id_images-__prefix__-image_url">Lien vers l'image</label> -->
-                                    <input type="hidden" name="images-__prefix__-image_url" maxlength="500" class="form-control" title="" id="id_images-__prefix__-image_url">
+                                    <input type="hidden" name="images-__prefix__-image_url" maxlength="500" class="form-control" aria-label="" id="id_images-__prefix__-image_url">
                                     <label for="id_images-__prefix__-image_form" class="js-display-if-javascript-enabled">Image</label>
                                     {% include "storage/s3_upload_form.html" with dropzone_form_id="id_images-__prefix__-image_form" %}
                                 </div>

--- a/lemarche/templates/dashboard/siae_search_adopt_confirm.html
+++ b/lemarche/templates/dashboard/siae_search_adopt_confirm.html
@@ -35,38 +35,38 @@
                 <p class="mb-0">
                    <i>Données fixes provenant de {{ siae.source_display }}.</i>
                 </p>
-                
+
                 <hr />
-                
-                <p title="{% get_verbose_name siae 'name' %}" class="mb-0">
+
+                <p aria-label="{% get_verbose_name siae 'name' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'name' %} :</strong>
                     {{ siae.name }}
                 </p>
-                <p title="{% get_verbose_name siae 'brand' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'brand' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'brand' %} :</strong>
                     {{ siae.brand|default:'' }}
                 </p>
-                <p title="{% get_verbose_name siae 'siret' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'siret' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'siret' %} :</strong>
                     {{ siae.siret_display }}
                 </p>
-                <p title="{% get_verbose_name siae 'kind' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'kind' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'kind' %} :</strong>
                     {{ siae.get_kind_display }}
                 </p>
-                <p title="{% get_verbose_name siae 'nature' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'nature' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'nature' %} :</strong>
                     {{ siae.get_nature_display }}
                 </p>
-                <p title="{% get_verbose_name siae 'city' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'city' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'city' %} :</strong>
                     {{ siae.city }}
                 </p>
-                <p title="{% get_verbose_name siae 'post_code' %}" class="mb-0">
+                <p aria-label="{% get_verbose_name siae 'post_code' %}" class="mb-0">
                     <strong>{% get_verbose_name siae 'post_code' %} :</strong>
                     {{ siae.post_code }}
                 </p>
-                <p title="{% get_verbose_name siae 'region' %}">
+                <p aria-label="{% get_verbose_name siae 'region' %}">
                     <strong>{% get_verbose_name siae 'region' %} :</strong>
                     {{ siae.region }}
                 </p>

--- a/lemarche/templates/dashboard/siae_search_by_siret.html
+++ b/lemarche/templates/dashboard/siae_search_by_siret.html
@@ -52,19 +52,19 @@
                         <hr />
                         <div class="row">
                             <div class="col">
-                                <p title="{% get_verbose_name siae 'name' %}" class="mb-0">
+                                <p aria-label="{% get_verbose_name siae 'name' %}" class="mb-0">
                                     <strong>{% get_verbose_name siae 'name' %} :</strong>
                                     {{ siae.name }}
                                 </p>
-                                <p title="{% get_verbose_name siae 'brand' %}" class="mb-0">
+                                <p aria-label="{% get_verbose_name siae 'brand' %}" class="mb-0">
                                     <strong>{% get_verbose_name siae 'brand' %} :</strong>
                                     {{ siae.brand|default:'' }}
                                 </p>
-                                <p title="{% get_verbose_name siae 'siret' %}" class="mb-0">
+                                <p aria-label="{% get_verbose_name siae 'siret' %}" class="mb-0">
                                     <strong>{% get_verbose_name siae 'siret' %} :</strong>
                                     {{ siae.siret_display }}
                                 </p>
-                                <p title="Localisation" class="mb-0">
+                                <p aria-label="Localisation" class="mb-0">
                                     <strong>Localisation :</strong>
                                     {{ siae.city }} {{ siae.post_code }}
                                 </p>

--- a/lemarche/templates/dashboard/siae_users.html
+++ b/lemarche/templates/dashboard/siae_users.html
@@ -44,14 +44,14 @@
                                     </p>
                                 </div>
                                 <div class="col">
-                                    <span class="badge badge-pill badge-warning mt-2" title="{{ siaeuserrequest.created_at|date:'d/m/Y H:i' }}">Nouveau collaborateur</span>
+                                    <span class="badge badge-pill badge-warning mt-2" aria-label="{{ siaeuserrequest.created_at|date:'d/m/Y H:i' }}">Nouveau collaborateur</span>
                                 </div>
                                 <div class="col">
                                     <div class="float-right">
-                                        <button class="btn btn-outline-success btn-ico" data-toggle="modal" data-target="#siae_user_request_confirm_modal" data-siae-slug="{{ siae.slug }}" data-initiator-full-name="{{ siaeuserrequest.initiator.full_name }}" data-siae-user-request-id="{{ siaeuserrequest.id }}" title="Confirmer la demande">
+                                        <button class="btn btn-outline-success btn-ico" data-toggle="modal" data-target="#siae_user_request_confirm_modal" data-siae-slug="{{ siae.slug }}" data-initiator-full-name="{{ siaeuserrequest.initiator.full_name }}" data-siae-user-request-id="{{ siaeuserrequest.id }}" aria-label="Confirmer la demande">
                                             <i class="ri-check-fill ri-lg font-weight-light"></i>
                                         </button>
-                                        <button class="btn btn-outline-danger btn-ico" data-toggle="modal" data-target="#siae_user_request_cancel_modal" data-siae-slug="{{ siae.slug }}" data-initiator-full-name="{{ siaeuserrequest.initiator.full_name }}" data-siae-user-request-id="{{ siaeuserrequest.id }}" title="Refuser la demande">
+                                        <button class="btn btn-outline-danger btn-ico" data-toggle="modal" data-target="#siae_user_request_cancel_modal" data-siae-slug="{{ siae.slug }}" data-initiator-full-name="{{ siaeuserrequest.initiator.full_name }}" data-siae-user-request-id="{{ siaeuserrequest.id }}" aria-label="Refuser la demande">
                                             <i class="ri-close-fill ri-lg font-weight-light"></i>
                                         </button>
                                     </div>
@@ -81,7 +81,7 @@
                             {% if siaeuser.user != user %}
                                 <div class="col">
                                     <div class="float-right mt-2">
-                                        <button class="btn btn-link btn-ico" data-toggle="modal" data-target="#siae_user_delete_modal" data-siae-slug="{{ siae.slug }}" data-user-full-name="{{ siaeuser.user.full_name }}" data-siae-user-id="{{ siaeuser.id }}" title="Supprimer le collaborateur">
+                                        <button class="btn btn-link btn-ico" data-toggle="modal" data-target="#siae_user_delete_modal" data-siae-slug="{{ siae.slug }}" data-user-full-name="{{ siaeuser.user.full_name }}" data-siae-user-id="{{ siaeuser.id }}" aria-label="Supprimer le collaborateur">
                                             <i class="ri-delete-bin-line ri-xl font-weight-light"></i>
                                         </button>
                                     </div>

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -23,7 +23,7 @@
                     <li><a href="/qui-sommes-nous/">Qui sommes-nous&nbsp;?</a></li>
                     <li><a href="{% url 'api:home' %}">API</a></li>
                     <li><a href="{% url 'pages:stats' %}">Statistiques</a></li>
-                    <li><a href="https://github.com/betagouv/itou-marche/" target="_blank" rel="noopener" title="Github (lien externe)">Code source</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                    <li><a href="https://github.com/betagouv/itou-marche/" target="_blank" rel="noopener" aria-label="Github (lien externe)">Code source</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
                 </ul>
             </div>
         </div>
@@ -80,10 +80,10 @@
                             Libérons notre potentiel d'inclusion pour créer 100&nbsp;000 emplois de plus.
                         </p>
                         <ul>
-                            <li><a href="https://emplois.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Les emplois (lien externe)">Les emplois</a></li>
-                            <li><a href="https://communaute-experimentation.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="La communauté (lien externe)">La communauté</a></li>
-                            <li><a href="https://pilotage.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Le pilotage (lien externe)">Le pilotage</a></li>
-                            <li><a href="https://lemarche.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Le marché (lien externe)">Le marché</a></li>
+                            <li><a href="https://emplois.inclusion.beta.gouv.fr" target="_blank" rel="noopener" aria-label="Les emplois (lien externe)">Les emplois</a></li>
+                            <li><a href="https://communaute-experimentation.inclusion.beta.gouv.fr" target="_blank" rel="noopener" aria-label="La communauté (lien externe)">La communauté</a></li>
+                            <li><a href="https://pilotage.inclusion.beta.gouv.fr" target="_blank" rel="noopener" aria-label="Le pilotage (lien externe)">Le pilotage</a></li>
+                            <li><a href="https://lemarche.inclusion.beta.gouv.fr" target="_blank" rel="noopener" aria-label="Le marché (lien externe)">Le marché</a></li>
                         </ul>
                     </div>
                 </div>
@@ -96,10 +96,10 @@
             <div class="s-footer-legal__row row">
                 <div class="s-footer-legal__col col-xs-12 col-lg-8">
                     <ul>
-                        <li><a href="https://doc.inclusion.beta.gouv.fr/mentions" rel="noopener" target="_blank" title="Mentions légales (lien externe)">Mentions légales</a></li>
-                        <li><a href="/cgu/" title="Conditions générales">Conditions générales</a></li>
-                        <li><a href="/cgu-api/" title="Conditions générales de l'API">Conditions générales de l'API</a></li>
-                        <li><a href="/confidentialite/" title="Confidentialité">Confidentialité</a></li>
+                        <li><a href="https://doc.inclusion.beta.gouv.fr/mentions" rel="noopener" target="_blank" aria-label="Mentions légales (lien externe)">Mentions légales</a></li>
+                        <li><a href="/cgu/" aria-label="Conditions générales">Conditions générales</a></li>
+                        <li><a href="/cgu-api/" aria-label="Conditions générales de l'API">Conditions générales de l'API</a></li>
+                        <li><a href="/confidentialite/" aria-label="Confidentialité">Confidentialité</a></li>
                     </ul>
                     <ul>
                         <li><a href="{% url 'pages:accessibilite' %}">Accessibilité : non conforme</a></li>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -11,31 +11,31 @@
             <div class="col-12 s-preheader__col d-flex align-items-center justify-content-end">
                 <ul>
                     <li>
-                        <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" title="La Plateforme de l'inclusion (lien externe)">
+                        <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" aria-label="La Plateforme de l'inclusion (lien externe)">
                             <span>La plateforme</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
                     </li>
                     <li>
-                        <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" title="Les emplois de l'inclusion (lien externe)">
+                        <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" aria-label="Les emplois de l'inclusion (lien externe)">
                             <span>Les emplois</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
                     </li>
                     <li>
-                        <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
+                        <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" aria-label="La communauté de l'inclusion (lien externe)">
                             <span>La communauté</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
                     </li>
                     <li>
-                        <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" title="Le marché de l'inclusion (lien externe)">
+                        <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" aria-label="Le marché de l'inclusion (lien externe)">
                             <span>Le marché</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
                     </li>
                     <li>
-                        <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" title="Le pilotage de l'inclusion (lien externe)">
+                        <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" aria-label="Le pilotage de l'inclusion (lien externe)">
                             <span>Le pilotage</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
@@ -247,31 +247,31 @@
                 <div>
                     <ul>
                         <li>
-                            <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" title="La Plateforme de l'inclusion (lien externe)">
+                            <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" aria-label="La Plateforme de l'inclusion (lien externe)">
                                 <span>La plateforme</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" title="Les emplois de l'inclusion (lien externe)">
+                            <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" aria-label="Les emplois de l'inclusion (lien externe)">
                                 <span>Les emplois</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
+                            <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" aria-label="La communauté de l'inclusion (lien externe)">
                                 <span>La communauté</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" title="Le marché de l'inclusion (lien externe)">
+                            <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" aria-label="Le marché de l'inclusion (lien externe)">
                                 <span>Le marché</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" title="Le pilotage de l'inclusion (lien externe)">
+                            <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" aria-label="Le pilotage de l'inclusion (lien externe)">
                                 <span>Le pilotage</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>

--- a/lemarche/templates/pages/groupements.html
+++ b/lemarche/templates/pages/groupements.html
@@ -53,7 +53,7 @@
                         <div class="card-body">
                             <p class="h3 lh-sm">{{ group.name }}</p>
                             {% if group.sectors.count %}
-                                <div class="d-flex" title="Secteurs d'activité">
+                                <div class="d-flex" aria-label="Secteurs d'activité">
                                     <i class="ri-award-line ri-xl mr-1"></i>
                                     <ul class="list-unstyled">
                                         {% siae_sectors_display group display_max=6 output_format='li' %}
@@ -61,7 +61,7 @@
                                 </div>
                             {% endif %}
                             {% if group.siae_count %}
-                                <p title="Nombre de structures">
+                                <p aria-label="Nombre de structures">
                                     <i class="ri-hotel-line ri-xl mr-1"></i>
                                     <span>{{ group.siae_count }} structures</span>
                                 </p>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -37,16 +37,16 @@
                     </ul>
                     {% if user.is_authenticated %}
                         {% if from_profile or siae.in_user_favorite_list_count %}
-                            <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" data-siae-id="{{ siae.id }}" data-siae-slug="{{ siae.slug }}" data-siae-name-display="{{ siae.name_display }}" title="Dans votre liste d'achat">
+                            <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" data-siae-id="{{ siae.id }}" data-siae-slug="{{ siae.slug }}" data-siae-name-display="{{ siae.name_display }}" aria-label="Dans votre liste d'achat">
                                 <i class="ri-star-fill ri-xl"></i>
                             </a>
                         {% else %}
-                            <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_add_modal" data-siae-id="{{ siae.id }}" data-siae-slug="{{ siae.slug }}" data-siae-name-display="{{ siae.name_display }}" title="Ajouter à votre liste d'achat">
+                            <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_add_modal" data-siae-id="{{ siae.id }}" data-siae-slug="{{ siae.slug }}" data-siae-name-display="{{ siae.name_display }}" aria-label="Ajouter à votre liste d'achat">
                                 <i class="ri-star-line ri-xl"></i>
                             </a>
                         {% endif %}
                     {% else %}
-                        <a href="#" id="favorite-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}" title="Ajouter à votre liste d'achat">
+                        <a href="#" id="favorite-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}" aria-label="Ajouter à votre liste d'achat">
                             <i class="ri-star-line ri-xl"></i>
                         </a>
                     {% endif %}
@@ -61,10 +61,10 @@
                 <span class="sr-only">Situé à {{ siae.city }}</span>
                 <span>{{ siae.city }}</span>
                 {% if siae.is_qpv %}
-                    <span class="badge badge-sm badge-pill badge-emploi-lightest" title="Quartier prioritaire de la politique de la ville">QPV</span>
+                    <span class="badge badge-sm badge-pill badge-emploi-lightest" aria-label="Quartier prioritaire de la politique de la ville">QPV</span>
                 {% endif %}
                 {% if siae.is_zrr %}
-                    <span class="badge badge-sm badge-pill badge-emploi-lightest" title="Zone de revitalisation rurale">ZRR</span>
+                    <span class="badge badge-sm badge-pill badge-emploi-lightest" aria-label="Zone de revitalisation rurale">ZRR</span>
                 {% endif %}
             </span>
             <span class="ml-3">

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -4,7 +4,7 @@
             <div class="col-md-8" style="border-right:1px solid">
                 <div class="row">
                     <div class="col-12">
-                        <span title="{{ tendersiae.created_at }}">{{ tendersiae.created_at|date }}</span>
+                        <span aria-label="{{ tendersiae.created_at }}">{{ tendersiae.created_at|date }}</span>
                     </div>
                 </div>
                 <div class="row">

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -19,7 +19,7 @@
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'siae:search_results' %}?{{ current_search_query }}" title="Revenir aux résultats de recherche">Recherche</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'siae:search_results' %}?{{ current_search_query }}" aria-label="Revenir aux résultats de recherche">Recherche</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display }}</li>
                     </ol>
                 </nav>
@@ -56,16 +56,16 @@
                                         </h1>
                                         {% if user.is_authenticated %}
                                             {% if siae.in_user_favorite_list_count %}
-                                                <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">
+                                                <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_remove_modal" aria-label="Dans votre liste d'achat">
                                                     <i class="ri-star-fill ri-xl"></i>
                                                 </a>
                                                 {% else %}
-                                                <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_add_modal" title="Ajouter à votre liste d'achat" >
+                                                <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_add_modal" aria-label="Ajouter à votre liste d'achat" >
                                                     <i class="ri-star-line ri-xl"></i>
                                                 </a>
                                             {% endif %}
                                         {% else %}
-                                            <a href="#" id="favorite-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}" title="Ajouter à votre liste d'achat">
+                                            <a href="#" id="favorite-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}" aria-label="Ajouter à votre liste d'achat">
                                                 <i class="ri-star-line ri-xl"></i>
                                             </a>
                                         {% endif %}
@@ -80,10 +80,10 @@
                                 <div class="row">
                                     <div class="col-12">
                                         {% if siae.is_qpv %}
-                                            <span class="badge badge-pill badge-emploi-lightest" title="Quartier prioritaire de la politique de la ville">QPV</span>
+                                            <span class="badge badge-pill badge-emploi-lightest" aria-label="Quartier prioritaire de la politique de la ville">QPV</span>
                                         {% endif %}
                                         {% if siae.is_zrr %}
-                                            <span class="badge badge-pill badge-emploi-lightest" title="Zone de revitalisation rurale">ZRR</span>
+                                            <span class="badge badge-pill badge-emploi-lightest" aria-label="Zone de revitalisation rurale">ZRR</span>
                                         {% endif %}
                                         {% for group in siae.groups.all %}
                                             <span class="badge badge-pill badge-emploi-light">{{ group.name }}</span>
@@ -311,7 +311,7 @@
                                             {% endfor %}
                                             </ul>
                                         </div>
-                                        <a class="mt-3 is-collapse-caret-clients has-collapse-caret collapsed" data-toggle="collapse" href="#collapseMoreRefClients" role="button" aria-expanded="false" aria-controls="collapseMoreRefClients" title="Plus de références clients">de références clients</a>
+                                        <a class="mt-3 is-collapse-caret-clients has-collapse-caret collapsed" data-toggle="collapse" href="#collapseMoreRefClients" role="button" aria-expanded="false" aria-controls="collapseMoreRefClients" aria-label="Plus de références clients">de références clients</a>
                                     {% endif %}
                                 </div>
                             </div>
@@ -404,7 +404,7 @@
                         <div id="image-grid" class="row">
                             {% for image in siae.images.all %}
                                 <div class="col-12 col-sm-4 pb-3"> <!-- 3 per row -->
-                                    <img src="{{ image.image_url }}" class="img-fluid" title="{{ image.name|default:'' }}" loading="lazy" />
+                                    <img src="{{ image.image_url }}" class="img-fluid" alt="{{ image.name|default:'' }}" loading="lazy" />
                                 </div>
                             {% endfor %}
                         </div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -27,13 +27,13 @@
         <hr />
 
         <div class="row">
-            <div class="col-md-4" title="Secteurs d'activité">
+            <div class="col-md-4" aria-label="Secteurs d'activité">
                 {% if tender.sectors.count %}
                     <i class="ri-award-line"></i>
                     {{ tender.sectors_list_string|safe }}
                 {% endif %}
             </div>
-            <div class="col-md-4 text-center" title="Lieu d'intervention">
+            <div class="col-md-4 text-center" aria-label="Lieu d'intervention">
                 {% if tender.perimeters_list_string %}
                     <i class="ri-map-pin-2-line"></i>
                     {{ tender.perimeters_list_string|safe }}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -146,7 +146,7 @@
                                 </p>
                             </div>
                         {% elif not user_siae_has_detail_contact_click_date %}
-                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="Répondre à cette opportunité">
+                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" aria-label="Répondre à cette opportunité">
                                 Répondre à cette opportunité
                             </button>
                             <div id="show-tender-contact-content" style="display:none">

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -18,16 +18,16 @@
             </div>
         </div>
         <div class="row text-bold">
-            <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
+            <div class="col" aria-label="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
                 <i class="ri-award-line"></i>
                 {{ tender.sectors_list_string }}
             </div>
-            <div class="col" title="Lieu d'éxécution">
+            <div class="col" aria-label="Lieu d'éxécution">
                 <i class="ri-map-pin-2-line"></i>
                 {{ tender.location_display|safe }}
             </div>
             {% if tender.presta_type %}
-                <div class="col" title="Type de prestation">
+                <div class="col" aria-label="Type de prestation">
                     <i class="ri-briefcase-4-line"></i>
                     {% array_choices_display tender 'presta_type' %}
                 </div>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/A11Y-Am-lioration-des-title-et-aria-label-7e6d702c19e749b6bd4e18ff09937376

### Pourquoi ?

Amélioration de l'accessibilité. Remplacement de l'attibut `title` par `aria-label` sur balises de liens `<a>` .

De manière générale, il est maintenant recommandé d'utiliser `aria-label` plutot que `title` partout sauf sur les `<iframes>` (et les tooltip, popover pour bs). Donc a mettre quand nécessaire sur les `<button>`, `<input>` (sans label), `<a>` 

### Liens utiles

PR liée à cette discussion : https://github.com/betagouv/itou/pull/2091#discussion_r1098804286