### PR TITLE
Dépôt de besoin : prestataires intéressés : répare le filtrage

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -328,7 +328,7 @@ class SiaeQuerySet(models.QuerySet):
     def has_contact_email(self):
         return self.exclude(contact_email__isnull=True).exclude(contact_email__exact="")
 
-    def filter_with_tender(self, tender, tender_status=None):  # noqa C901
+    def filter_with_tender(self, tender, tendersiae_status=None):  # noqa C901
         """
         Filter Siaes with tenders:
         - first we filter the Siae that are live + can be contacted
@@ -338,7 +338,7 @@ class SiaeQuerySet(models.QuerySet):
             - else we filter on the perimeters
         - then we filter on presta_type
         - then we filter on kind
-        - finally we filter with the tender_status passed as a parameter
+        - finally we filter with the tendersiae_status passed as a parameter
 
         Args:
             tender (Tender): Tender used to make the matching
@@ -377,10 +377,10 @@ class SiaeQuerySet(models.QuerySet):
             qs = qs.filter(kind__in=tender.siae_kind)
 
         # tender status
-        if tender_status == "INTERESTED":
+        if tendersiae_status == "INTERESTED":
             qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
-        elif tender_status == "VIEWED":
+        elif tendersiae_status == "VIEWED":
             qs = qs.filter(
                 Q(tendersiae__tender=tender)
                 & (
@@ -389,23 +389,23 @@ class SiaeQuerySet(models.QuerySet):
                 )
             )
             qs = qs.order_by("-tendersiae__email_link_click_date")
-        elif tender_status == "COCONTRACTED":
+        elif tendersiae_status == "COCONTRACTED":
             qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_cocontracting_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_cocontracting_click_date")
-        elif tender_status == "ALL":
+        elif tendersiae_status == "ALL":
             # why need to filter more ?
             qs = qs.filter(tendersiae__tender=tender, tendersiae__email_send_date__isnull=False)
             qs = qs.order_by("-tendersiae__email_send_date")
 
         return qs.distinct()
 
-    def filter_with_tender_status(self, tender, tender_status=None):
+    def filter_with_tender_tendersiae_status(self, tender, tendersiae_status=None):
         qs = self.prefetch_related("sectors").is_live().has_contact_email()  # .filter(tendersiae__tender=tender)
         # tender status
-        if tender_status == "INTERESTED":
+        if tendersiae_status == "INTERESTED":
             qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
-        elif tender_status == "VIEWED":
+        elif tendersiae_status == "VIEWED":
             qs = qs.filter(
                 Q(tendersiae__tender=tender)
                 & (
@@ -414,7 +414,7 @@ class SiaeQuerySet(models.QuerySet):
                 )
             )
             qs = qs.order_by("-tendersiae__email_link_click_date")
-        elif tender_status == "COCONTRACTED":
+        elif tendersiae_status == "COCONTRACTED":
             qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_cocontracting_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_cocontracting_click_date")
         else:  # "ALL"

--- a/lemarche/templates/tenders/_detail_side_infos_author.html
+++ b/lemarche/templates/tenders/_detail_side_infos_author.html
@@ -42,7 +42,7 @@
         {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
     </a>
     <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEWED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
-        <i class="ri-focus-2-line"></i>
+        <i class="ri-eye-line"></i>
         {{ tender.siae_email_link_click_date_or_detail_display_date_count }} prestataire{{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize }} qui {{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize:'a,ont' }} vu
     </a>
     <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-interested-list-from-detail-btn" class="btn btn-primary mb-3">

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -115,10 +115,10 @@
                         <i class="ri-download-line ri-lg"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right">
-                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&{{ current_search_query }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tendersiae_status={{ status|default:"" }}&{{ current_search_query }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
                             Télécharger la liste (.xls)
                         </a>
-                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&{{ current_search_query }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tendersiae_status={{ status|default:"" }}&{{ current_search_query }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
                             Télécharger la liste (.csv)
                         </a>
                     </div>

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -162,7 +162,7 @@ class SiaeFilterForm(forms.Form):
     tender = forms.ModelChoiceField(
         queryset=Tender.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
-    tender_status = forms.CharField(required=False, widget=forms.HiddenInput())
+    tendersiae_status = forms.CharField(required=False, widget=forms.HiddenInput())
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
@@ -307,8 +307,8 @@ class SiaeFilterForm(forms.Form):
         # a Tender author can export its Siae list
         tender = self.cleaned_data.get("tender", None)
         if tender:
-            tender_status = self.cleaned_data.get("tender_status", "ALL")
-            qs = qs.filter_with_tender(tender=tender, tender_status=tender_status)
+            tendersiae_status = self.cleaned_data.get("tendersiae_status", "ALL")
+            qs = qs.filter_with_tender(tender=tender, tendersiae_status=tendersiae_status)
 
         locations = self.cleaned_data.get("locations", None)
         if locations:

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -550,13 +550,13 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         qs = super().get_queryset()
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
-        qs = qs.filter_with_tender(tender=self.tender, tender_status=self.status)
+        qs = qs.filter_with_tender_status(tender=self.tender, tender_status=self.status)
         # then filter with the form
         self.filter_form = SiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         return qs
 
-    def get(self, request, status="ALL", *args, **kwargs):
+    def get(self, request, status=None, *args, **kwargs):
         """
         - set status
         - update 'siae_list_last_seen_date'

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -550,7 +550,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         qs = super().get_queryset()
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
-        qs = qs.filter_with_tender_status(tender=self.tender, tender_status=self.status)
+        qs = qs.filter_with_tender_tendersiae_status(tender=self.tender, tendersiae_status=self.status)
         # then filter with the form
         self.filter_form = SiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)


### PR DESCRIPTION
### Quoi ?

Actuellement, dans la page des prestataires intéressés, on ne fait pas le bon filtrage. On recalcule les prestataires qui "étaient initialement concernés", au lieu de filtrer en fonction de nos stats TenderSiae.

Du coup certains prestataires qui avaient ou qui s'étaient montrés intéressés, sans pour autant avoir été ciblés au début, n'apparaissaient pas dans les listes :exploding_head: 

J'ai rajouté des tests
