### PR TITLE
Dépôt de besoin x APProch : si besoin existant, mais kind a changé, alors en re-créer un

### DIFF
--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -56,17 +56,17 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
             if user.id == settings.PARTNER_APPROCH_USER_ID:
                 tender_partner_approch_id = serializer.validated_data.get("extra_data", {}).get("id", None)
                 if tender_partner_approch_id:
+                    # try to find an existing tender (same id + kind)
+                    # if found, update some fields
+                    # if not found, create it !
                     try:
-                        # try to find an existing tender
-                        # if found, update some fields
-                        tender = Tender.objects.get(partner_approch_id=tender_partner_approch_id)
-                        if tender.kind != serializer.validated_data.get("kind"):
-                            pass
-                        else:
-                            for field in PARTNER_APPROCH_UPDATE_FIELDS:
-                                setattr(tender, field, serializer.validated_data.get(field))
-                            tender.save(update_fields=PARTNER_APPROCH_UPDATE_FIELDS)
-                            return
+                        tender = Tender.objects.get(
+                            partner_approch_id=tender_partner_approch_id, kind=serializer.validated_data.get("kind")
+                        )
+                        for field in PARTNER_APPROCH_UPDATE_FIELDS:
+                            setattr(tender, field, serializer.validated_data.get(field))
+                        tender.save(update_fields=PARTNER_APPROCH_UPDATE_FIELDS)
+                        return
                     except Tender.DoesNotExist:
                         serializer.validated_data["partner_approch_id"] = tender_partner_approch_id
         # pop non-model fields

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -60,10 +60,13 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
                         # try to find an existing tender
                         # if found, update some fields
                         tender = Tender.objects.get(partner_approch_id=tender_partner_approch_id)
-                        for field in PARTNER_APPROCH_UPDATE_FIELDS:
-                            setattr(tender, field, serializer.validated_data.get(field))
-                        tender.save(update_fields=PARTNER_APPROCH_UPDATE_FIELDS)
-                        return
+                        if tender.kind != serializer.validated_data.get("kind"):
+                            pass
+                        else:
+                            for field in PARTNER_APPROCH_UPDATE_FIELDS:
+                                setattr(tender, field, serializer.validated_data.get(field))
+                            tender.save(update_fields=PARTNER_APPROCH_UPDATE_FIELDS)
+                            return
                     except Tender.DoesNotExist:
                         serializer.validated_data["partner_approch_id"] = tender_partner_approch_id
         # pop non-model fields


### PR DESCRIPTION
### Quoi ?

Suite de #1069

Lorsqu'un besoin existant est reçu, il existe un cas particulier où l'on souhaite tout de même le recréer : si le champ `kind a changé`.

### Reste à faire

Faire un "lien" avec le besoin précédent ?