### PR TITLE
[Wagtail] Correction du chargement des pages statiques

### DIFF
--- a/lemarche/cms/models.py
+++ b/lemarche/cms/models.py
@@ -36,10 +36,12 @@ class ArticlePage(Page):
         blank=True, verbose_name="Contenu de l'article", features=settings.WAGTAIL_RICHTEXT_FIELD_FEATURES
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    # Override template file for static pages
+    def get_template(self, request, *args, **kwargs):
         if self.is_static_page:
-            self.template = f"cms/static/{self.template_name}"
+            return f"cms/static/{self.template_name}"
+        else:
+            return super().get_template(request, *args, **kwargs)
 
     base_form_class = ArticlePageForm
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -352,7 +352,7 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(tender_with_siae_1.siae_email_send_count_annotated, 5)
         self.assertEqual(tender_with_siae_1.siae_email_link_click_count_annotated, 4)
         self.assertEqual(tender_with_siae_1.siae_detail_display_count_annotated, 2)
-        self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count_annotated, 2)
+        self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count_annotated, 4)
         self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count_annotated, 1)
         self.assertEqual(tender_with_siae_1.siae_detail_cocontracting_click_count_annotated, 1)
         self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count_annotated, 1)


### PR DESCRIPTION
### Quoi ?

Correction d'une erreur de chargement des pages statiques dans l'admin Wagtail.

# Pourquoi ?

Le chargement du menu "Ressources" dans la sidebar et l'édition des pages statiques produisent une erreur 500.
Il semblerait que la modification du constructeur créé une boucle infinie. 

# Comment ?

J'ai surchargé la méthode `get_template` plutôt que de modifier le constructeur.

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/7385f3f6-68e4-49a3-8f86-1c1228ee8162)

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/4e27cb14-f84a-442e-b67c-77b11795546d)


