### PR TITLE
fix(API): Réparer le script de synchro avec les emplois

### DIFF
--- a/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
+++ b/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
@@ -211,7 +211,7 @@ class Command(BaseCommand):
             return c1_list_cleaned
         except Exception as e:
             api_slack.send_message_to_channel("Erreur lors de la synchronisation emplois <-> marché")
-            self.stdout_error(e)
+            self.stdout_error(str(e))
             raise Exception(e)
 
     def filter_c1_export(self, c1_list):

--- a/lemarche/stats/management/commands/import_users_for_stats.py
+++ b/lemarche/stats/management/commands/import_users_for_stats.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         try:
             return StatsUser.objects.bulk_create(stats_users_list, batch_size=50)
         except IntegrityError as e:
-            self.stdout_error(e)
+            self.stdout_error(str(e))
 
     def clean_stats_users(self):
         count_delete, _ = StatsUser.objects.all().delete()

--- a/lemarche/utils/apis/api_emplois_inclusion.py
+++ b/lemarche/utils/apis/api_emplois_inclusion.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import requests
 from django.conf import settings
@@ -26,6 +27,7 @@ def get_siae_list():
                 siae_list.append(siae)
         if data["next"]:
             pagination += 1
+            time.sleep(1)
         else:
             break
 


### PR DESCRIPTION
### Quoi ?

Lorsqu'il y a une erreur de synchro, les détails sont mal remontés sur Slack.
J'ai aussi rajouté un petit sleep pour ne pas trop forcer l'API des emplois

Lié aux changements dans #993