### PR TITLE
Dépôt de besoin : fini de réparer l'envoi par batch

### DIFF
--- a/lemarche/tenders/management/commands/send_validated_tenders.py
+++ b/lemarche/tenders/management/commands/send_validated_tenders.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from lemarche.tenders.models import Tender
-from lemarche.www.tenders.tasks import send_tender_emails_to_siaes, send_validated_tender
+from lemarche.www.tenders.tasks import send_validated_sent_batch_tender, send_validated_tender
 
 
 class Command(BaseCommand):
@@ -32,4 +32,4 @@ class Command(BaseCommand):
                 f"Found {validated_sent_tenders_batch_to_send.count()} validated sent tender(s) to batch"
             )
             for tender in validated_sent_tenders_batch_to_send:
-                send_tender_emails_to_siaes(tender)
+                send_validated_sent_batch_tender(tender)

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -26,7 +26,7 @@ def send_validated_tender(tender: Tender):
     # send the tender to all matching Siaes & Partners
     send_tender_emails_to_siaes(tender)
     send_tender_emails_to_partners(tender)
-    # log
+    # set first_sent_at & last_sent_at, log
     tender.set_sent()
     # hubspot
     if settings.BITOUBI_ENV == "prod":
@@ -34,10 +34,10 @@ def send_validated_tender(tender: Tender):
 
 
 def send_validated_sent_batch_tender(tender: Tender):
-    # the tender has already been sent a first time
+    # the tender has already been sent a first time with send_validated_tender
     # this is the second/third/... iteration
     send_tender_emails_to_siaes(tender)
-    # log
+    # update last_sent_at, log
     tender.set_sent()
 
 

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -28,8 +28,17 @@ def send_validated_tender(tender: Tender):
     send_tender_emails_to_partners(tender)
     # log
     tender.set_sent()
+    # hubspot
     if settings.BITOUBI_ENV == "prod":
         api_hubspot.create_deal_from_tender(tender=tender)
+
+
+def send_validated_sent_batch_tender(tender: Tender):
+    # the tender has already been sent a first time
+    # this is the second/third/... iteration
+    send_tender_emails_to_siaes(tender)
+    # log
+    tender.set_sent()
 
 
 def restart_send_tender_task(tender: Tender):


### PR DESCRIPTION
### Quoi ?

Suite et fin de #1046

Lorsque j'ai séparé validation et envoi par batch, j'ai oublié de mettre à jour le champ `last_sent_at`
Ce qui provoquait l'envoi "batch" toutes les 5 minutes au lieu de tous les jours
