### PR TITLE
refactor(tender): Admin : ré-ajoute les stats du nombre de structures qui ont vues et qui ont cliquées

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -201,6 +201,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "siae_email_send_count_annotated_with_link",
         "siae_email_link_click_count_annotated_with_link",
         "siae_detail_display_count_annotated_with_link",
+        "siae_email_link_click_or_detail_display_count_annotated",
         "siae_email_link_click_or_detail_display_count_annotated_with_link",
         "siae_detail_contact_click_count_annotated_with_link",
         "siae_detail_cocontracting_click_count_annotated_with_link",
@@ -310,9 +311,10 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 "fields": (
                     "siae_count_annotated_with_link",
                     "siae_email_send_count_annotated_with_link",
-                    # "siae_email_link_click_count_annotated_with_link",
-                    # "siae_detail_display_count_annotated_with_link",
-                    "siae_email_link_click_or_detail_display_count_annotated_with_link",
+                    "siae_email_link_click_count_annotated_with_link",
+                    "siae_detail_display_count_annotated_with_link",
+                    "siae_email_link_click_or_detail_display_count_annotated",
+                    # "siae_email_link_click_or_detail_display_count_annotated_with_link",
                     "siae_detail_contact_click_count_annotated_with_link",
                     "siae_detail_cocontracting_click_count_annotated_with_link",
                     "siae_detail_not_interested_click_count_annotated_with_link",
@@ -543,7 +545,16 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     siae_detail_display_count_annotated_with_link.short_description = "S. vues"
     siae_detail_display_count_annotated_with_link.admin_order_field = "siae_detail_display_count_annotated"
 
+    def siae_email_link_click_or_detail_display_count_annotated(self, tender):
+        return getattr(tender, "siae_email_link_click_or_detail_display_count_annotated", 0)
+
+    siae_email_link_click_or_detail_display_count_annotated.short_description = "S. cliquées ou vues"
+    siae_email_link_click_or_detail_display_count_annotated.admin_order_field = (
+        "siae_email_link_click_or_detail_display_count_annotated"
+    )
+
     def siae_email_link_click_or_detail_display_count_annotated_with_link(self, tender):
+        # TO FIX (if possible ?): wrong url, should be link_click OR detail_display
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"


### PR DESCRIPTION
### Quoi ?

Suite à #1091, on avait fait le ménage et gardé seulement `S. cliquées ou vues`. Or on a une limitation sur le lien qui mène à la liste effective de ces structures.

Du coup j'ai revert : 
- ré-ajouté `S. cliquées`
- ré-ajouté `S. vues`
- affiche `S. cliquées ou vues` sans lien

### Capture d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/cd42732a-e03e-405c-a75f-56cc432bf01b)
