### PR TITLE
feat(Dashboard SIAE): Réordonner les besoins (derniers publiés en premier)

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -183,6 +183,9 @@ class TenderQuerySet(models.QuerySet):
             "deadline_date_is_outdated_annotated", "deadline_date", "-updated_at"
         )
 
+    def order_by_last_published(self):
+        return self.order_by("-published_at", "-updated_at")
+
     def with_question_stats(self):
         return self.annotate(question_count_annotated=Count("questions", distinct=True))
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -27,12 +27,12 @@ from lemarche.utils.admin.admin_site import MarcheAdminSite, get_admin_change_vi
 from lemarche.www.tenders import utils as tender_utils
 
 
-date_tomorrow = timezone.now() + timedelta(days=1)
-date_next_week = timezone.now() + timedelta(days=7)
-date_today = timezone.now() + timedelta(days=7)
-date_two_days_ago = timezone.now() - timedelta(days=2)
-date_last_week = timezone.now() - timedelta(days=7)
-date_last_month = timezone.now() - timedelta(days=30)
+date_today = timezone.now()
+date_tomorrow = date_today + timedelta(days=1)
+date_next_week = date_today + timedelta(days=7)
+date_two_days_ago = date_today - timedelta(days=2)
+date_last_week = date_today - timedelta(days=7)
+date_last_month = date_today - timedelta(days=30)
 
 
 class TenderModelTest(TestCase):

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -29,8 +29,10 @@ from lemarche.www.tenders import utils as tender_utils
 
 date_tomorrow = timezone.now() + timedelta(days=1)
 date_next_week = timezone.now() + timedelta(days=7)
+date_today = timezone.now() + timedelta(days=7)
 date_two_days_ago = timezone.now() - timedelta(days=2)
 date_last_week = timezone.now() - timedelta(days=7)
+date_last_month = timezone.now() - timedelta(days=30)
 
 
 class TenderModelTest(TestCase):
@@ -418,9 +420,9 @@ class TenderModelQuerysetTest(TestCase):
 class TenderModelQuerysetOrderTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.tender_1 = TenderFactory(deadline_date=date_next_week)
-        cls.tender_2 = TenderFactory(deadline_date=date_tomorrow)
-        cls.tender_3 = TenderFactory(deadline_date=date_last_week)
+        cls.tender_1 = TenderFactory(deadline_date=date_next_week, published_at=date_today)
+        cls.tender_2 = TenderFactory(deadline_date=date_tomorrow, published_at=date_two_days_ago)
+        cls.tender_3 = TenderFactory(deadline_date=date_last_week, published_at=date_last_month)
 
     def test_default_order(self):
         tender_queryset = Tender.objects.all()
@@ -431,6 +433,12 @@ class TenderModelQuerysetOrderTest(TestCase):
         tender_queryset = Tender.objects.order_by_deadline_date()
         self.assertEqual(tender_queryset.count(), 3)
         self.assertEqual(tender_queryset.first().id, self.tender_2.id)
+        self.assertEqual(tender_queryset.last().id, self.tender_3.id)
+
+    def test_order_by_last_published(self):
+        tender_queryset = Tender.objects.order_by_last_published()
+        self.assertEqual(tender_queryset.count(), 3)
+        self.assertEqual(tender_queryset.first().id, self.tender_1.id)
         self.assertEqual(tender_queryset.last().id, self.tender_3.id)
 
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -65,7 +65,7 @@ class DashboardHomeView(LoginRequiredMixin, DetailView):
         if user.kind == User.KIND_SIAE:
             siaes = user.siaes.all()
             if siaes:
-                context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes).order_by_deadline_date()[:3]
+                context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes).order_by_last_published()[:3]
         else:
             context["last_3_tenders"] = Tender.objects.filter(author=user).order_by_deadline_date()[:3]
             context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()


### PR DESCRIPTION
### Quoi ?

Réordonner les DDB sur page dashboard des SIAEs.

### Pourquoi ?

Mettre en avant les derniers DDB publié.

