### PR TITLE
[Affichage des Siaes] Ajout du badge visuel des super esi

### DIFF
--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -313,6 +313,9 @@ $super-badge-color: #ffbe18;
 	text-align: left;
 }
 
+.super-badge-tab {
+	border-color: $super-badge-color !important;
+}
 
 // TODO: integrate to the theme
 $purple-marche: #6C38D9;

--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -294,6 +294,26 @@
 	}
 }
 
+
+$super-badge-color: #ffbe18;
+
+.super-badge-card {
+	border: 1px solid $super-badge-color;
+}
+.super-badge-badge {
+	padding: 2px 6px;
+	background: linear-gradient(0deg, #fff7e0, #fff7e0), linear-gradient(0deg, $super-badge-color, $super-badge-color);
+	border: 1px solid $super-badge-color;
+	gap: 4px;
+	//styleName: Mentions/fs-xs + bold;
+	font-size: 12px;
+	font-weight: 700;
+	line-height: 20px;
+	letter-spacing: 0px;
+	text-align: left;
+}
+
+
 // TODO: integrate to the theme
 $purple-marche: #6C38D9;
 

--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -304,8 +304,6 @@ $super-badge-color: #ffbe18;
 	padding: 2px 6px;
 	background: linear-gradient(0deg, #fff7e0, #fff7e0), linear-gradient(0deg, $super-badge-color, $super-badge-color);
 	border: 1px solid $super-badge-color;
-	gap: 4px;
-	//styleName: Mentions/fs-xs + bold;
 	font-size: 12px;
 	font-weight: 700;
 	line-height: 20px;

--- a/lemarche/static/js/utils.js
+++ b/lemarche/static/js/utils.js
@@ -24,9 +24,10 @@ window.addEventListener('DOMContentLoaded', function () {
 
     $('.s-tabs-01__nav .nav-item').on('click', function (event) {
         event.preventDefault()
-        let tabContent = $($(this).parents()[1]).find(".tab-content")[0];
+        let tabContent = this.parentElement.parentElement.querySelector(".tab-content");
+        let hasSuperBadgeTab = this.children[0].classList.contains("super-badge-tab");
 
-        if ($(this).children()[0].classList.contains("super-badge-tab")) {
+        if (hasSuperBadgeTab) {
             tabContent.classList.add("super-badge-tab");
         } else {
             tabContent.classList.remove("super-badge-tab");

--- a/lemarche/static/js/utils.js
+++ b/lemarche/static/js/utils.js
@@ -20,7 +20,19 @@ window.addEventListener('DOMContentLoaded', function () {
         location.href = "mailto:?" + rot13(this.dataset['nextUrl']);
     });
 
-    initModalMessages()
+    initModalMessages();
+
+    $('.s-tabs-01__nav .nav-item').on('click', function (event) {
+        event.preventDefault()
+        let tabContent = $($(this).parents()[1]).find(".tab-content")[0];
+
+        if ($(this).children()[0].classList.contains("super-badge-tab")) {
+            tabContent.classList.add("super-badge-tab");
+        } else {
+            tabContent.classList.remove("super-badge-tab");
+        }
+        $(this).tab('show')
+    })
 });
 
 let toggleRequiredClasses = (toggle, element) => {

--- a/lemarche/templates/dashboard/_siae_tab_content.html
+++ b/lemarche/templates/dashboard/_siae_tab_content.html
@@ -2,15 +2,23 @@
 
 <div class="row">
     <div class="col-12 col-md-7">
-        <div class="d-flex align-items-center mb-3">
-            <span class="mr-3">
+        <div class="row mb-3">
+            <div class="col-auto">
                 {% if siae.logo_url %}
                     <img class="img-fluid" style="width:50px" src="{{ siae.logo_url }}" alt="Logo de la structure {{ siae.name }}" loading="lazy" />
                 {% else %}
                     <img class="img-fluid" style="width:50px" src="{% static 'img/default-listing.png' %}" alt="{{ siae.name }}" loading="lazy" />
                 {% endif %}
-            </span>
-            <h2 class="mb-0">{{ siae.name_display }}</h2>
+            </div>
+            <div class="col">
+                <h2 class="mb-0">{{ siae.name_display }}</h2>
+                {% if  siae.super_badge %}
+                    <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
+                        <i class="ri-award-fill mr-1"></i>
+                        Super prestataire
+                    </span>
+                {% endif %}
+            </div>
         </div>
         {% include "includes/_completion_progress_bar.html" with completion_percent=siae.completion_rate_calculated %}
     </div>

--- a/lemarche/templates/dashboard/_siae_tab_content.html
+++ b/lemarche/templates/dashboard/_siae_tab_content.html
@@ -14,7 +14,7 @@
                 <h2 class="mb-0">{{ siae.name_display }}</h2>
                 {% if  siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
-                        <i class="ri-award-fill mr-1"></i>
+                        <i class="ri-award-fill"></i>
                         Super prestataire
                     </span>
                 {% endif %}

--- a/lemarche/templates/dashboard/_siae_tab_content.html
+++ b/lemarche/templates/dashboard/_siae_tab_content.html
@@ -12,7 +12,7 @@
             </div>
             <div class="col">
                 <h2 class="mb-0">{{ siae.name_display }}</h2>
-                {% if  siae.super_badge %}
+                {% if siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                         <i class="ri-award-fill"></i>
                         Super prestataire

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -40,7 +40,7 @@
                     <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                         {% for siaeuser in user.siaeuser_set.all %}
                             <li class="nav-item" role="presentation">
-                                <a class="nav-link {% if forloop.first %}active{% endif %} {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}" id="{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+                                <a class="nav-link {% if forloop.first %}active{% endif %} {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}" id="id-{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
                                     <span class="mr-2">
                                         {% if siaeuser.siae.logo_url %}
                                             <img class="img-fluid" style="width:20px" src="{{ siaeuser.siae.logo_url }}" alt="Logo de la structure {{ siaeuser.siae.name }}" loading="lazy" />
@@ -68,7 +68,7 @@
                             {% if forloop.first %}
                                 <div class="tab-content {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}">
                             {% endif %}
-                            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
+                            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="id-{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
                                 {% include "dashboard/_siae_tab_content.html" with siae=siaeuser.siae %}
                             </div>
                             {% if forloop.last %}

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -64,13 +64,17 @@
                         </li>
                     </ul>
                     {% if user.siaeuser_set.count %}
-                        <div class="tab-content {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}">
-                            {% for siaeuser in user.siaeuser_set.all %}
-                                <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
-                                    {% include "dashboard/_siae_tab_content.html" with siae=siaeuser.siae %}
+                        {% for siaeuser in user.siaeuser_set.all %}
+                            {% if forloop.first %}
+                                <div class="tab-content {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}">
+                            {% endif %}
+                            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
+                                {% include "dashboard/_siae_tab_content.html" with siae=siaeuser.siae %}
+                            </div>
+                            {% if forloop.last %}
                                 </div>
-                            {% endfor %}
-                        </div>
+                            {% endif %}
+                        {% endfor %}
                     {% endif %}
                 </div>
             </div>

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -40,7 +40,7 @@
                     <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                         {% for siaeuser in user.siaeuser_set.all %}
                             <li class="nav-item" role="presentation">
-                                <a class="nav-link {% if forloop.first %}active{% endif %} {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}" id="id-{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+                                <a class="nav-link {% if forloop.first %}active{% endif %} {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}" id="id-{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#id-{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
                                     <span class="mr-2">
                                         {% if siaeuser.siae.logo_url %}
                                             <img class="img-fluid" style="width:20px" src="{{ siaeuser.siae.logo_url }}" alt="Logo de la structure {{ siaeuser.siae.name }}" loading="lazy" />
@@ -68,7 +68,7 @@
                             {% if forloop.first %}
                                 <div class="tab-content {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}">
                             {% endif %}
-                            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="id-{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
+                            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="id-{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="id-{{ siaeuser.siae.slug }}-tab">
                                 {% include "dashboard/_siae_tab_content.html" with siae=siaeuser.siae %}
                             </div>
                             {% if forloop.last %}
@@ -139,4 +139,5 @@
 {% endif %}
 
 {% include "dashboard/_aides_territoires_section.html" with extra_class="pt-3" %}
+
 {% endblock %}

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -40,7 +40,7 @@
                     <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                         {% for siaeuser in user.siaeuser_set.all %}
                             <li class="nav-item" role="presentation">
-                                <a class="nav-link {% if forloop.first %}active{% endif %}" id="{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+                                <a class="nav-link {% if forloop.first %}active{% endif %} {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}" id="{{ siaeuser.siae.slug }}-tab" data-toggle="tab" href="#{{ siaeuser.siae.slug }}" role="tab" aria-controls="{{ siaeuser.siae.slug }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
                                     <span class="mr-2">
                                         {% if siaeuser.siae.logo_url %}
                                             <img class="img-fluid" style="width:20px" src="{{ siaeuser.siae.logo_url }}" alt="Logo de la structure {{ siaeuser.siae.name }}" loading="lazy" />
@@ -64,7 +64,7 @@
                         </li>
                     </ul>
                     {% if user.siaeuser_set.count %}
-                        <div class="tab-content">
+                        <div class="tab-content {% if siaeuser.siae.super_badge %}super-badge-tab{% endif %}">
                             {% for siaeuser in user.siaeuser_set.all %}
                                 <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ siaeuser.siae.slug }}" role="tabpanel" aria-labelledby="{{ siaeuser.siae.slug }}-tab">
                                     {% include "dashboard/_siae_tab_content.html" with siae=siaeuser.siae %}

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -17,7 +17,7 @@
                             {{ siae.name_display }}
                         </h1>
                         {% if  siae.super_badge %}
-                            <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-1 font-weight-bold">
+                            <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                                 <i class="ri-award-fill mr-1"></i>
                                 Super prestataire
                             </span>

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -16,7 +16,7 @@
                         <h1 class="h2 mb-0">
                             {{ siae.name_display }}
                         </h1>
-                        {% if  siae.super_badge %}
+                        {% if siae.super_badge %}
                             <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                                 <i class="ri-award-fill"></i>
                                 Super prestataire

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -13,12 +13,12 @@
             <div class="col">
                 <div class="row">
                     <div class="col-sm-12">
-                        <h1 class="h2 mb-1">
+                        <h1 class="h2 mb-0">
                             {{ siae.name_display }}
                         </h1>
                         {% if  siae.super_badge %}
                             <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
-                                <i class="ri-award-fill mr-1"></i>
+                                <i class="ri-award-fill"></i>
                                 Super prestataire
                             </span>
                         {% endif %}

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<div class="card c-card c-card--hovershadow siae-card">
+<div class="card c-card c-card--hovershadow siae-card {% if siae.super_badge %}super-badge-card{% endif %}">
     <div class="card-header">
         <div class="row">
             <div class="col-auto">
@@ -13,11 +13,16 @@
             <div class="col">
                 <div class="row">
                     <div class="col-sm-12">
-                        <h1 class="h2 mb-2">
+                        <h1 class="h2 mb-1">
                             {{ siae.name_display }}
-                            <br />
-                            <small>(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</small>
                         </h1>
+                        {% if  siae.super_badge %}
+                            <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-1 font-weight-bold">
+                                <i class="ri-award-fill mr-1"></i>
+                                Super prestataire
+                            </span>
+                        {% endif %}
+                        <p class="mt-3 mb-1 font-italic">(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</p>
                         {% if user.is_authenticated %}
                             {% if siae.in_user_favorite_list_count_annotated %}
                                 <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -19,7 +19,7 @@
                     {% endif %}
                 </h2>
                 {% if  siae.super_badge %}
-                    <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-1 font-weight-bold">
+                    <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                         <i class="ri-award-fill mr-1"></i>
                         Super prestataire
                     </span>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -1,7 +1,7 @@
 {% load static siae_sectors_display %}
 {% load theme_inclusion %}
 
-<div class="card c-card c-card--hovershadow siae-card">
+<div class="card c-card c-card--hovershadow siae-card {% if siae.super_badge %}super-badge-card{% endif %}">
     <div class="card-header">
         <div class="row">
             <div class="col-auto">
@@ -18,6 +18,12 @@
                         <span class="fs-sm font-weight-normal">(bientôt inscrite sur le marché)</span>
                     {% endif %}
                 </h2>
+                {% if  siae.super_badge %}
+                    <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-1 font-weight-bold">
+                        <i class="ri-award-fill mr-1"></i>
+                        Super prestataire
+                    </span>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -20,7 +20,7 @@
                 </h2>
                 {% if  siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
-                        <i class="ri-award-fill mr-1"></i>
+                        <i class="ri-award-fill"></i>
                         Super prestataire
                     </span>
                 {% endif %}

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -18,7 +18,7 @@
                         <span class="fs-sm font-weight-normal">(bientôt inscrite sur le marché)</span>
                     {% endif %}
                 </h2>
-                {% if  siae.super_badge %}
+                {% if siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                         <i class="ri-award-fill"></i>
                         Super prestataire

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -12,7 +12,7 @@
             </div>
             <div class="col">
                 <h2 class="h4 mb-0">{{ siae.name_display }}</h2>
-                {% if  siae.super_badge %}
+                {% if siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
                         <i class="ri-award-fill"></i>
                         Super prestataire

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -14,7 +14,7 @@
                 <h2 class="h4 mb-0">{{ siae.name_display }}</h2>
                 {% if  siae.super_badge %}
                     <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
-                        <i class="ri-award-fill mr-1"></i>
+                        <i class="ri-award-fill"></i>
                         Super prestataire
                     </span>
                 {% endif %}

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<div class="card c-card c-card--marche siae-card">
+<div class="card c-card siae-card super-esi-card {% if siae.super_badge %}super-badge-card{% endif %}">
     <div class="card-header">
         <div class="row">
             <div class="col-auto">
@@ -12,6 +12,12 @@
             </div>
             <div class="col">
                 <h2 class="h4 mb-0">{{ siae.name_display }}</h2>
+                {% if  siae.super_badge %}
+                    <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
+                        <i class="ri-award-fill mr-1"></i>
+                        Super prestataire
+                    </span>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Quoi ?

[Affichage des Siaes] Ajout du badge visuel des super esi.

### Pourquoi ?

Mettre en avant les esi actives sur la plateforme.

### Captures d'écran (optionnel)
Favoris : 
<img width="1631" alt="favoris" src="https://github.com/gip-inclusion/le-marche/assets/12339682/7604ac09-9f75-4553-83b7-9716930f605b">

Détail des fiches : 
<img width="1631" alt="image" src="https://github.com/gip-inclusion/le-marche/assets/12339682/45a3c316-6729-48da-bd48-c2ab33c8affd">

Liste dans le dépôt de besoins:
<img width="1631" alt="image" src="https://github.com/gip-inclusion/le-marche/assets/12339682/e31d2a55-435c-4fd7-b57a-79b5554f0087">

Dans la liste de recherches:
<img width="1631" alt="image" src="https://github.com/gip-inclusion/le-marche/assets/12339682/0f2ceecc-2932-4fd3-8e07-62d470f65ef7">

