### PR TITLE
feat(Emails): remplacer l'envoi de finalisation du compte par son TemplateTransactional

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -323,9 +323,6 @@ NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")
 GIP_CONTACT_EMAIL = env("GIP_CONTACT_EMAIL", default="gip.contact@example.com")
 
 # Transactional email templates
-# -- user: new user password reset
-MAILJET_NEW_USER_PASSWORD_RESET_ID = env.int("MAILJET_NEW_USER_PASSWORD_RESET_ID", 4216730)
-
 # -- siae: completion
 MAILJET_SIAE_COMPLETION_REMINDER_TEMPLATE_ID = env.int("MAILJET_SIAE_COMPLETION_REMINDER_TEMPLATE_ID", 4791779)
 

--- a/lemarche/www/auth/tasks.py
+++ b/lemarche/www/auth/tasks.py
@@ -5,8 +5,8 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
+from lemarche.conversations.models import TemplateTransactional
 from lemarche.users.models import User
-from lemarche.utils.apis import api_mailjet
 from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
 from lemarche.utils.urls import get_domain_url
 
@@ -42,7 +42,7 @@ def send_signup_notification_email(user):
 
 
 def send_new_user_password_reset_link(user: User):
-    email_subject = "Finalisez votre inscription sur le marché de l'inclusion"
+    email_template = TemplateTransactional.objects.get(code="NEW_USER_PASSWORD_RESET")
     recipient_list = whitelist_recipient_list([user.email])
     if recipient_list:
         recipient_email = recipient_list[0] if recipient_list else ""
@@ -50,13 +50,12 @@ def send_new_user_password_reset_link(user: User):
 
         variables = {
             "USER_FIRST_NAME": user.first_name,
+            "USER_EMAIL": user.email,
             "PASSWORD_RESET_LINK": generate_password_reset_link(user),
         }
 
-        api_mailjet.send_transactional_email_with_template(
-            template_id=settings.MAILJET_NEW_USER_PASSWORD_RESET_ID,
+        email_template.send_transactional_email(
             recipient_email=recipient_email,
             recipient_name=recipient_name,
             variables=variables,
-            subject=email_subject,
         )

--- a/lemarche/www/auth/tasks.py
+++ b/lemarche/www/auth/tasks.py
@@ -44,8 +44,8 @@ def send_signup_notification_email(user):
 def send_new_user_password_reset_link(user: User):
     email_template = TemplateTransactional.objects.get(code="NEW_USER_PASSWORD_RESET")
     recipient_list = whitelist_recipient_list([user.email])
-    if recipient_list:
-        recipient_email = recipient_list[0] if recipient_list else ""
+    if len(recipient_list):
+        recipient_email = recipient_list[0]
         recipient_name = user.full_name
 
         variables = {


### PR DESCRIPTION
### Quoi ?

Suite de #1018 & #1024

Premier utilisation de TemplateTransactional, sur le seul mail "auth" qui est géré par Mailjet.