### PR TITLE
Dépôt de besoins : envoyer les e-mails aux prestataires (et aux partenaires) à partir d'une autre adresse mail

### DIFF
--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -89,7 +89,7 @@
                                         </p>
                                         <p class="mb-0">
                                             Contactez Sofiane via
-                                            <a href="mailto:{{ CONTACT_EMAIL }}?subject=Demande d'information pour {{ tender.title }}">{{ CONTACT_EMAIL }}</a>
+                                            <a href="mailto:{{ TEAM_CONTACT_EMAIL }}?subject=Demande d'information pour {{ tender.title }}">{{ TEAM_CONTACT_EMAIL }}</a>
                                             pour être mis en relation avec le client.
                                         </p>
                                     </div>

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -126,7 +126,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
             recipient_email_list=recipient_list,
             variables=variables,
             from_email=settings.TEAM_CONTACT_EMAIL,
-            from_name="Raphaël du Marché de l'inclusion",
+            from_name="Pauline du Marché de l'inclusion",
         )
 
         # log email
@@ -176,7 +176,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             recipient_name=recipient_name,
             variables=variables,
             from_email=settings.TEAM_CONTACT_EMAIL,
-            from_name="Raphaël du Marché de l'inclusion",
+            from_name="Pauline du Marché de l'inclusion",
         )
 
 

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -125,6 +125,8 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
             subject=email_subject,
             recipient_email_list=recipient_list,
             variables=variables,
+            from_email=settings.TEAM_CONTACT_EMAIL,
+            from_name="Raphaël du Marché de l'inclusion",
         )
 
         # log email

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -173,7 +173,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             recipient_email=recipient_email,
             recipient_name=recipient_name,
             variables=variables,
-            from_email=settings.CONTACT_EMAIL,
+            from_email=settings.TEAM_CONTACT_EMAIL,
             from_name="Raphaël du Marché de l'inclusion",
         )
 


### PR DESCRIPTION
### Quoi ?

- changer le `from_email` des e-mails envoyés aux prestataires concernés (et aux partenaires)
- remplacer "Raphael" par "Pauline"
- changer l'e-mail affiché sur un des encarts de la page détail des besoins