### PR TITLE
[Structures] Rattachement : déplacer la mention de contacter le support

### DIFF
--- a/lemarche/templates/dashboard/siae_search_adopt_confirm.html
+++ b/lemarche/templates/dashboard/siae_search_adopt_confirm.html
@@ -73,9 +73,14 @@
 
                 {% if siae.users.count %}
                     <div class="alert alert-warning" role="alert">
-                        <p class="mb-0">
-                            <i>{{ siae.users.first.full_name }}</i> est déjà rattaché à cette structure sur le marché.<br />
+                        <p>
+                            <i>{{ siae.users.first.full_name }}</i> est déjà rattaché à cette structure sur le marché.
+                        </p>
+                        <p>
                             En cliquant sur <strong>Demander le rattachement</strong>, un e-mail sera envoyé à <i>{{ siae.users.first.full_name }}</i> ({{ siae.users.first.email_anonymized }}) afin qu'il ou elle valide votre rattachement.
+                        </p>
+                        <p class="mb-0">
+                            Cet utilisateur ne fait plus partie de la structure ? <a href="{% url 'pages:contact' %}?siret={{ siae.siret }}">Contactez le support</a>
                         </p>
                     </div>
                 {% endif %}

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -86,10 +86,7 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
                 logs=[{"action": "create", "timestamp": timezone.now().isoformat()}],
             )
             send_siae_user_request_email_to_assignee(siae_user_request)
-            success_message = (
-                f"La demande a été envoyée à {self.object.users.first().full_name}.<br />"
-                f"<i>Cet utilisateur ne fait plus partie de la structure ? <a href=\"{reverse_lazy('pages:contact')}?siret={self.object.siret}\">Contactez le support</a></i>"  # noqa
-            )
+            success_message = f"La demande a été envoyée à {self.object.users.first().full_name}."
             messages.add_message(self.request, messages.SUCCESS, success_message)
             return HttpResponseRedirect(reverse_lazy("dashboard:home"))
 


### PR DESCRIPTION
### Quoi ?

Demande de rattachement lorsqu'un utilisateur est déjà rattaché, rajouter le message de contacter le support si cette personne ne fait plus partie de la structure.

### Pourquoi ?

La mention de contacter le support était trop loin dans le workflow, c'est mieux de la mettre avant de faire l'action de demande de rattachement.