### PR TITLE
refactor(api): Mieux renvoyer les structures dans l'endpoint par siret

### DIFF
--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -242,8 +242,8 @@ class SiaeRetrieveBySirenApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         SiaeFactory(name="Une structure", siret="12312312312345", department="38")
-        SiaeFactory(name="Une autre structure", siret="22222222222222", department="69")
-        SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222222222", department="69")
+        SiaeFactory(name="Une autre structure", siret="22222222233333", department="69")
+        SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222233333", department="69")
         UserFactory(api_key="admin")
 
     def test_should_return_400_if_siren_malformed(self):
@@ -276,8 +276,8 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["siret"], "22222222222222")
-        self.assertEqual(response.data[1]["siret"], "22222222222222")
+        self.assertEqual(response.data[0]["siret"], "22222222233333")
+        self.assertEqual(response.data[1]["siret"], "22222222233333")
         self.assertTrue("sectors" not in response.data[0])
         # authenticated user
         url = reverse("api:siae-retrieve-by-siren", args=["123123123"]) + "?token=admin"
@@ -293,8 +293,8 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["siret"], "22222222222222")
-        self.assertEqual(response.data[1]["siret"], "22222222222222")
+        self.assertEqual(response.data[0]["siret"], "22222222233333")
+        self.assertEqual(response.data[1]["siret"], "22222222233333")
         self.assertTrue("sectors" in response.data[0])
 
 
@@ -302,22 +302,26 @@ class SiaeRetrieveBySiretApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         SiaeFactory(name="Une structure", siret="12312312312345", department="38")
-        SiaeFactory(name="Une autre structure", siret="22222222222222", department="69")
-        SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222222222", department="69")
+        SiaeFactory(name="Une autre structure", siret="22222222233333", department="69")
+        SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222233333", department="69")
         UserFactory(api_key="admin")
 
-    def test_should_return_404_if_siret_unknown(self):
-        url = reverse("api:siae-retrieve-by-siret", args=["123"])  # anonymous user
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+    def test_should_return_404_if_siret_malformed(self):
+        # anonymous user
+        for siret in ["123", "123123123123456"]:
+            url = reverse("api:siae-retrieve-by-siret", args=[siret])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
 
     def test_should_return_404_if_siret_known_but_with_spaces(self):
-        url = reverse("api:siae-retrieve-by-siret", args=["123 123 123 12345"])  # anonymous user
+        # anonymous user
+        url = reverse("api:siae-retrieve-by-siret", args=["123 123 123 12345"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_siae_if_siret_known(self):
-        url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"])  # anonymous user
+        # anonymous user
+        url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), dict)
@@ -334,27 +338,29 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         self.assertTrue("sectors" in response.data)
 
     def test_should_return_siae_list_if_siret_known_and_duplicate(self):
-        url = reverse("api:siae-retrieve-by-siret", args=["22222222222222"])  # anonymous user
+        # anonymous user
+        url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
-        self.assertEqual(response.data[0]["siret"], "22222222222222")
-        self.assertEqual(response.data[1]["siret"], "22222222222222")
+        self.assertEqual(response.data[0]["siret"], "22222222233333")
+        self.assertEqual(response.data[1]["siret"], "22222222233333")
         self.assertTrue("sectors" not in response.data[0])
 
     def test_should_return_siae_detailed_list_if_siret_known_and_duplicate(self):
-        url = reverse("api:siae-retrieve-by-siret", args=["22222222222222"]) + "?token=admin"
+        url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"]) + "?token=admin"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
-        self.assertEqual(response.data[0]["siret"], "22222222222222")
-        self.assertEqual(response.data[1]["siret"], "22222222222222")
+        self.assertEqual(response.data[0]["siret"], "22222222233333")
+        self.assertEqual(response.data[1]["siret"], "22222222233333")
         self.assertTrue("sectors" in response.data[0])
 
 
 class SiaeChoicesApiTest(TestCase):
     def test_should_return_siae_kinds_list(self):
-        url = reverse("api:siae-kinds-list")  # anonymous user
+        # anonymous user
+        url = reverse("api:siae-kinds-list")
         response = self.client.get(url)
         self.assertEqual(response.data["count"], 10)
         self.assertEqual(len(response.data["results"]), 10)
@@ -363,7 +369,8 @@ class SiaeChoicesApiTest(TestCase):
         self.assertTrue("parent" in response.data["results"][0])
 
     def test_should_return_siae_presta_types_list(self):
-        url = reverse("api:siae-presta-types-list")  # anonymous user
+        # anonymous user
+        url = reverse("api:siae-presta-types-list")
         response = self.client.get(url)
         self.assertEqual(response.data["count"], 3)
         self.assertEqual(len(response.data["results"]), 3)

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -1,4 +1,4 @@
-from django.http import Http404, HttpResponseBadRequest
+from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, viewsets
@@ -109,16 +109,10 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         Note : le siret n'est pas nécessairement unique, il peut y avoir plusieurs structures retournées.<br /><br />
         <i>Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.</i>
         """
-        if len(siret) != 13:
+        if len(siret) != 14:
             return HttpResponseBadRequest("siret must be 14 caracters long")
         queryset = self.get_queryset().prefetch_many_to_one().filter(siret=siret)
-        queryset_count = queryset.count()
-        if queryset_count == 0:
-            raise Http404
-        elif queryset_count == 1:
-            return self._retrieve_return(request, queryset.first(), format)
-        else:
-            return self._list_return(request, queryset, format)
+        return self._list_return(request, queryset, format)
 
     def _retrieve_return(self, request, queryset, format):
         token = request.GET.get("token", None)

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -109,6 +109,8 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         Note : le siret n'est pas nécessairement unique, il peut y avoir plusieurs structures retournées.<br /><br />
         <i>Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.</i>
         """
+        if len(siret) != 13:
+            return HttpResponseBadRequest("siret must be 14 caracters long")
         queryset = self.get_queryset().prefetch_many_to_one().filter(siret=siret)
         queryset_count = queryset.count()
         if queryset_count == 0:


### PR DESCRIPTION
### Quoi ?

Suite à #1074 

Améliorations sur l'endpoint `/siae/siret/<siret>`
- renvoyer une liste dans tous les cas
- vérifications du format du siret