### PR TITLE
Emails : finaliser la configuration d'envoi d'-mails transactionnels avec Brevo

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -313,10 +313,8 @@ MAILJET_API_URL = "https://api.mailjet.com/v3.1"
 
 EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 
-DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
-DEFAULT_FROM_EMAIL_BREVO = env("DEFAULT_FROM_EMAIL_BREVO", default=DEFAULT_FROM_EMAIL)
-DEFAULT_FROM_NAME = "Marché de l'inclusion"
-DEFAULT_FROM_NAME_BREVO = "Le Marché de l'inclusion"
+DEFAULT_FROM_EMAIL = "ne-pas-repondre@lemarche.inclusion.beta.gouv.fr"
+DEFAULT_FROM_NAME = "Le Marché de l'inclusion"
 CONTACT_EMAIL = env("CONTACT_EMAIL", default="contact@example.com")
 TEAM_CONTACT_EMAIL = env("TEAM_CONTACT_EMAIL", default="team.contact@example.com")
 NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -314,7 +314,9 @@ MAILJET_API_URL = "https://api.mailjet.com/v3.1"
 EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
+DEFAULT_FROM_EMAIL_BREVO = env("DEFAULT_FROM_EMAIL_BREVO", default=DEFAULT_FROM_EMAIL)
 DEFAULT_FROM_NAME = "Marché de l'inclusion"
+DEFAULT_FROM_NAME_BREVO = "Le Marché de l'inclusion"
 CONTACT_EMAIL = env("CONTACT_EMAIL", default="contact@example.com")
 TEAM_CONTACT_EMAIL = env("TEAM_CONTACT_EMAIL", default="team.contact@example.com")
 NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")

--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -72,8 +72,8 @@ def send_transactional_email_with_template(
     recipient_email: str,
     recipient_name: str,
     variables: dict,
-    from_email=settings.DEFAULT_FROM_EMAIL_BREVO,
-    from_name=settings.DEFAULT_FROM_NAME_BREVO,
+    from_email=settings.DEFAULT_FROM_EMAIL,
+    from_name=settings.DEFAULT_FROM_NAME,
 ):
     api_client = get_api_client()
     api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)


### PR DESCRIPTION
### Quoi ?

Lié à #1028

La configuration actuelle fonctionne mais ne permettait pas d'envoyer des e-mails transactionnels à la manière de Mailjet.

J'ai aussi modifié le DEFAULT_FROM_EMAIL & DEFAULT_FROM_NAME