### PR TITLE
[API] Cleanup (retirer inbound parsing de la doc)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -604,8 +604,11 @@ SPECTACULAR_SETTINGS = {
     },
     "PREPROCESSING_HOOKS": ["lemarche.api.utils.custom_preprocessing_hook"],
     "ENUM_NAME_OVERRIDES": {
-        "kind": "lemarche.siaes.constants.KIND_CHOICES",
-        "department": "lemarche.siaes.models.Siae.DEPARTMENT_CHOICES",
+        "SiaeKindEnum": "lemarche.siaes.constants.KIND_CHOICES",
+        "TenderKindEnum": "lemarche.tenders.constants.KIND_CHOICES",
+        "PerimeterKindEnum": "lemarche.perimeters.models.Perimeter.KIND_CHOICES",
+        "ConversationKindEnum": "lemarche.conversations.models.Conversation.KIND_CHOICES",
+        "DepartmentEnum": "lemarche.siaes.models.Siae.DEPARTMENT_CHOICES",
     },
     "SWAGGER_UI_SETTINGS": {"defaultModelsExpandDepth": -1},  # hide model schemas
 }

--- a/lemarche/api/emails/views.py
+++ b/lemarche/api/emails/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -30,6 +31,7 @@ def clean_saved_data_of_inbound(data_inbound: dict):
 
 
 class InboundParsingEmailView(APIView):
+    @extend_schema(exclude=True)
     def post(self, request):
         serializer = EmailsSerializer(data=request.data)
         if serializer.is_valid():

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -948,11 +948,11 @@ class Siae(models.Model):
                 raise e
 
     @property
-    def kind_is_esat_or_ea_or_eatt(self):
+    def kind_is_esat_or_ea_or_eatt(self) -> bool:
         return self.kind in [siae_constants.KIND_ESAT, siae_constants.KIND_EA, siae_constants.KIND_EATT]
 
     @property
-    def kind_parent(self):
+    def kind_parent(self) -> str:
         if self.kind in siae_constants.KIND_GROUP_INSERTION_LIST:
             return siae_constants.KIND_GROUP_INSERTION_NAME
         if self.kind in siae_constants.KIND_GROUP_HANDICAP_LIST:
@@ -972,13 +972,13 @@ class Siae(models.Model):
         return None
 
     @property
-    def name_display(self):
+    def name_display(self) -> str:
         if self.brand:
             return self.brand
         return self.name
 
     @property
-    def presta_type_display(self):
+    def presta_type_display(self) -> str:
         if self.kind == siae_constants.KIND_ETTI:
             return "Intérim"
         if self.kind == siae_constants.KIND_AI:
@@ -991,7 +991,7 @@ class Siae(models.Model):
         return ""
 
     @property
-    def siret_display(self):
+    def siret_display(self) -> str:
         """
         SIRET = 14 numbers
         SIREN = 9 numbers
@@ -1004,11 +1004,11 @@ class Siae(models.Model):
         return self.siret
 
     @property
-    def siren(self):
+    def siren(self) -> str:
         return self.siret[:9]
 
     @property
-    def nic(self):
+    def nic(self) -> str:
         """
         The second part of SIRET is called the NIC (numéro interne de classement).
         https://www.insee.fr/fr/metadonnees/definition/c1981


### PR DESCRIPTION
### Quoi ?

Modifications apportées : 
- retiré l'endpoint "inbound parsing" de la doc
- ajout de type hint sur certaines propriétés (enlève 2 warnings)
- ajout d'enums (mais pas réussi à enlever le dernier warning)

### Messages de warning

```
Warning [SiaeViewSet > SiaeListSerializer]: unable to resolve type hint for function "kind_parent". Consider using a type hint or @extend_schema_field. Defaulting to string.
Warning [SiaeViewSet > SiaeDetailSerializer]: unable to resolve type hint for function "kind_parent". Consider using a type hint or @extend_schema_field. Defaulting to string.
Warning: enum naming encountered a non-optimally resolvable collision for fields named "kind". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "Kind61cEnum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
```