### PR TITLE
feat(tender): Admin : réduire la taille de la page grâce aux collapse

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -296,7 +296,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 ),
             },
         ),
-        ("Partenaire APProch", {"fields": ("is_partner_approch", "partner_approch_id")}),
+        ("Partenaire APProch", {"classes": ["collapse"], "fields": ("is_partner_approch", "partner_approch_id")}),
         (
             "Structures",
             {
@@ -357,6 +357,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         (
             "Stats",
             {
+                "classes": ["collapse"],
                 "fields": (
                     "siae_list_last_seen_date",
                     "source",
@@ -365,8 +366,8 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 ),
             },
         ),
-        ("Si importé", {"fields": ("import_raw_object_display",)}),
-        ("Dates", {"fields": ("created_at", "updated_at")}),
+        ("Si importé", {"classes": ["collapse"], "fields": ("import_raw_object_display",)}),
+        ("Dates", {"classes": ["collapse"], "fields": ("created_at", "updated_at")}),
     ]
 
     change_form_template = "tenders/admin_change_form.html"

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -336,12 +336,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         ),
         (
             "Utilité du marché de l'inclusion",
-            {
-                "fields": (
-                    "scale_marche_useless",
-                    "marche_benefits",
-                )
-            },
+            {"fields": ("scale_marche_useless",)},
         ),
         (
             "Status",
@@ -359,6 +354,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
             {
                 "classes": ["collapse"],
                 "fields": (
+                    "marche_benefits",
                     "siae_list_last_seen_date",
                     "source",
                     "logs_display",

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -303,8 +303,8 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 "fields": (
                     "siae_count_annotated_with_link",
                     "siae_email_send_count_annotated_with_link",
-                    "siae_email_link_click_count_annotated_with_link",
-                    "siae_detail_display_count_annotated_with_link",
+                    # "siae_email_link_click_count_annotated_with_link",
+                    # "siae_detail_display_count_annotated_with_link",
                     "siae_email_link_click_or_detail_display_count_annotated_with_link",
                     "siae_detail_contact_click_count_annotated_with_link",
                     "siae_detail_cocontracting_click_count_annotated_with_link",

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -244,7 +244,7 @@ class Tender(models.Model):
         "created_at",
         "updated_at",
     ]
-    FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + []
+    FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + ["marche_benefits"]
     READONLY_FIELDS = FIELDS_SURVEY_TRANSACTIONED + FIELDS_STATS
 
     # used in templates


### PR DESCRIPTION
### Quoi ?

Utiliser la fonctionnalité `collapse` des fieldset, pour cacher certaines sections de l'admin.
- sections concernées : APProch, Stats, Si importé, Dates
- j'ai aussi déplacé le champ "Bénéfices du marché" dans Stats
- et caché 2 stats "Structures cliquées" et "Structures vues" car demandé

### Pourquoi ?

Pour réduire la taille

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/21530793-cf29-4f1f-9754-da87b2faa29d)|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/95af23c9-2605-406b-b655-7fc6bc9477bf)|