### PR TITLE
Dépôt de besoin x APProch : stocker l'ID lorsqu'un nouveau besoin est reçu via l'API

### DIFF
--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, viewsets
@@ -32,18 +33,32 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         - pop non-model fields
         - create Tender !
         """
-        source = (
+        tender_source = (
             tender_constants.SOURCE_TALLY
             if serializer.validated_data.get("extra_data", {}).get("source") == tender_constants.SOURCE_TALLY
             else tender_constants.SOURCE_API
         )
+        user_source = (
+            user_constants.SOURCE_TALLY_FORM
+            if (tender_source == tender_constants.SOURCE_TALLY)
+            else user_constants.SOURCE_SIGNUP_FORM
+        )
         # get Tender author
         user = get_or_create_user_from_anonymous_content(
             serializer.validated_data,
-            source=user_constants.SOURCE_TALLY_FORM
-            if source == tender_constants.SOURCE_TALLY
-            else user_constants.SOURCE_SIGNUP_FORM,
+            source=user_source,
         )
+        # Manage Partner APProch
+        if tender_source == tender_constants.SOURCE_API:
+            if user.id == settings.PARTNER_APPROCH_USER_ID:
+                tender_partner_approch_id = serializer.validated_data.get("extra_data", {}).get("id", None)
+                if tender_partner_approch_id:
+                    try:
+                        Tender.objects.get(partner_approch_id=tender_partner_approch_id)
+                        # TODO: update existing tender
+                        return
+                    except Tender.DoesNotExist:
+                        serializer.validated_data["partner_approch_id"] = tender_partner_approch_id
         # pop non-model fields
         serializer.validated_data.pop("contact_kind", None)
         serializer.validated_data.pop("contact_buyer_kind_detail", None)
@@ -52,7 +67,7 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
             author=user,
             status=tender_constants.STATUS_PUBLISHED,
             published_at=timezone.now(),
-            source=source,
+            source=tender_source,
             import_raw_object=self.request.data,
         )
 


### PR DESCRIPTION
### Quoi ?

Grâce à #1058

- on rempli le champ `partner_approch_id` si c'est un nouveau besoin
- ne ne recréé pas de besoin si l'id existe déjà