### PR TITLE
Refonte ergonomique de la liste des opportunités

### DIFF
--- a/lemarche/static/itou_marche/base/_custom.scss
+++ b/lemarche/static/itou_marche/base/_custom.scss
@@ -107,3 +107,8 @@ a.disabled {
 .htmx-request .htmx-indicator{
     opacity:1
 }
+
+.badge-new {
+    color: $white;
+    background-color: $marche-green;
+}

--- a/lemarche/static/itou_marche/base/_variables.scss
+++ b/lemarche/static/itou_marche/base/_variables.scss
@@ -43,3 +43,7 @@ $marche-lightest: #FFF6F6;
 $marche-gray-10: #F2F3F5;
 $marche-gray-light: rgb(251, 251, 251);
 $marche-purple: #6C38D9;
+
+$marche-tender: #30748B;
+$marche-proj: #6C38D9;
+$marche-quote: #0063CB;

--- a/lemarche/static/itou_marche/base/_variables.scss
+++ b/lemarche/static/itou_marche/base/_variables.scss
@@ -47,3 +47,4 @@ $marche-purple: #6C38D9;
 $marche-tender: #30748B;
 $marche-proj: #6C38D9;
 $marche-quote: #0063CB;
+$marche-outdated: #E6E6EB;

--- a/lemarche/static/itou_marche/base/_variables.scss
+++ b/lemarche/static/itou_marche/base/_variables.scss
@@ -43,6 +43,7 @@ $marche-lightest: #FFF6F6;
 $marche-gray-10: #F2F3F5;
 $marche-gray-light: rgb(251, 251, 251);
 $marche-purple: #6C38D9;
+$marche-green: #18a47d;
 
 $marche-tender: #30748B;
 $marche-proj: #6C38D9;

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -17,6 +17,7 @@
 @import "sections/filiere";
 @import "sections/partenaires";
 @import "sections/valoriser";
+@import "sections/tender";
 
 // Pages
 @import "layouts/pages";

--- a/lemarche/static/itou_marche/sections/_tender.scss
+++ b/lemarche/static/itou_marche/sections/_tender.scss
@@ -3,7 +3,7 @@
 }
 
 .badge-tender, .badge-proj, .badge-quote {
-    color: #FFF;
+    color: $white;
 }
 
 .c-card--marche-tender::after, .badge-tender {

--- a/lemarche/static/itou_marche/sections/_tender.scss
+++ b/lemarche/static/itou_marche/sections/_tender.scss
@@ -1,0 +1,19 @@
+.c-card--marche-tender::after, .c-card--marche-proj::after, .c-card--marche-quote::after {
+    height: 4px;
+}
+
+.badge-tender, .badge-proj, .badge-quote {
+    color: #FFF;
+}
+
+.c-card--marche-tender::after, .badge-tender {
+    background-color: $marche-tender;
+}
+
+.c-card--marche-proj::after, .badge-proj {
+    background-color: $marche-proj;
+}
+
+.c-card--marche-quote::after, .badge-quote {
+    background-color: $marche-quote;
+}

--- a/lemarche/static/itou_marche/sections/_tender.scss
+++ b/lemarche/static/itou_marche/sections/_tender.scss
@@ -17,3 +17,7 @@
 .c-card--marche-quote::after, .badge-quote {
     background-color: $marche-quote;
 }
+
+.c-card--marche-outdated::after {
+    background-color: $marche-outdated;
+}

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -13,7 +13,7 @@
             <div class="col-md-12">
                 <h1>
                     {{ tender.title }}
-                    <span class="fs-sm badge badge-base badge-pill badge-emploi float-right" aria-hidden="true">{{ tender_kind_display|default:tender.get_kind_display }}</span>
+                    <span class="fs-sm badge badge-base badge-pill badge-{{ tender.kind|lower }} float-right" aria-hidden="true">{{ tender_kind_display|default:tender.get_kind_display }}</span>
                 </h1>
             </div>
         </div>

--- a/lemarche/templates/tenders/_list_item_detail_row.html
+++ b/lemarche/templates/tenders/_list_item_detail_row.html
@@ -21,8 +21,10 @@
     </div>
     {% if tender.accept_share_amount %}
         <div class="col-md-4" title="{% get_verbose_name tender 'amount' %}">
-            <i class="ri-money-euro-circle-line"></i>
-            {{ tender.get_amount_display|default:"-" }}
+            <strong>
+                <i class="ri-money-euro-circle-line"></i>
+                {{ tender.amount_display|default:"-" }}
+            </strong>
         </div>
     {% endif %}
 </div>

--- a/lemarche/templates/tenders/_list_item_detail_row.html
+++ b/lemarche/templates/tenders/_list_item_detail_row.html
@@ -2,29 +2,26 @@
 
 <div class="row">
     {% if tender.contact_company_name_display %}
-        <div class="col-md-4" title="Entreprise">
+        <div class="col-md-3" title="Entreprise">
             <i class="ri-building-4-line"></i>
             {{ tender.contact_company_name_display }}
         </div>
     {% endif %}
-    <div class="col-md-4" title="{% get_verbose_name tender 'location' %}">
+    <div class="col-md-9" title="{% get_verbose_name tender 'location' %}">
         {% if tender.perimeters_list_string %}
             <i class="ri-map-pin-2-line"></i>
             {{ tender.location_display|safe }}
         {% endif %}
     </div>
-    <div class="col-md-4" title="{% get_verbose_name tender 'sectors' %} : {{ tender.sectors_full_list_string|safe }}">
-        {% if tender.sectors.count %}
-            <i class="ri-award-line"></i>
-            {{ tender.sectors_list_string|safe }}
-        {% endif %}
-    </div>
-    {% if tender.accept_share_amount %}
-        <div class="col-md-4" title="{% get_verbose_name tender 'amount' %}">
+</div>
+{% if tender.accept_share_amount %}
+    <hr />
+    <div class="row">
+        <div class="col-md-3" title="{% get_verbose_name tender 'amount' %}">
             <strong>
-                <i class="ri-money-euro-circle-line"></i>
-                {{ tender.amount_display|default:"-" }}
+                Budget : {{ tender.amount_display|default:"-" }}
             </strong>
         </div>
-    {% endif %}
-</div>
+    </div>
+{% endif %}
+

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -18,7 +18,7 @@
                         Disponible <strong>jusqu'au : {{ tender.deadline_date|default:"" }}</strong>
                     {% endif %}
                     {% if not tender.tendersiae_set.first.detail_display_date %}
-                        <span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>
+                        <span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>
                     {% endif %}
                 </p>
             </div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -1,24 +1,25 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
+<div class="card c-card c-card--marche c-card--marche-{{ tender.kind|lower }} c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
         <div class="row">
             <div class="col-md-12">
                 <p class="mb-1">
-                    Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_is_outdated_annotated %}
-                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
-                    {% endif %}
-                    {% if not tender.tendersiae_set.first.detail_display_date %}
-                        <span class="badge badge-sm badge-pill badge-important">Nouveau</span>
-                    {% endif %}
-                    <span class="float-right badge badge-base badge-pill badge-emploi">
+                    <span class="badge badge-base badge-pill mr-1 badge-{{ tender.kind|lower }}">
                         {% if tender.kind == "PROJ" %}
                             {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
                         {% else %}
                             {{ tender.get_kind_display }}
                         {% endif %}
                     </span>
+                    {% if tender.deadline_date_is_outdated_annotated %}
+                        <span class="badge badge-sm badge-base badge-pill badge-light">Clôturé le {{ tender.deadline_date|default:"" }}</span>
+                    {% else %}
+                        Disponible <strong>jusqu'au : {{ tender.deadline_date|default:"" }}</strong>
+                    {% endif %}
+                    {% if not tender.tendersiae_set.first.detail_display_date %}
+                        <span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>
+                    {% endif %}
                 </p>
             </div>
         </div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -1,30 +1,30 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche c-card--marche-{{ tender.kind|lower }} c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
+<div class="card c-card c-card--marche c-card--marche-{{ tender.kind|lower }}{% if tender.deadline_date_is_outdated_annotated %} c-card--marche-outdated{% endif %} c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
         <div class="row">
             <div class="col-md-12">
                 <p class="mb-1">
-                    <span class="badge badge-base badge-pill mr-1 badge-{{ tender.kind|lower }}">
-                        {% if tender.kind == "PROJ" %}
-                            {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
-                        {% else %}
-                            {{ tender.get_kind_display }}
-                        {% endif %}
-                    </span>
                     {% if tender.deadline_date_is_outdated_annotated %}
-                        <span class="badge badge-sm badge-base badge-pill badge-light">Clôturé le {{ tender.deadline_date|default:"" }}</span>
+                        <span class="badge badge-sm badge-base badge-pill badge-nuance-08">Clôturé le {{ tender.deadline_date|default:"" }}</span>
                     {% else %}
+                        <span class="badge badge-base badge-pill mr-1 badge-{{ tender.kind|lower }}">
+                            {% if tender.kind == "PROJ" %}
+                                {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
+                            {% else %}
+                                {{ tender.get_kind_display }}
+                            {% endif %}
+                        </span>
                         Disponible <strong>jusqu'au : {{ tender.deadline_date|default:"" }}</strong>
                     {% endif %}
                     {% if not tender.tendersiae_set.first.detail_display_date %}
-                        <span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>
+                        <span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>
                     {% endif %}
                 </p>
             </div>
         </div>
 
-        <h2 class="py-2">{{ tender.title }}</h2>
+        <h2 class="py-2{% if tender.deadline_date_is_outdated_annotated %} text-nuance-03{% endif %}">{{ tender.title }}</h2>
 
         <hr />
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -527,7 +527,9 @@ class TenderListViewTest(TestCase):
         self.assertContains(response, "2 prestataires ciblés")  # tender_3
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
         self.assertNotContains(response, "Demandes reçues")
-        self.assertNotContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
+        self.assertNotContains(
+            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+        )
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
         self.client.force_login(self.user_partner)
@@ -553,7 +555,9 @@ class TenderListViewTest(TestCase):
         # The badge in header
         self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>')
         # The badge in tender list
-        self.assertContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
+        self.assertContains(
+            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+        )
 
         # Open tender detail page
         detail_url = reverse("tenders:detail", kwargs={"slug": self.tender_3.slug})
@@ -564,7 +568,9 @@ class TenderListViewTest(TestCase):
         self.assertNotContains(
             response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>'
         )
-        self.assertNotContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
+        self.assertNotContains(
+            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+        )
 
 
 class TenderDetailViewTest(TestCase):

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -528,7 +528,7 @@ class TenderListViewTest(TestCase):
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
         self.assertNotContains(response, "Demandes reçues")
         self.assertNotContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
+            response, '<span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>'
         )
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
@@ -555,9 +555,7 @@ class TenderListViewTest(TestCase):
         # The badge in header
         self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>')
         # The badge in tender list
-        self.assertContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
-        )
+        self.assertContains(response, '<span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>')
 
         # Open tender detail page
         detail_url = reverse("tenders:detail", kwargs={"slug": self.tender_3.slug})
@@ -569,7 +567,7 @@ class TenderListViewTest(TestCase):
             response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>'
         )
         self.assertNotContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
+            response, '<span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>'
         )
 
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -528,7 +528,7 @@ class TenderListViewTest(TestCase):
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
         self.assertNotContains(response, "Demandes reçues")
         self.assertNotContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
         )
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
@@ -556,7 +556,7 @@ class TenderListViewTest(TestCase):
         self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>')
         # The badge in tender list
         self.assertContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
         )
 
         # Open tender detail page
@@ -569,7 +569,7 @@ class TenderListViewTest(TestCase):
             response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>'
         )
         self.assertNotContains(
-            response, '<span class="float-right badge badge-sm badge-pill badge-important">Nouveau</span>'
+            response, '<span class="float-right badge badge-sm badge-pill badge-communaute">Nouveau</span>'
         )
 
 


### PR DESCRIPTION
### Quoi ?

Refonte ergonomique de la liste des opportunités

### Pourquoi ?

Permettre aux ESI de différencier les types de demandes client par un code couleur afin de gagner en lisibilité.

### Comment ?

- Le badge “Type de besoin” passe à gauche
- Le badge “Type de besoin” a une couleur associée
- La ligne en bas de la carte prend la couleur du “Type de besoin”
- La ligne en bas de la carte se réduit en épaisseur
- Le montant du besoin passe en gras
- Le montant du besoin = “Montant exact” si non “Fourchette” (Si l’acheteur le partage)
- Le tag “Nouveau” passe à droite de la carte

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/19582d5e-3ad1-4ded-85f6-f8cceda4a57e)
