### PR TITLE
feat(api) Pouvoir chercher les structures par SIREN

### DIFF
--- a/lemarche/api/urls.py
+++ b/lemarche/api/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path("", TemplateView.as_view(template_name="api/home.html"), name="home"),
     # Additional API endpoints
     path("siae/slug/<str:slug>/", SiaeViewSet.as_view({"get": "retrieve_by_slug"}), name="siae-retrieve-by-slug"),
+    path("siae/siren/<str:siren>/", SiaeViewSet.as_view({"get": "retrieve_by_siren"}), name="siae-retrieve-by-siren"),
     path("siae/siret/<str:siret>/", SiaeViewSet.as_view({"get": "retrieve_by_siret"}), name="siae-retrieve-by-siret"),
     path(
         "siaes/siret/<str:siret>/",


### PR DESCRIPTION
### Quoi ?

Autre demande d'API Entreprise (après la #955)

Avoir une URL pour récupérer les structures par siren (on avait déjà par siret)
- `/siae/siren/<siren>`
- siren = 9 caractères, siret = 13