### PR TITLE
Dépôt de besoin : envoi sondage transaction : mise en place de relances

### DIFF
--- a/clevercloud/tenders_send_author_transactioned_question_emails.sh
+++ b/clevercloud/tenders_send_author_transactioned_question_emails.sh
@@ -20,3 +20,4 @@ fi
 cd $APP_HOME
 
 django-admin send_author_transactioned_question_emails
+django-admin send_author_transactioned_question_emails --reminder

--- a/lemarche/tenders/management/commands/send_author_transactioned_question_emails.py
+++ b/lemarche/tenders/management/commands/send_author_transactioned_question_emails.py
@@ -1,9 +1,13 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.core.management.base import BaseCommand
 
 from lemarche.tenders.models import Tender
 from lemarche.www.tenders.tasks import send_tenders_author_feedback_or_survey
+
+
+seven_days_ago = datetime.today().date() - timedelta(days=7)
+one_day_ago = datetime.today().date() - timedelta(days=1)
 
 
 class Command(BaseCommand):
@@ -13,8 +17,8 @@ class Command(BaseCommand):
 
     Usage:
     python manage.py send_author_transactioned_question_emails --dry-run
-    python manage.py send_author_transactioned_question_emails --all
     python manage.py send_author_transactioned_question_emails --kind QUOTE
+    python manage.py send_author_transactioned_question_emails --reminder
     python manage.py send_author_transactioned_question_emails
     """
 
@@ -22,31 +26,36 @@ class Command(BaseCommand):
         parser.add_argument("--kind", type=str, dest="kind")
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Dry run, no sends")
         parser.add_argument(
-            "--all",
-            dest="is_all_tenders",
+            "--reminder",
+            dest="reminder",
             action="store_true",
-            help="Send to all tenders with deadline_date 7 days ago",
+            help="Send a second e-mail to authors who haven't responded to the first survey",
         )
 
-    def handle(self, kind=None, dry_run=False, is_all_tenders=False, **options):
+    def handle(self, kind=None, reminder=False, dry_run=False, **options):
         self.stdout.write("-" * 80)
         self.stdout.write("Script to send email transactioned_question for tenders...")
 
         self.stdout.write("-" * 80)
-        start_date_feature = datetime(2022, 6, 23).date()
-        # we first filter on validated tenders
-        tender_qs = (
-            Tender.objects.sent()
-            .transaction_survey_email(kind=kind, all=is_all_tenders)
-            .filter(deadline_date__gte=start_date_feature)
-        )
+        tender_qs = Tender.objects.sent()
+        if kind:
+            tender_qs = tender_qs.filter(kind=kind)
+        if reminder:
+            tender_qs = (
+                tender_qs.exclude(survey_transactioned_send_date=None)
+                .filter(survey_transactioned_answer=None)
+                .filter(start_working_date=one_day_ago)
+            )
+        else:
+            tender_qs = tender_qs.filter(survey_transactioned_send_date=None).filter(deadline_date=seven_days_ago)
 
         self.stdout.write(f"Found {tender_qs.count()} tenders")
 
         if not dry_run:
+            email_kind = f"transactioned_question_7d{'_reminder' if reminder else ''}"
             for tender in tender_qs:
-                send_tenders_author_feedback_or_survey(tender, kind="transactioned_question_7d")
-            self.stdout.write(f"Sent {tender_qs.count()} J+7 transactioned_question")
+                send_tenders_author_feedback_or_survey(tender, kind=email_kind)
+            self.stdout.write(f"Sent {tender_qs.count()} {email_kind}")
 
         self.stdout.write("-" * 80)
         self.stdout.write("Done!")

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -80,17 +80,6 @@ class TenderQuerySet(models.QuerySet):
     def has_amount(self):
         return self.filter(Q(amount__isnull=False) | Q(amount_exact__isnull=False))
 
-    def transaction_survey_email(self, kind=None, all=False):
-        seven_days_ago = datetime.today().date() - timedelta(days=7)
-        qs = self.sent().filter(survey_transactioned_answer=None)
-        if kind:
-            qs = qs.filter(kind=kind)
-        if all:
-            qs = qs.filter(deadline_date__lte=seven_days_ago)
-        else:
-            qs = qs.filter(deadline_date=seven_days_ago)
-        return qs
-
     def in_perimeters(self, post_code, department, region):
         filters = (
             Q(perimeters__post_codes__contains=[post_code])

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -553,7 +553,7 @@ def send_tenders_author_feedback_or_survey(tender: Tender, kind="feedback_30d"):
             "TENDER_KIND": tender.get_kind_display(),
         }
 
-        if kind == "transactioned_question_7d":
+        if kind in ["transactioned_question_7d", "transactioned_question_7d_reminder"]:
             template_id = settings.MAILJET_TENDERS_AUTHOR_TRANSACTIONED_QUESTION_7D_TEMPLATE_ID
             user_sesame_query_string = sesame_get_query_string(tender.author)  # TODO: sesame scope parameter
             answer_url_with_sesame_token = (


### PR DESCRIPTION
### Quoi ?

Il existe déjà un e-mail automatique envoyé aux auteurs de besoins à J+7 pour savoir si ils ont transactionné.

Cette PR rajoute une option de relance + maj du cron

J'en ai profité pour cleaner un peu le fonctionnement actuel.

### Pourquoi ?

Pour recueillir d'avantage de réponses !
