### PR TITLE
[Tech] Renommer le script de synchro avec le C1

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -3,7 +3,7 @@
     "15 0 * * * $ROOT/clevercloud/stats_export_user_download_list_to_file.sh",
     "30 0 * * * $ROOT/clevercloud/stats_export_user_search_list_to_file.sh",
     "0 1 * * * $ROOT/clevercloud/tenders_update_count_fields.sh",
-    "0 7 * * 1 $ROOT/clevercloud/siaes_sync_c1_c4.sh",
+    "0 7 * * 1 $ROOT/clevercloud/siaes_sync_with_emplois_inclusion.sh",
     "5 7 * * 1 $ROOT/clevercloud/siaes_sync_c2_c4.sh",
     "10 7 * * 1 $ROOT/clevercloud/siaes_update_api_entreprise_fields.sh",
     "15 7 * * 1 $ROOT/clevercloud/siaes_update_api_qpv_fields.sh",

--- a/clevercloud/siaes_sync_with_emplois_inclusion.sh
+++ b/clevercloud/siaes_sync_with_emplois_inclusion.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -l
 
-# Fetch new siaes from C1 + update existing
+# Fetch new siaes from les-emplois + update existing
 
 # Do not run if this env var is not set:
-if [[ -z "$CRON_SYNC_C1_C4_ENABLED" ]]; then
-    echo "CRON_SYNC_C1_C4_ENABLED not set. Exiting..."
+if [[ -z "$CRON_SYNC_WITH_EMPLOIS_INCLUSION_ENABLED" ]]; then
+    echo "CRON_SYNC_WITH_EMPLOIS_INCLUSION_ENABLED not set. Exiting..."
     exit 0
 fi
 
@@ -19,4 +19,4 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd $APP_HOME
 
-django-admin sync_c1_c4
+django-admin sync_with_emplois_inclusion


### PR DESCRIPTION
### Quoi ?

Suite de #993

- remplacé au maximum "C1" par "Les emplois"
- le nouveau script s'appelle `sync_with_emplois_inclusion`