### PR TITLE
[Utilisateurs] Rattacher correctement les utilisateurs provenant de Tally

### DIFF
--- a/lemarche/api/tenders/serializers.py
+++ b/lemarche/api/tenders/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.models import Sector
 from lemarche.tenders.models import Tender
+from lemarche.users import constants as user_constants
 
 
 class TenderSerializer(serializers.ModelSerializer):
@@ -14,6 +15,13 @@ class TenderSerializer(serializers.ModelSerializer):
         queryset=Perimeter.objects.all(), slug_field="slug", allow_null=True, required=False
     )
     extra_data = serializers.JSONField(required=False)
+    # non-model fields
+    contact_kind = serializers.ChoiceField(
+        choices=user_constants.KIND_CHOICES, allow_blank=True, write_only=True, required=False
+    )
+    contact_buyer_kind_detail = serializers.ChoiceField(
+        choices=user_constants.BUYER_KIND_DETAIL_CHOICES, allow_blank=True, write_only=True, required=False
+    )
 
     class Meta:
         model = Tender
@@ -47,4 +55,7 @@ class TenderSerializer(serializers.ModelSerializer):
             "deadline_date",
             # extra data
             "extra_data",
+            # non-model fields
+            "contact_kind",
+            "contact_buyer_kind_detail",
         ]

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -64,9 +64,7 @@ def get_or_create_user_from_anonymous_content(
     buyer_kind_detail = (
         tender_dict.get("contact_buyer_kind_detail") if tender_dict.get("contact_buyer_kind_detail") else ""
     )
-    company_name = (
-        tender_dict.get("contact_company_name") if tender_dict.get("contact_company_name") else "Particulier"
-    )
+    company_name = tender_dict.get("contact_company_name") if tender_dict.get("contact_company_name") else ""
     user, created = User.objects.get_or_create(
         email=email,
         defaults={

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -56,16 +56,26 @@ def get_or_create_user_from_anonymous_content(
     tender_dict: dict, source: str = user_constants.SOURCE_TENDER_FORM
 ) -> User:
     email = tender_dict.get("contact_email").lower()
+    kind = (
+        tender_dict.get("contact_kind")
+        if tender_dict.get("contact_kind")
+        else (User.KIND_BUYER if tender_dict.get("contact_company_name") else User.KIND_INDIVIDUAL)
+    )
+    buyer_kind_detail = (
+        tender_dict.get("contact_buyer_kind_detail") if tender_dict.get("contact_buyer_kind_detail") else ""
+    )
+    company_name = (
+        tender_dict.get("contact_company_name") if tender_dict.get("contact_company_name") else "Particulier"
+    )
     user, created = User.objects.get_or_create(
         email=email,
         defaults={
             "first_name": tender_dict.get("contact_first_name"),
             "last_name": tender_dict.get("contact_last_name"),
             "phone": tender_dict.get("contact_phone"),
-            "company_name": tender_dict.get("contact_company_name")
-            if tender_dict.get("contact_company_name")
-            else "Particulier",
-            "kind": User.KIND_BUYER if tender_dict.get("contact_company_name") else User.KIND_INDIVIDUAL,
+            "kind": kind,
+            "buyer_kind_detail": buyer_kind_detail,
+            "company_name": company_name,
             "source": source,
         },
     )

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -65,7 +65,7 @@ def get_or_create_user_from_anonymous_content(
             "company_name": tender_dict.get("contact_company_name")
             if tender_dict.get("contact_company_name")
             else "Particulier",
-            "kind": User.KIND_BUYER,  # not necessarily true, could be a PARTNER
+            "kind": User.KIND_BUYER if tender_dict.get("contact_company_name") else User.KIND_INDIVIDUAL,
             "source": source,
         },
     )

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -61,10 +61,8 @@ def get_or_create_user_from_anonymous_content(
         if tender_dict.get("contact_kind")
         else (User.KIND_BUYER if tender_dict.get("contact_company_name") else User.KIND_INDIVIDUAL)
     )
-    buyer_kind_detail = (
-        tender_dict.get("contact_buyer_kind_detail") if tender_dict.get("contact_buyer_kind_detail") else ""
-    )
-    company_name = tender_dict.get("contact_company_name") if tender_dict.get("contact_company_name") else ""
+    buyer_kind_detail = tender_dict.get("contact_buyer_kind_detail", "")
+    company_name = tender_dict.get("contact_company_name", "")
     user, created = User.objects.get_or_create(
         email=email,
         defaults={


### PR DESCRIPTION
### Quoi ?

Grâce à #1002 on a maintenant un type d'utilisateur "Particulier"

On souhaite donc labelliser correctement les nouveaux utilisateurs créés à partir des besoins Tally
- Particuliers
- Acheteurs > Association
- Acheteurs

### Comment

Depuis Tally on reçoit 2 informations : `contact_kind` & `contact_buyer_kind_detail`
Il faut les mapper aux bons utilisateurs

### Après avoir MEP

Script à lancer pour labelliser les utilisateurs passés
```
from lemarche.users.models import User

User.objects.filter(company_name="Particulier").count()
User.objects.filter(company_name="Particulier").update(kind=User.KIND_INDIVIDUAL)
```
