### PR TITLE
feat(SIAE): nouvelle property is_live

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -950,6 +950,10 @@ class Siae(models.Model):
                 raise e
 
     @property
+    def is_live(self) -> bool:
+        return self.is_active and not self.is_delisted
+
+    @property
     def kind_is_esat_or_ea_or_eatt(self) -> bool:
         return self.kind in [siae_constants.KIND_ESAT, siae_constants.KIND_EA, siae_constants.KIND_EATT]
 

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -83,6 +83,15 @@ class SiaeModelTest(TestCase):
         siae = SiaeFactory(name="Ma boite")
         self.assertEqual(str(siae), "Ma boite")
 
+    def test_is_live(self):
+        siae_live = SiaeFactory(is_active=True, is_delisted=False)
+        siae_not_live_1 = SiaeFactory(is_active=True, is_delisted=True)
+        siae_not_live_2 = SiaeFactory(is_active=False, is_delisted=False)
+        siae_not_live_3 = SiaeFactory(is_active=False, is_delisted=True)
+        self.assertTrue(siae_live.is_live)
+        for s in [siae_not_live_1, siae_not_live_2, siae_not_live_3]:
+            self.assertFalse(s.is_live)
+
     def test_name_display_property(self):
         siae_without_brand = SiaeFactory(name="Ma raison sociale")
         siae_with_brand = SiaeFactory(name="Ma raison sociale", brand="Mon enseigne")
@@ -408,10 +417,10 @@ class SiaeModelQuerysetTest(TestCase):
         pass
 
     def test_is_live_queryset(self):
-        SiaeFactory(is_active=True, is_delisted=True)
-        SiaeFactory(is_active=False, is_delisted=True)
         SiaeFactory(is_active=True, is_delisted=False)  # live
+        SiaeFactory(is_active=True, is_delisted=True)
         SiaeFactory(is_active=False, is_delisted=False)
+        SiaeFactory(is_active=False, is_delisted=True)
         self.assertEqual(Siae.objects.count(), 4)
         self.assertEqual(Siae.objects.is_live().count(), 1)
         self.assertEqual(Siae.objects.is_not_live().count(), 3)


### PR DESCRIPTION
### Quoi ?

On a déjà le queryset `is_live()` (active + pas délistée)

Mais il serait utile d'avoir cette info au niveau objet, par exemple pour #1106

J'ai ajouté un test