### PR TITLE
feat(Besoins): Ajout d'un filtre par type de besoin

### DIFF
--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -35,6 +35,14 @@
                         <i class="ri-add-fill ri-lg mr-2"></i>Publier un besoin d'achat
                     </a>
                 </div>
+            {% else %}
+                <div class="col-12 col-md-auto">
+                    <form method="GET" action="">
+                        <div class="form-group">
+                            {{ filter_form.kind }}
+                        </div>
+                    </form>
+                </div>
             {% endif %}
         </div>
         <div class="row">
@@ -110,7 +118,7 @@
                     {% include "includes/_pagination.html" %}
                     {% if not tenders %}
                         <p class="text-muted">
-                            Désolé, nous n'avons aucune opportunités à vous présenter pour le moment.
+                            Désolé, nous n'avons aucune opportunité à vous présenter pour le moment.
                             <br />
                             Si ce n'est pas déjà fait, pensez à <a href="{% url 'dashboard:home' %}">compléter votre fiche structure</a>
                             pour optimiser vos chances de trouver de nouvelles opportunités.

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -340,3 +340,24 @@ class TenderSiaeSurveyTransactionedForm(forms.ModelForm):
             self.fields["survey_transactioned_answer"].disabled = True
             if tender_survey_transactioned_answer is False:
                 self.fields["survey_transactioned_amount"].widget = forms.HiddenInput()
+
+
+class TenderFilterForm(forms.Form):
+    FORM_KIND_CHOICES = (
+        ("", "Toutes les opportunités"),
+        (tender_constants.KIND_QUOTE, tender_constants.KIND_QUOTE_DISPLAY),
+        (tender_constants.KIND_TENDER, tender_constants.KIND_TENDER_DISPLAY),
+        (tender_constants.KIND_PROJECT, "Projets d'achats"),
+    )
+
+    kind = forms.ChoiceField(
+        label="Type de besoin",
+        choices=FORM_KIND_CHOICES,
+        widget=forms.Select(
+            attrs={
+                "class": "form-control",
+                "onchange": "this.form.submit()",
+            }
+        ),
+        required=False,
+    )

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -491,7 +491,9 @@ class TenderListViewTest(TestCase):
             email_send_date=timezone.now(),
             detail_contact_click_date=timezone.now(),
         )
-        cls.tender_4 = TenderFactory(author=cls.user_buyer_1, perimeters=[perimeter])
+        cls.tender_4 = TenderFactory(
+            author=cls.user_buyer_1, perimeters=[perimeter], kind=tender_constants.KIND_TENDER
+        )
         cls.tendersiae_4_1 = TenderSiae.objects.create(
             tender=cls.tender_4, siae=cls.siae_1, email_send_date=timezone.now()
         )
@@ -576,6 +578,19 @@ class TenderListViewTest(TestCase):
         self.assertNotContains(
             response, '<span class="float-right badge badge-sm badge-pill badge-new">Nouveau</span>'
         )
+
+    def test_siae_user_should_only_see_filtered_kind(self):
+        self.client.force_login(self.siae_user_2)
+        url = reverse("tenders:list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["tenders"]), 2)
+
+        url = reverse("tenders:list")
+        response = self.client.get(f"{url}?kind={tender_constants.KIND_TENDER}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["tenders"]), 1)
+        self.assertEqual(response.context["tenders"][0], self.tender_4)
 
 
 class TenderDetailViewTest(TestCase):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -32,6 +32,7 @@ from lemarche.www.tenders.forms import (
     TenderCreateStepDetailForm,
     TenderCreateStepGeneralForm,
     TenderCreateStepSurveyForm,
+    TenderFilterForm,
     TenderSiaeSurveyTransactionedForm,
     TenderSurveyTransactionedForm,
 )
@@ -296,6 +297,13 @@ class TenderListView(LoginRequiredMixin, ListView):
             qs = Tender.objects.by_user(user).with_siae_stats()
             if self.status:
                 qs = qs.filter(status=self.status)
+
+        filter_form = TenderFilterForm(self.request.GET or None)
+        if filter_form.is_valid():
+            kind = filter_form.cleaned_data.get("kind")
+            if kind:
+                qs = qs.filter(kind=kind)
+
         qs = qs.prefetch_many_to_many().select_foreign_keys()
         qs = qs.order_by_deadline_date()
         return qs
@@ -317,6 +325,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         context["page_title"] = TITLE_DETAIL_PAGE_SIAE if user_kind == User.KIND_SIAE else TITLE_DETAIL_PAGE_OTHERS
         context["title_kind_sourcing_siae"] = TITLE_KIND_SOURCING_SIAE
         context["tender_constants"] = tender_constants
+        context["filter_form"] = TenderFilterForm(self.request.GET or None)
         return context
 
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -298,9 +298,9 @@ class TenderListView(LoginRequiredMixin, ListView):
             if self.status:
                 qs = qs.filter(status=self.status)
 
-        filter_form = TenderFilterForm(self.request.GET or None)
-        if filter_form.is_valid():
-            kind = filter_form.cleaned_data.get("kind")
+        self.filter_form = TenderFilterForm(data=self.request.GET)
+        if self.filter_form.is_valid():
+            kind = self.filter_form.cleaned_data.get("kind")
             if kind:
                 qs = qs.filter(kind=kind)
 
@@ -325,7 +325,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         context["page_title"] = TITLE_DETAIL_PAGE_SIAE if user_kind == User.KIND_SIAE else TITLE_DETAIL_PAGE_OTHERS
         context["title_kind_sourcing_siae"] = TITLE_KIND_SOURCING_SIAE
         context["tender_constants"] = tender_constants
-        context["filter_form"] = TenderFilterForm(self.request.GET or None)
+        context["filter_form"] = self.filter_form
         return context
 
 


### PR DESCRIPTION
### Quoi ?

Ajout d'un filtre par type de besoin sur la liste des opportunités

### Pourquoi ?

Pour permettre aux ESI de prioriser comme elles le souhaitent.

### Comment ?

Une liste déroulante qui submit au changement.

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/9c9360e7-6c97-432e-a242-d6259cd3ff2b)

### Note

La carte prévoyait de mettre des compteurs dans la liste déroulante pour indiquer le nombre de nouveaux, je pense que ça peut faire l'objet d'autre PR. 
