### PR TITLE
refactor: Améliorer le badge de clôture du DDB 

### DIFF
--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -2,7 +2,7 @@
     <time class="fs-sm d-block" aria-label="Date de clôture">
         <span>{{ tender.deadline_date|default:"" }}</span>
         {% if tender.deadline_date_is_outdated_annotated %}
-            <span class="badge badge-xs badge-base badge-pill badge-pilotage float-right">Clôturé</span>
+            <span class="badge badge-xs badge-base badge-pill badge-{{ tender.kind|lower }} float-right">Clôturé</span>
         {% endif %}
         {% if tender.is_draft %}
             <span class="badge badge-xs badge-base badge-pill badge-outline-warning float-right">

--- a/lemarche/templates/tenders/_closed_badge.html
+++ b/lemarche/templates/tenders/_closed_badge.html
@@ -1,3 +1,4 @@
 <span class="badge badge-xs badge-base badge-pill badge-{{ tender.kind|lower }}">
-    {{ tender_kind_display|default:tender.get_kind_display }} clôturé le {{ tender.deadline_date|default:"" }}
+    {{ tender_kind_display|default:tender.get_kind_display }} clôturé{% if tender.kind == "QUOTE" %}e{% endif %}
+    le {{ tender.deadline_date|default:"" }}
 </span>

--- a/lemarche/templates/tenders/_closed_badge.html
+++ b/lemarche/templates/tenders/_closed_badge.html
@@ -1,0 +1,3 @@
+<span class="badge badge-xs badge-base badge-pill badge-{{ tender.kind|lower }}">
+    {{ tender_kind_display|default:tender.get_kind_display }} clôturé le {{ tender.deadline_date|default:"" }}
+</span>

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -1,11 +1,8 @@
 {% load bootstrap4 static humanize array_choices_display %}
 
 <div class="card c-card c-card--marche siae-card rounded-lg shadow-lg">
-    <div class="card-header text-right bg-marche text-white fs-sm rounded-top rounded-lg p-3 mb-0">
-        Date limite de réponse : {{ tender.deadline_date|default:"" }}
-        {% if not source_form and tender.deadline_date_outdated %}
-            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Clôturé</span>
-        {% endif %}
+    <div class="card-header fs-sm rounded-top rounded-lg px-5">
+        {% include "tenders/_closed_badge.html" with tender=tender %}
     </div>
     <div class="card-body pb-5 px-5">
         <!-- title & header -->
@@ -13,7 +10,6 @@
             <div class="col-md-12">
                 <h1>
                     {{ tender.title }}
-                    <span class="fs-sm badge badge-base badge-pill badge-{{ tender.kind|lower }} float-right" aria-hidden="true">{{ tender_kind_display|default:tender.get_kind_display }}</span>
                 </h1>
             </div>
         </div>

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -5,10 +5,7 @@
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid;">
                 <p class="mb-1">
-                    Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_is_outdated_annotated %}
-                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
-                    {% endif %}
+                    {% include "tenders/_closed_badge.html" with tender=tender %}
                     {% if tender.is_draft %}
                         <span class="badge badge-sm badge-base badge-pill badge-outline-warning float-right">
                             <i class="ri-draft-fill"></i>Brouillon

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -7,17 +7,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <p class="mb-1">
-                            Date de clôture : {{ tender.deadline_date|default:"" }}
-                            {% if tender.deadline_date_is_outdated_annotated %}
-                                <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
-                            {% endif %}
-                            <span class="float-right badge badge-base badge-pill badge-emploi">
-                                {% if tender.kind == "PROJ" %}
-                                    {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
-                                {% else %}
-                                    {{ tender.get_kind_display }}
-                                {% endif %}
-                            </span>
+                            {% include "tenders/_closed_badge.html" with tender=tender %}
                         </p>
                     </div>
                 </div>

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1,5 +1,4 @@
 import json
-import locale
 from datetime import timedelta
 from unittest import mock
 
@@ -681,12 +680,6 @@ class TenderDetailViewTest(TestCase):
             detail_display_date=timezone.now(),
             detail_not_interested_click_date=timezone.now(),
         )
-        # set local in french for datetime human dispaly
-        locale.setlocale(locale.LC_TIME, "fr_FR")
-
-    @classmethod
-    def get_closed_verbatim(cls, tender: Tender):
-        return f"{tender.get_kind_display()} clôturé le {tender.deadline_date.strftime('%d %B %Y')}"
 
     def test_anyone_can_view_sent_tenders(self):
         for tender in Tender.objects.all():
@@ -813,17 +806,6 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Montant du marché")
         self.assertContains(response, tender_constants.ACCEPT_SHARE_AMOUNT_FALSE)
 
-    def test_tender_deadline_date_display(self):
-        # tender is not outdated by default
-        url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
-        response = self.client.get(url)
-        self.assertNotContains(response, self.get_closed_verbatim(tender=self.tender_1))
-        # new tender with outdated deadline_date
-        tender_2 = TenderFactory(deadline_date=timezone.now() - timedelta(days=1))
-        url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
-        response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
-
     def test_tender_author_has_additional_stats(self):
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
@@ -856,7 +838,6 @@ class TenderDetailViewTest(TestCase):
         # anonymous user
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertNotContains(response, self.get_closed_verbatim(tender=self.tender_1))
         self.assertContains(response, "Cet appel d'offres vous intéresse ?")
         self.assertContains(response, "Répondre en co-traitance ?")
         self.assertContains(response, "Cette demande ne vous intéresse pas ?")
@@ -915,7 +896,6 @@ class TenderDetailViewTest(TestCase):
         # anonymous user
         url = reverse("tenders:detail", kwargs={"slug": self.tender_3_response_is_anonymous.slug})
         response = self.client.get(url)
-        self.assertNotContains(response, self.get_closed_verbatim(tender=self.tender_3_response_is_anonymous))
         self.assertContains(response, "Cet appel d'offres vous intéresse ?")
         self.assertContains(response, "Répondre en co-traitance ?")
         self.assertContains(response, "Cette demande ne vous intéresse pas ?")
@@ -977,33 +957,28 @@ class TenderDetailViewTest(TestCase):
         # anonymous user
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
         self.assertNotContains(response, "Répondre à cette opportunité")
         # siae user interested
         self.client.force_login(self.siae_user_1)
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
         self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # siae user not concerned
         self.client.force_login(self.siae_user_6)
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
         self.assertNotContains(response, "Répondre à cette opportunité")
         # siae user without siae
         self.client.force_login(self.siae_user_without_siae)
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
         self.assertNotContains(response, "veuillez d'abord vous")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # author
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
-        self.assertContains(response, self.get_closed_verbatim(tender=tender_2))
         self.assertContains(response, "Coordonnées")
         self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")


### PR DESCRIPTION
### Quoi ?

Améliorer le badge de clôture du DDB.

### Pourquoi ?

Apporter plus de visibilité aux utilisateurs.

### Comment ?

En créant un composant réutilisable dans toute les templates.

### Captures d'écran

Avant : 
<img width="1703" alt="image" src="https://github.com/gip-inclusion/le-marche/assets/12339682/e722d0f6-4b95-489f-9641-f5cec480f8fc">

Après : 
<img width="1703" alt="image" src="https://github.com/gip-inclusion/le-marche/assets/12339682/ae924e36-de67-41c9-97f5-ca0c7b18a314">
