### PR TITLE
fix(tender): Suppression de l'affichage du badge "Nouveau" sur les DDB clôturés

### DIFF
--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -16,9 +16,9 @@
                             {% endif %}
                         </span>
                         Disponible <strong>jusqu'au : {{ tender.deadline_date|default:"" }}</strong>
-                    {% endif %}
-                    {% if not tender.tendersiae_set.first.detail_display_date %}
-                        <span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>
+                        {% if not tender.tendersiae_set.first.detail_display_date %}
+                            <span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>
+                        {% endif %}
                     {% endif %}
                 </p>
             </div>

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
@@ -364,9 +366,10 @@ class User(AbstractUser):
     def tender_siae_unread_count(self):
         from lemarche.tenders.models import TenderSiae
 
-        qs = TenderSiae.objects.filter(siae__in=self.siaes.all(), tender__validated_at__isnull=False).filter(
-            detail_display_date__isnull=True
-        )
+        limit_date = datetime.today()
+        qs = TenderSiae.objects.filter(
+            siae__in=self.siaes.all(), tender__validated_at__isnull=False, tender__deadline_date__gt=limit_date
+        ).filter(detail_display_date__isnull=True)
         return qs.count()
 
 


### PR DESCRIPTION
### Quoi ?

Suppression de l'affichage du badge "Nouveau" sur les dépôts de besoins clôturés et ajustement du compteur d'entête.

### Pourquoi ?

Pour que le badge "Nouveau" soit cohérent et attire l’œil sur des besoins encore en cours.

### Captures d'écran

![screenshot-localhost_8880-2024 02 19-12_31_56](https://github.com/gip-inclusion/le-marche/assets/17601807/4af09bf7-fccc-4785-b7ff-14c256c81e96)


