### PR TITLE
Permettre de renseigner le montant exact sur l'api des dépôt de besoins

### DIFF
--- a/lemarche/api/tenders/serializers.py
+++ b/lemarche/api/tenders/serializers.py
@@ -32,6 +32,7 @@ class TenderSerializer(serializers.ModelSerializer):
             "external_link",
             "constraints",
             "amount",
+            "amount_exact",
             "why_amount_is_blank",
             "accept_share_amount",
             "accept_cocontracting",


### PR DESCRIPTION
### Quoi ?

Permettre de renseigner le montant exact sur l'api.

### Pourquoi ?

Faire gagner du temps aux bizdevs dans la conciergerie des DDB.

### Comment ?

Ajouter le champs montant exact dans le Serializer des Tenders, et au niveau n8n ajout du champs `amount_exact` dans le call d'api.
