### PR TITLE
[Dépôt de besoin] Conserver les coordonnées dans les données d'étape.

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -928,13 +928,6 @@ class PartnerShareTender(models.Model):
 
 
 class TenderStepsData(models.Model):
-    FIELDS_TO_REDACT = [
-        "contact-contact_email",
-        "contact-contact_phone",
-        "contact-contact_last_name",
-        "contact-contact_first_name",
-    ]
-
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
     uuid = ShortUUIDField(

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -158,11 +158,6 @@ class TenderCreateMultiStepView(SessionWizardView):
         if "csrfmiddlewaretoken" in data:
             del data["csrfmiddlewaretoken"]
 
-        # Hide personal data
-        for field_to_redacted in TenderStepsData.FIELDS_TO_REDACT:
-            if field_to_redacted in data:
-                data[field_to_redacted] = "[REDACTED]"
-
         data["timestamp"] = timezone.now().isoformat()
 
         uuid = self.request.session.get("tender_steps_data_uuid", None)


### PR DESCRIPTION
### Quoi ?

Conservation des coordonnées du contact dans les données d'étapes.

### Pourquoi ?

Afin de mieux comprendre les dépôts de besoin abandonnés.

### Comment ?

En retirant le système de masquage des champs sensibles.
