### PR TITLE
refactor: améliore un peu la génération des URL absolute & admin

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -26,6 +26,7 @@ from lemarche.users.models import User
 from lemarche.utils.constants import DEPARTMENTS_PRETTY, RECALCULATED_FIELD_HELP_TEXT, REGIONS_PRETTY
 from lemarche.utils.data import round_by_base
 from lemarche.utils.fields import ChoiceArrayField
+from lemarche.utils.urls import get_object_admin_url
 
 
 def get_region_filter(perimeter):
@@ -1229,6 +1230,9 @@ class Siae(models.Model):
 
     def get_absolute_url(self):
         return reverse("siae:detail", kwargs={"slug": self.slug})
+
+    def get_admin_url(self):
+        return get_object_admin_url(self)
 
     def set_super_badge(self):
         update_fields_list = ["super_badge"]

--- a/lemarche/siaes/tasks.py
+++ b/lemarche/siaes/tasks.py
@@ -7,7 +7,7 @@ from lemarche.users.models import User
 from lemarche.utils.apis import api_mailjet
 from lemarche.utils.apis.geocoding import get_geocoding_data
 from lemarche.utils.emails import whitelist_recipient_list
-from lemarche.utils.urls import get_domain_url, get_share_url_object
+from lemarche.utils.urls import get_domain_url, get_object_share_url
 
 
 @task()
@@ -46,7 +46,7 @@ def send_completion_reminder_email_to_siae(siae):
             variables = {
                 "SIAE_USER_FIRST_NAME": siae_user.first_name,
                 "SIAE_NAME": siae.name_display,
-                "SIAE_URL": get_share_url_object(siae),
+                "SIAE_URL": get_object_share_url(siae),
                 "SIAE_EDIT_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard_siaes:siae_edit_contact', args=[siae.slug])}",  # noqa
             }
 

--- a/lemarche/templates/siaes/_detail_admin_extra_info.html
+++ b/lemarche/templates/siaes/_detail_admin_extra_info.html
@@ -24,7 +24,7 @@
                     </li>
                 {% endif %}
                 <li>
-                    <a href="{% url 'admin:siaes_siae_change' siae.id %}" target="_blank" id="siae-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
+                    <a href="{{ siae.get_admin_url }}" target="_blank" id="siae-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
                         <span>
                             Lien vers l'admin&nbsp;
                             <i class="ri-external-link-line" aria-hidden="true"></i>

--- a/lemarche/templates/tenders/_detail_admin_extra_info.html
+++ b/lemarche/templates/tenders/_detail_admin_extra_info.html
@@ -44,7 +44,7 @@
                     </li>
                 {% endif %}
                 <li>
-                    <a href="{% url 'admin:tenders_tender_change' tender.id %}" target="_blank" id="tender-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
+                    <a href="{{ siae.get_admin_url }}" target="_blank" id="tender-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
                         <span>
                             Lien vers l'admin&nbsp;
                             <i class="ri-external-link-line" aria-hidden="true"></i>

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -22,6 +22,7 @@ from lemarche.users.models import User
 from lemarche.utils.apis import api_elasticsearch
 from lemarche.utils.constants import ADMIN_FIELD_HELP_TEXT, MARCHE_BENEFIT_CHOICES, RECALCULATED_FIELD_HELP_TEXT
 from lemarche.utils.fields import ChoiceArrayField
+from lemarche.utils.urls import get_object_admin_url
 
 
 def get_perimeter_filter(siae):
@@ -845,6 +846,9 @@ class Tender(models.Model):
 
     def get_absolute_url(self):
         return reverse("tenders:detail", kwargs={"slug": self.slug})
+
+    def get_admin_url(self):
+        return get_object_admin_url(self)
 
     def set_hubspot_id(self, hubspot_deal_id, with_save=True):
         self.extra_data.update({"hubspot_deal_id": hubspot_deal_id})

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -1,7 +1,7 @@
 import xlwt
 
 from lemarche.siaes.models import Siae
-from lemarche.utils.urls import get_share_url_object
+from lemarche.utils.urls import get_object_share_url
 
 
 SIAE_FIELDS_TO_EXPORT = [
@@ -73,7 +73,7 @@ def generate_siae_row(siae: Siae, siae_field_list):
         elif field_name == "Inscrite":
             col_value = "Oui" if siae.user_count else "Non"
         elif field_name == "Lien vers le marché":
-            col_value = f"{get_share_url_object(siae)}?cmp=export-excel"
+            col_value = f"{get_object_share_url(siae)}?cmp=export-excel"
         else:
             col_value = getattr(siae, field_name, "")
         siae_row.append(col_value)

--- a/lemarche/utils/urls.py
+++ b/lemarche/utils/urls.py
@@ -57,7 +57,7 @@ def get_share_url_object(obj: Model):
     return f"https://{get_domain_url()}{obj.get_absolute_url()}"
 
 
-def get_admin_url_object(obj: Model):
+def get_object_admin_url(obj: Model):
     admin_url = reverse_lazy(f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change", args=[obj.id])
     return f"https://{get_domain_url()}{admin_url}"
 

--- a/lemarche/utils/urls.py
+++ b/lemarche/utils/urls.py
@@ -53,7 +53,7 @@ def get_safe_url(request, param_name=None, fallback_url=None, url=None):
     return fallback_url
 
 
-def get_share_url_object(obj: Model):
+def get_object_share_url(obj: Model):
     return f"https://{get_domain_url()}{obj.get_absolute_url()}"
 
 

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -12,7 +12,7 @@ from lemarche.tenders.models import PartnerShareTender, Tender, TenderSiae
 from lemarche.utils.apis import api_hubspot, api_mailjet, api_slack
 from lemarche.utils.data import date_to_string
 from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
-from lemarche.utils.urls import get_domain_url, get_object_admin_url, get_share_url_object
+from lemarche.utils.urls import get_domain_url, get_object_admin_url, get_object_share_url
 
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
-            "TENDER_URL": get_share_url_object(tender),
+            "TENDER_URL": get_object_share_url(tender),
         }
 
         api_mailjet.send_transactional_email_many_recipient_with_template(
@@ -189,7 +189,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             "TENDER_PERIMETERS": tender.location_display,
             "TENDER_AMOUNT": tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
-            "TENDER_URL": f"{get_share_url_object(tender)}?siae_id={siae.id}",
+            "TENDER_URL": f"{get_object_share_url(tender)}?siae_id={siae.id}",
         }
 
         api_mailjet.send_transactional_email_with_template(
@@ -267,7 +267,7 @@ def send_tender_contacted_reminder_email_to_siae(
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
             "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
-            "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
+            "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
         }
 
         api_mailjet.send_transactional_email_with_template(
@@ -341,7 +341,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
             "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
-            "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
+            "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
         }
 
         api_mailjet.send_transactional_email_with_template(
@@ -386,7 +386,7 @@ def send_confirmation_published_email_to_author(tender: Tender, nb_matched_siaes
             "TENDER_AMOUNT": tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_NB_MATCH": nb_matched_siaes,
-            "TENDER_URL": get_share_url_object(tender),
+            "TENDER_URL": get_object_share_url(tender),
         }
 
         api_mailjet.send_transactional_email_with_template(
@@ -456,7 +456,7 @@ def send_siae_interested_email_to_author(tender: Tender):
                 variables = {
                     "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
                     "TENDER_TITLE": tender.title,
-                    "TENDER_SIAE_INTERESTED_LIST_URL": f"{get_share_url_object(tender)}/prestataires",  # noqa
+                    "TENDER_SIAE_INTERESTED_LIST_URL": f"{get_object_share_url(tender)}/prestataires",  # noqa
                 }
 
                 api_mailjet.send_transactional_email_with_template(

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -12,7 +12,7 @@ from lemarche.tenders.models import PartnerShareTender, Tender, TenderSiae
 from lemarche.utils.apis import api_hubspot, api_mailjet, api_slack
 from lemarche.utils.data import date_to_string
 from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
-from lemarche.utils.urls import get_admin_url_object, get_domain_url, get_share_url_object
+from lemarche.utils.urls import get_domain_url, get_object_admin_url, get_share_url_object
 
 
 logger = logging.getLogger(__name__)
@@ -481,7 +481,7 @@ def send_siae_interested_email_to_author(tender: Tender):
 
 def notify_admin_tender_created(tender: Tender):
     email_subject = f"Marché de l'inclusion : dépôt de besoin, ajout d'un nouveau {tender.get_kind_display()}"
-    tender_admin_url = get_admin_url_object(tender)
+    tender_admin_url = get_object_admin_url(tender)
     email_body = render_to_string(
         "tenders/create_notification_email_admin_body.txt",
         {
@@ -558,7 +558,7 @@ def send_tenders_author_feedback_or_survey(tender: Tender, kind="feedback_30d"):
 
 def notify_admin_siae_wants_cocontracting(tender: Tender, siae: Siae):
     email_subject = f"Marché de l'inclusion : la structure {siae.name} souhaite répondre en co-traitance"
-    tender_admin_url = get_admin_url_object(tender)
+    tender_admin_url = get_object_admin_url(tender)
     email_body = render_to_string(
         "tenders/cocontracting_notification_email_admin_body.txt",
         {


### PR DESCRIPTION
### Quoi ?

Modifications apportées : 
- renommé `get_share_url_object` en `get_object_share_url`
- renommé `get_admin_url_object` en `get_object_admin_url`
- Tender : ajouté la property `get_admin_url` + utilisé dans un template
- Siae : ajouté la property `get_admin_url` + utilisé dans un template