### PR TITLE
refactor(tender): Réorganisation des colonnes de la liste des dépôts de besoins dans l'admin

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -433,7 +433,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     title_with_link.admin_order_field = "title"
 
     def amount_display(self, tender):
-        return f"{tender.amount_exact} €" if tender.amount_exact else tender.get_amount_display()
+        return tender.amount_admin_display
 
     amount_display.short_description = "Budget"
     amount_display.admin_order_field = "amount_exact"

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -132,28 +132,16 @@ class TenderForm(forms.ModelForm):
 @admin.register(Tender, site=admin_site)
 class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     list_display = [
-        "id",
-        "status",
-        "is_validated_or_sent",
-        "title",
-        "author_with_link",
-        "author_kind_detail",
+        "title_with_link",
         "kind",
-        "deadline_date",
-        "start_working_date",
-        "siae_count_annotated_with_link",
-        # "siae_email_send_count_annotated_with_link",
-        "siae_email_link_click_count_annotated_with_link",
-        "siae_detail_display_count_annotated_with_link",
-        # "siae_email_link_click_or_detail_display_count_annotated_with_link",
-        "siae_detail_contact_click_count_annotated_with_link",
-        "siae_detail_cocontracting_click_count_annotated_with_link",
-        "siae_transactioned",
-        "created_at",
-        "validated_at",
-        "first_sent_at",
-        "limit_send_to_siae_batch",
-        "limit_nb_siae_interested",
+        "amount_display",
+        "location_in_list",
+        "distance_location_in_list",
+        "deadline_date_in_list",
+        "start_working_date_in_list",
+        "siae_count_annotated_with_link_in_list",
+        "siae_detail_contact_click_count_annotated_with_link_in_list",
+        "is_validated_or_sent",
     ]
 
     list_filter = [
@@ -429,7 +417,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         return tender.is_validated_or_sent
 
     is_validated_or_sent.boolean = True
-    is_validated_or_sent.short_description = "Validé / Envoyé"
+    is_validated_or_sent.short_description = "Valider"
 
     def question_count_with_link(self, tender):
         url = reverse("admin:tenders_tenderquestion_changelist") + f"?tender__in={tender.id}"
@@ -437,12 +425,42 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
 
     question_count_with_link.short_description = TenderQuestion._meta.verbose_name_plural
 
-    def author_with_link(self, tender):
-        url = reverse("admin:users_user_change", args=[tender.author_id])
-        return format_html(f'<a href="{url}">{tender.author}</a>')
+    def title_with_link(self, tender):
+        url = reverse("admin:tenders_tender_change", args=[tender.id])
+        return format_html(f'<a href="{url}">{tender.title}</a>')
 
-    author_with_link.short_description = "Client"
-    author_with_link.admin_order_field = "author"
+    title_with_link.short_description = "Titre du besoin"
+    title_with_link.admin_order_field = "title"
+
+    def amount_display(self, tender):
+        return f"{tender.amount_exact} €" if tender.amount_exact else tender.get_amount_display()
+
+    amount_display.short_description = "Budget"
+    amount_display.admin_order_field = "amount_exact"
+
+    def location_in_list(self, tender):
+        return tender.location
+
+    location_in_list.short_description = "Lieu d'inter"
+    location_in_list.admin_order_field = "location"
+
+    def distance_location_in_list(self, tender):
+        return tender.distance_location
+
+    distance_location_in_list.short_description = "Dist. d'inter"
+    distance_location_in_list.admin_order_field = "distance_location"
+
+    def deadline_date_in_list(self, tender):
+        return tender.deadline_date
+
+    deadline_date_in_list.short_description = "Clôture"
+    deadline_date_in_list.admin_order_field = "deadline_date"
+
+    def start_working_date_in_list(self, tender):
+        return tender.start_working_date
+
+    start_working_date_in_list.short_description = "Début"
+    start_working_date_in_list.admin_order_field = "start_working_date"
 
     def author_kind_detail(self, tender):
         return tender.author.kind_detail_display
@@ -462,7 +480,12 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         return format_html(f'<a href="{url}">{getattr(tender, "siae_count_annotated", 0)}</a>')
 
     siae_count_annotated_with_link.short_description = "S. concernées"
-    siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"
+
+    def siae_count_annotated_with_link_in_list(self, tender):
+        return self.siae_count_annotated_with_link(tender)
+
+    siae_count_annotated_with_link_in_list.short_description = "S. concer."
+    siae_count_annotated_with_link_in_list.admin_order_field = "siae_count_annotated"
 
     def siae_ai_count_annotated_with_link(self, tender):
         url = (
@@ -526,7 +549,14 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_contact_click_count_annotated", 0)}</a>')
 
     siae_detail_contact_click_count_annotated_with_link.short_description = "S. intéressées"
-    siae_detail_contact_click_count_annotated_with_link.admin_order_field = "siae_detail_contact_click_count_annotated"
+
+    def siae_detail_contact_click_count_annotated_with_link_in_list(self, tender):
+        return self.siae_detail_contact_click_count_annotated_with_link(tender)
+
+    siae_detail_contact_click_count_annotated_with_link_in_list.short_description = "S. intér."
+    siae_detail_contact_click_count_annotated_with_link_in_list.admin_order_field = (
+        "siae_detail_contact_click_count_annotated"
+    )
 
     def siae_detail_cocontracting_click_count_annotated_with_link(self, tender):
         url = (

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -661,6 +661,10 @@ class Tender(models.Model):
         else:
             return "Non renseigné"
 
+    @cached_property
+    def amount_admin_display(self) -> str:
+        return f"{self.amount_exact} €" if self.amount_exact else self.get_amount_display()
+
     def questions_list(self):
         return list(self.questions.values("id", "text"))
 


### PR DESCRIPTION
### Quoi ?

Admin :  Réorganisation des colonnes de la liste des dépôts de besoins

### Pourquoi ?

Pour la rendre plus lisible et plus facile à utiliser.

### Comment ?

- Réduction du nombre de colonnes
- Réduction des entêtes de colonnes

### Captures d'écran

**Avant**

![screenshot--2024 02 19-18_12_22](https://github.com/gip-inclusion/le-marche/assets/17601807/267f6a9b-e5f5-437e-a73c-1a9ec2135b70)

**Après**

![screenshot-localhost_8880-2024 02 19-17_58_01](https://github.com/gip-inclusion/le-marche/assets/17601807/789c99b8-5e03-495a-bb0a-d78414008c8c)


