### PR TITLE
[Tech] Léger refactoring des champs en lecture seule dans l'admin

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -182,7 +182,6 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "tender_detail_display_count_annotated_with_link",
         "tender_detail_contact_click_count_annotated_with_link",
         "logs_display",
-        # "import_raw_object",
         "import_raw_object_display",
     ]
     formfield_overrides = {

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -184,8 +184,6 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "logs_display",
         # "import_raw_object",
         "import_raw_object_display",
-        "created_at",
-        "updated_at",
     ]
     formfield_overrides = {
         ChoiceArrayField: {"widget": forms.CheckboxSelectMultiple(attrs={"class": "custom-checkbox-select-multiple"})},
@@ -231,13 +229,13 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                 )
             },
         ),
-        ("Données C2", {"fields": Siae.READONLY_FIELDS_FROM_C2}),
-        ("Données API Entreprise", {"fields": Siae.READONLY_FIELDS_FROM_API_ENTREPRISE}),
+        ("Données C2", {"fields": Siae.FIELDS_FROM_C2}),
+        ("Données API Entreprise", {"fields": Siae.FIELDS_FROM_API_ENTREPRISE}),
         (
             "Données API QPV (Quartier prioritaire de la politique de la ville)",
-            {"fields": Siae.READONLY_FIELDS_FROM_QPV},
+            {"fields": Siae.FIELDS_FROM_QPV},
         ),
-        ("Données API ZRR (Zone de revitalisation rurale)", {"fields": Siae.READONLY_FIELDS_FROM_ZRR}),
+        ("Données API ZRR (Zone de revitalisation rurale)", {"fields": Siae.FIELDS_FROM_ZRR}),
         (
             "Détails",
             {

--- a/lemarche/siaes/management/commands/update_siae_count_fields.py
+++ b/lemarche/siaes/management/commands/update_siae_count_fields.py
@@ -4,25 +4,6 @@ from lemarche.utils.apis import api_slack
 from lemarche.utils.commands import BaseCommand
 
 
-SIAE_COUNT_FIELDS = [
-    "user_count",
-    "sector_count",
-    "network_count",
-    "group_count",
-    "offer_count",
-    "client_reference_count",
-    "label_count",
-    "image_count",
-    "etablissement_count",
-    "completion_rate",
-    "tender_count",
-    "tender_email_send_count",
-    "tender_email_link_click_count",
-    "tender_detail_display_count",
-    "tender_detail_contact_click_count",
-]
-
-
 class Command(BaseCommand):
     """
     Goal: update the '_count' fields of each Siae
@@ -47,9 +28,9 @@ class Command(BaseCommand):
 
         # Step 1a: build the queryset
         siae_queryset = (
-            Siae.objects.prefetch_related(
-                "users", "sectors", "networks", "groups", "offers", "client_references", "labels", "images"
-            )
+            Siae.objects.prefetch_many_to_many()
+            .prefetch_many_to_one()
+            .prefetch("users", "groups", "labels")
             .with_tender_stats()
             .all()
         )
@@ -58,7 +39,7 @@ class Command(BaseCommand):
         self.stdout_messages_info(f"Found {siae_queryset.count()} siaes")
 
         # Step 1b: init fields to update
-        update_fields = options["fields"] if options["fields"] else SIAE_COUNT_FIELDS
+        update_fields = options["fields"] if options["fields"] else Siae.FIELDS_STATS_COUNT
         self.stdout_messages_info(f"Fields to update: {update_fields}")
 
         # Step 2: loop on each Siae

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -491,7 +491,7 @@ class SiaeQuerySet(models.QuerySet):
 
 
 class Siae(models.Model):
-    READONLY_FIELDS_FROM_C1 = [
+    FIELDS_FROM_C1 = [
         "name",
         "slug",  # generated from 'name'
         "brand",
@@ -518,14 +518,14 @@ class Siae(models.Model):
         "c1_last_sync_date",
         "source",
     ]
-    READONLY_FIELDS_FROM_C2 = [
+    FIELDS_FROM_C2 = [
         "c2_etp_count",
         "c2_etp_count_date_saisie",
         "c2_etp_count_last_sync_date",
     ]
-    READONLY_FIELDS_FROM_QPV = ["is_qpv", "qpv_name", "qpv_code", "api_qpv_last_sync_date"]
-    READONLY_FIELDS_FROM_ZRR = ["is_zrr", "zrr_name", "zrr_code", "api_zrr_last_sync_date"]
-    READONLY_FIELDS_FROM_API_ENTREPRISE = [
+    FIELDS_FROM_QPV = ["is_qpv", "qpv_name", "qpv_code", "api_qpv_last_sync_date"]
+    FIELDS_FROM_ZRR = ["is_zrr", "zrr_name", "zrr_code", "api_zrr_last_sync_date"]
+    FIELDS_FROM_API_ENTREPRISE = [
         "api_entreprise_forme_juridique",
         "api_entreprise_forme_juridique_code",
         "api_entreprise_entreprise_last_sync_date",
@@ -537,14 +537,27 @@ class Siae(models.Model):
         "api_entreprise_ca_date_fin_exercice",
         "api_entreprise_exercice_last_sync_date",
     ]
-    READONLY_FIELDS_STATS = ["etablissement_count", "signup_date", "content_filled_basic_date", "completion_rate"]
+    FIELDS_STATS_COUNT = [
+        "user_count",
+        "sector_count",
+        "network_count",
+        "group_count",
+        "offer_count",
+        "client_reference_count",
+        "label_count",
+        "image_count",
+        "etablissement_count",
+        "completion_rate",
+        "tender_count",
+        "tender_email_send_count",
+        "tender_email_link_click_count",
+        "tender_detail_display_count",
+        "tender_detail_contact_click_count",
+    ]
+    FIELDS_STATS_TIMESTAMPS = ["signup_date", "content_filled_basic_date", "created_at", "updated_at"]
+    FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + ["completion_rate"]
     READONLY_FIELDS = (
-        READONLY_FIELDS_FROM_C1
-        + READONLY_FIELDS_FROM_C2
-        + READONLY_FIELDS_FROM_QPV
-        + READONLY_FIELDS_FROM_ZRR
-        + READONLY_FIELDS_FROM_API_ENTREPRISE
-        + READONLY_FIELDS_STATS
+        FIELDS_FROM_C1 + FIELDS_FROM_C2 + FIELDS_FROM_QPV + FIELDS_FROM_ZRR + FIELDS_FROM_API_ENTREPRISE + FIELDS_STATS
     )
 
     TRACK_UPDATE_FIELDS = [

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -136,16 +136,9 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     ordering = ["-created_at"]
 
     autocomplete_fields = ["sectors", "location", "perimeters", "author"]
-    readonly_fields = [field.name for field in Tender._meta.fields if field.name.endswith("_last_seen_date")] + [
+    readonly_fields = [field for field in Tender.READONLY_FIELDS] + [
         # slug
         # status
-        "survey_transactioned_send_date",
-        "survey_transactioned_answer",
-        "survey_transactioned_amount",
-        "survey_transactioned_feedback",
-        "survey_transactioned_answer_date",
-        "validated_at",
-        "sent_at",
         "question_count_with_link",
         "siae_count_annotated_with_link",
         "siae_email_send_count_annotated_with_link",
@@ -156,11 +149,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "logs_display",
         "extra_data_display",
         "source",
-        # "import_raw_object",
         "import_raw_object_display",
-        "created_at",
-        "published_at",
-        "updated_at",
     ]
     formfield_overrides = {
         models.TextField: {"widget": CKEditorWidget},

--- a/lemarche/tenders/management/commands/update_tender_count_fields.py
+++ b/lemarche/tenders/management/commands/update_tender_count_fields.py
@@ -3,16 +3,6 @@ from lemarche.utils.apis import api_slack
 from lemarche.utils.commands import BaseCommand
 
 
-TENDER_COUNT_FIELDS = [
-    "siae_count",
-    "siae_email_send_count",
-    "siae_email_link_click_count",
-    "siae_detail_display_count",
-    "siae_email_link_click_or_detail_display_count",
-    "siae_detail_contact_click_count",
-]
-
-
 class Command(BaseCommand):
     """
     Goal: update the '_count' fields of each Tender
@@ -40,7 +30,7 @@ class Command(BaseCommand):
         self.stdout_messages_info(f"Found {tender_queryset.count()} tenders")
 
         # Step 1b: init fields to update
-        update_fields = options["fields"] if options["fields"] else TENDER_COUNT_FIELDS
+        update_fields = options["fields"] if options["fields"] else Tender.FIELDS_STATS_COUNT
         self.stdout_messages_info(f"Fields to update: {update_fields}")
 
         # Step 2: loop on each Tender

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -206,7 +206,14 @@ class Tender(models.Model):
         "siae_email_link_click_or_detail_display_count",
         "siae_detail_contact_click_count",
     ]
-    FIELDS_STATS_TIMESTAMPS = ["published_at", "validated_at", "sent_at", "siae_list_last_seen_date", "created_at", "updated_at"]
+    FIELDS_STATS_TIMESTAMPS = [
+        "published_at",
+        "validated_at",
+        "sent_at",
+        "siae_list_last_seen_date",
+        "created_at",
+        "updated_at",
+    ]
     FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + []
     READONLY_FIELDS = FIELDS_SURVEY_TRANSACTIONED + FIELDS_STATS
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -191,6 +191,25 @@ class TenderQuerySet(models.QuerySet):
 class Tender(models.Model):
     """Appel d'offres, demande de devis et sourcing"""
 
+    FIELDS_SURVEY_TRANSACTIONED = [
+        "survey_transactioned_send_date",
+        "survey_transactioned_answer",
+        "survey_transactioned_amount",
+        "survey_transactioned_feedback",
+        "survey_transactioned_answer_date",
+    ]
+    FIELDS_STATS_COUNT = [
+        "siae_count",
+        "siae_email_send_count",
+        "siae_email_link_click_count",
+        "siae_detail_display_count",
+        "siae_email_link_click_or_detail_display_count",
+        "siae_detail_contact_click_count",
+    ]
+    FIELDS_STATS_TIMESTAMPS = ["published_at", "validated_at", "sent_at", "siae_list_last_seen_date", "created_at", "updated_at"]
+    FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + []
+    READONLY_FIELDS = FIELDS_SURVEY_TRANSACTIONED + FIELDS_STATS
+
     # used in templates
     STATUS_DRAFT = tender_constants.STATUS_DRAFT
     STATUS_PUBLISHED = tender_constants.STATUS_PUBLISHED

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -185,18 +185,14 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
     autocomplete_fields = ["company", "partner_network"]
     readonly_fields = (
         [field.name for field in User._meta.fields if field.name.startswith("c4_")]
-        + [f"{field}_last_updated" for field in User.TRACK_UPDATE_FIELDS]
-        + [field.name for field in User._meta.fields if field.name.endswith("_last_seen_date")]
+        + [field for field in User.READONLY_FIELDS]
         + [
             "siae_count_annotated_with_link",
             "tender_count_annotated_with_link",
             "favorite_list_count_with_link",
-            "last_login",
             "image_url",
             "image_url_display",
             "extra_data",
-            "created_at",
-            "updated_at",
         ]
     )
 

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -133,6 +133,18 @@ class User(AbstractUser):
         "api_key",
     ]
 
+    FIELDS_STATS_COUNT = ["favorite_list_count"]
+    FIELDS_STATS_TIMESTAMPS = [
+        "api_key_last_updated",
+        "dashboard_last_seen_date",
+        "tender_list_last_seen_date",
+        "date_joined",
+        "last_login",
+        "created_at",
+        "updated_at",
+    ]
+    READONLY_FIELDS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS
+
     # used in templates
     KIND_SIAE = user_constants.KIND_SIAE
     KIND_BUYER = user_constants.KIND_BUYER


### PR DESCRIPTION
### Quoi ?

J'ai essayé de centraliser la liste des champs en lecture seule, à la manière de ce que l'on fait déjà pour le modèle `Siae`
- Siae : en rajoutant d'autres champs readonly
- Tender : en répliquant cette logique
- User : idem