### PR TITLE
[Dépôt de besoin] Admin : ajout de validation sur les règles de ciblage par km

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -105,9 +105,13 @@ class TenderForm(forms.ModelForm):
         if distance_location:
             location = cleaned_data.get("location")
             if not location:
-                raise ValidationError({"location": "Distance en km est spécifié, ce champ doit donc être rempli"})
+                raise ValidationError(
+                    {"location": "Le champ 'Distance en km' est spécifié, ce champ doit donc être rempli"}
+                )
             if location.kind != Perimeter.KIND_CITY:
-                raise ValidationError({"location": "Distance en km est spécifié, ce champ doit être une ville"})
+                raise ValidationError(
+                    {"location": "Le champ 'Distance en km' est spécifié, ce champ doit être une ville"}
+                )
 
 
 @admin.register(Tender, site=admin_site)


### PR DESCRIPTION
### Quoi ?

Suite de #999

Cette PR a introduit un nouveau champ `distance_location` et quelques mini règles pour que le ciblage se passe bien.

J'ai rajouté ces règles dans le clean du formulaire admin, pour renvoyer des `ValidationError` si jamais elle n'étaient pas respectées