### PR TITLE
Dépôt de besoin : Répare le trop grand nombre d'envoi d'e-mails en mode batch

### DIFF
--- a/lemarche/tenders/migrations/0066_tender_limit_nb_siae_interested_and_more.py
+++ b/lemarche/tenders/migrations/0066_tender_limit_nb_siae_interested_and_more.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             name="version",
             field=models.PositiveIntegerField(default=0, verbose_name="Version"),
         ),
-        # this is migration to manage the existants stock
+        # we set the value to 0 for existing Tenders, and 1 to future Tenders
         migrations.AlterField(
             model_name="tender",
             name="version",

--- a/lemarche/utils/constants.py
+++ b/lemarche/utils/constants.py
@@ -1,5 +1,6 @@
 EMPTY_CHOICE = (("", ""),)
 
+ADMIN_FIELD_HELP_TEXT = "Champ renseigné par un ADMIN"
 RECALCULATED_FIELD_HELP_TEXT = "Champ recalculé à intervalles réguliers"
 
 MARCHE_BENEFIT_TIME = "TIME"


### PR DESCRIPTION
### Quoi ?

Suite / fix de #1025

Le mode batch engendré un appel à la tâche `send_validated_tender(tender)`, qui (r)envoyait des e-mails à l'auteur du besoin ainsi qu'aux partenaires.

J'ai donc séparé entre 
- les nouveaux besoins à envoyer
- les besoins déjà envoyés qui sont à renvoyer en mode batch