### PR TITLE
[Utilisateurs] Inscription : évite la valeur par défaut pour buyer_kind_detail

### DIFF
--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -16,6 +16,7 @@ class SignupForm(UserCreationForm):
         (User.KIND_PARTNER, "Un partenaire (réseaux, facilitateurs)"),
         (User.KIND_INDIVIDUAL, "Un particulier"),
     )
+    FORM_BUYER_KIND_DETAIL_CHOICES = EMPTY_CHOICE + user_constants.BUYER_KIND_DETAIL_CHOICES
     FORM_PARTNER_KIND_CHOICES = EMPTY_CHOICE + user_constants.PARTNER_KIND_CHOICES
 
     kind = forms.ChoiceField(label="", widget=forms.RadioSelect, choices=KIND_CHOICES_FORM, required=True)
@@ -30,7 +31,7 @@ class SignupForm(UserCreationForm):
     )
     # buyer_kind_detail is hidden by default in the frontend. Shown if the user choses kind BUYER
     buyer_kind_detail = forms.ChoiceField(
-        label="Type de votre organisation", choices=user_constants.BUYER_KIND_DETAIL_CHOICES, required=False
+        label="Type de votre organisation", choices=FORM_BUYER_KIND_DETAIL_CHOICES, required=False
     )
     # company_name is hidden by default in the frontend. Shown if the user choses kind BUYER or PARTNER
     company_name = forms.CharField(

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -99,6 +99,12 @@ def scroll_to_and_click_element(driver, element, click=True, sleep_time=1):
             driver.execute_script("arguments[0].click();", element)
 
 
+def element_select_option(driver, element, option=""):
+    field_select = Select(element)
+    scroll_to_and_click_element(driver, element, click=False)
+    field_select.select_by_visible_text(option)
+
+
 class SignupFormTest(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
@@ -182,9 +188,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self._complete_form(user_profile=BUYER, with_submit=False)
 
         buyer_kind_detail_select_element = self.driver.find_element(By.CSS_SELECTOR, "select#id_buyer_kind_detail")
-        buyer_kind_detail_select = Select(buyer_kind_detail_select_element)
-        scroll_to_and_click_element(self.driver, buyer_kind_detail_select_element, click=False)
-        buyer_kind_detail_select.select_by_visible_text("Grand groupe (+5000 salariés)")
+        element_select_option(self.driver, buyer_kind_detail_select_element, "Grand groupe (+5000 salariés)")
 
         submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
         scroll_to_and_click_element(self.driver, submit_element)
@@ -194,6 +198,10 @@ class SignupFormTest(StaticLiveServerTestCase):
 
     def test_buyer_submits_signup_form_success_extra_data(self):
         self._complete_form(user_profile=BUYER, with_submit=False)
+
+        buyer_kind_detail_select_element = self.driver.find_element(By.CSS_SELECTOR, "select#id_buyer_kind_detail")
+        element_select_option(self.driver, buyer_kind_detail_select_element, "Grand groupe (+5000 salariés)")
+
         nb_of_handicap = "3"
         nb_of_inclusive = "4"
         nb_of_handicap_provider_2022_element = self.driver.find_element(


### PR DESCRIPTION
### Quoi ?

Répare un souci introduit par #987

La valeur "Grand groupe" était toujours sélectionnée par défaut, même pour les utilisateurs non-acheteurs (comme les particuliers)