### PR TITLE
Dépôt de besoin : Détail : basculer l'action 'pas intéressé' dans une modale

### DIFF
--- a/lemarche/templates/tenders/_detail_cta_not_interested.html
+++ b/lemarche/templates/tenders/_detail_cta_not_interested.html
@@ -1,38 +1,19 @@
 <div id="detail_not_interested_container" class="mt-3">
-    {% if not tender.siae_detail_not_interested_click_date_count %}
-        <div class="card c-card rounded-lg shadow-lg">
-            <div class="card-body">
-                <h3>Pas intéressé ?</h3>
-                <p>
-                    Cette demande ne vous intéresse pas ? Dites-le nous !
-                </p>
-                {% if user_can_click %}
-                    <form method="POST" action="{% url 'tenders:detail-not-interested-click' tender.slug %}?siae_id=">
-                        {% csrf_token %}
-                        <div class="form-group">
-                            <label for="id_detail_not_interested_feedback">Afin d'améliorer la pertinence des demandes que nous vous envoyons, expliquez-nous pourquoi celle-ci ne vous intéresse pas.</label>
-                            <textarea id="id_detail_not_interested_feedback" class="form-control" name="detail_not_interested_feedback" placeholder="Parce que..." rows="3"></textarea>
-                        </div>
-                        <div>
-                            {% if user.is_authenticated %}
-                                <button type="submit" class="btn btn-warning btn-block" title="{{ tender.cta_not_interested_card_button_text|safe }}" hx-post="{% url 'tenders:detail-not-interested-click' tender.slug %}" hx-target="#detail_not_interested_container">
-                                    <span>{{ tender.cta_not_interested_card_button_text|safe }}</span>
-                                </button>
-                            {% elif siae_id %}
-                                <button type="submit" class="btn btn-warning btn-block" title="{{ tender.cta_not_interested_card_button_text|safe }}" hx-post="{% url 'tenders:detail-not-interested-click' tender.slug %}?siae_id={{siae_id}}" hx-target="#detail_not_interested_container">
-                                    <span>{{ tender.cta_not_interested_card_button_text|safe }}</span>
-                                </button>
-                            {% endif %}
-                        </div>
-                    </form>
-                {% else %}
-                    <a href="#" id="show-tender-not-interested-modal-btn" class="btn btn-primary btn-block" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
-                        <span>{{ tender.cta_not_interested_card_button_text|safe }}</span>
-                    </a>
-                {% endif %}
-            </div>
+    <div class="card c-card rounded-lg shadow-lg">
+        <div class="card-body">
+            <h3>Pas intéressé ?</h3>
+            <p>
+                Cette demande ne vous intéresse pas ? Dites-le nous !
+            </p>
+            {% if user_can_click %}
+                <button type="button" id="show-tender-contact-modal-btn" class="btn btn-warning btn-block" data-toggle="modal" data-target="#detail_not_interested_click_confirm_modal" data-siae-id="{{ siae_id }}" title="{{ tender.cta_not_interested_card_button_text|safe }}">
+                    {{ tender.cta_not_interested_card_button_text|safe }}
+                </button>
+            {% else %}
+                <a href="#" id="show-tender-not-interested-modal-btn" class="btn btn-warning btn-block" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
+                    <span>{{ tender.cta_not_interested_card_button_text|safe }}</span>
+                </a>
+            {% endif %}
         </div>
-    {% else %}
-        {% include "tenders/_detail_not_interested_click_confirm.html" %}
-    {% endif %}
+    </div>
 </div>

--- a/lemarche/templates/tenders/_detail_not_interested_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_not_interested_click_confirm_modal.html
@@ -1,0 +1,45 @@
+<div class="modal fade modal-siae" id="detail_not_interested_click_confirm_modal" tabindex="-1" role="dialog" aria-modal="true" data-backdrop="static" data-keyboard="false" aria-labelledby="modalTitle">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="modalTitle">Pas intéressé ?</h3>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                    <i class="ri-close-line"></i>
+                </button>
+            </div>
+            <form method="POST" action="{% url 'tenders:detail-not-interested-click' tender.slug %}?siae_id=siae-id-params-to-replace">
+                {% csrf_token %}
+                <div class="modal-body home-content-body">
+                    <div class="form-group">
+                        <label for="id_detail_not_interested_feedback">Afin d'améliorer la pertinence des demandes que nous vous envoyons, expliquez-nous pourquoi celle-ci ne vous intéresse pas.</label>
+                        <textarea id="id_detail_not_interested_feedback" class="form-control" name="detail_not_interested_feedback" placeholder="Parce que..." rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-sm btn-warning" title="{{ tender.cta_not_interested_card_button_text|safe }}">
+                        <span>{{ tender.cta_not_interested_card_button_text|safe }}</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    const MODAL_ID = '#detail_not_interested_click_confirm_modal';
+    $(MODAL_ID).on('show.bs.modal', function (event) {
+        // Button that triggered the modal
+        var button = $(event.relatedTarget);
+
+        // Extract info from data-* attributes
+        var siaeIdParams = button.data('siae-id');
+
+        // Update the modal's content
+        var modal = document.querySelector(MODAL_ID);
+        var form = modal.querySelector('form');
+        var formAction = form.getAttribute('action');
+        form.setAttribute('action', formAction.replace('siae-id-params-to-replace', siaeIdParams));
+    });
+});
+</script>

--- a/lemarche/templates/tenders/_detail_not_interested_click_error.html
+++ b/lemarche/templates/tenders/_detail_not_interested_click_error.html
@@ -1,5 +1,0 @@
-<div class="alert alert-danger mt-3 mt-lg-0" role="alert">
-    <p class="mb-0 fs-sm">
-        N'ayant pu identifier votre structure, nous n'avons pas pu prendre en compte votre non intérêt pour ce besoin.
-    </p>
-</div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -68,6 +68,7 @@
 {% block modals %}
 {% include "auth/_login_or_signup_siae_tender_modal.html" %}
 {% include "tenders/_detail_contact_click_confirm_modal.html" %}
+{% include "tenders/_detail_not_interested_click_confirm_modal.html" %}
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
### Quoi ?

Comportement similaire à celui déjà présent qui permet aux prestataires de montrer leur intérêt.
Mais cette fois-ci pour l'action 'pas intéressé' - Suite à #1038

### Pourquoi ?

Pour rajouter une étape de "confirmation"
Pour homogénéiser avec 

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/4b01820b-4bde-4d4e-af64-0268144406bd)
