### PR TITLE
fix(Admin): Besoins : répare le filtre par montant exact

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -67,12 +67,13 @@ class AmountCustomFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         value = self.value()
-        amount_10k = 10 * 10**3  # 10k
+        amount_5k = 5 * 10**3
+        amount_10k = 10 * 10**3
         if value == "<10k":
             return queryset.filter_by_amount_exact(amount_10k, operation="lt")
         elif value == "5k-10k":
             return queryset.filter_by_amount_exact(amount_10k, operation="lte").filter_by_amount_exact(
-                amount_10k, operation="gte"
+                amount_5k, operation="gte"
             )
         elif value == ">=10k":
             return queryset.filter_by_amount_exact(amount_10k, operation="gte")

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -18,6 +18,7 @@ from lemarche.perimeters.models import Perimeter
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.models import Siae
 from lemarche.tenders import constants as tender_constants
+from lemarche.tenders.utils import find_amount_ranges
 from lemarche.users.models import User
 from lemarche.utils.apis import api_elasticsearch
 from lemarche.utils.constants import ADMIN_FIELD_HELP_TEXT, MARCHE_BENEFIT_CHOICES, RECALCULATED_FIELD_HELP_TEXT
@@ -31,35 +32,6 @@ def get_perimeter_filter(siae):
         | Q(perimeters__insee_code=siae.department)
         | Q(perimeters__name=siae.region)
     )
-
-
-def find_amount_ranges(amount, operation):
-    """
-    Returns the keys from AMOUNT_RANGE that match a given operation on a specified amount.
-
-    :param amount: The amount to compare against.
-    :param operation: The operation to perform ('lt', 'lte', 'gt', 'gte').
-    :return: A list of matching keys.
-    """
-    amount = int(amount)
-    if operation == "lt":
-        if amount < tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_0_1):
-            return [tender_constants.AMOUNT_RANGE_0_1]
-        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value < amount]
-    elif operation == "lte":
-        if amount <= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_0_1):
-            return [tender_constants.AMOUNT_RANGE_0_1]
-        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value <= amount]
-    elif operation == "gt":
-        if amount >= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_1000_MORE):
-            return [tender_constants.AMOUNT_RANGE_1000_MORE]
-        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value > amount]
-    elif operation == "gte":
-        if amount >= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_1000_MORE):
-            return [tender_constants.AMOUNT_RANGE_1000_MORE]
-        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value >= amount]
-    else:
-        raise ValueError("Unrecognized operation. Use 'lt', 'lte', 'gt', or 'gte'.")
 
 
 class TenderQuerySet(models.QuerySet):

--- a/lemarche/tenders/utils.py
+++ b/lemarche/tenders/utils.py
@@ -1,0 +1,30 @@
+from lemarche.tenders import constants as tender_constants
+
+
+def find_amount_ranges(amount, operation):
+    """
+    Returns the keys from AMOUNT_RANGE that match a given operation on a specified amount.
+
+    :param amount: The amount to compare against.
+    :param operation: The operation to perform ('lt', 'lte', 'gt', 'gte').
+    :return: A list of matching keys.
+    """
+    amount = int(amount)
+    if operation == "lt":
+        if amount < tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_0_1):
+            return [tender_constants.AMOUNT_RANGE_0_1]
+        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value < amount]
+    elif operation == "lte":
+        if amount <= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_0_1):
+            return [tender_constants.AMOUNT_RANGE_0_1]
+        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value <= amount]
+    elif operation == "gt":
+        if amount >= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_1000_MORE):
+            return [tender_constants.AMOUNT_RANGE_1000_MORE]
+        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value > amount]
+    elif operation == "gte":
+        if amount >= tender_constants.AMOUNT_RANGE_CHOICE_EXACT.get(tender_constants.AMOUNT_RANGE_1000_MORE):
+            return [tender_constants.AMOUNT_RANGE_1000_MORE]
+        return [key for key, value in tender_constants.AMOUNT_RANGE_CHOICE_EXACT.items() if value >= amount]
+    else:
+        raise ValueError("Unrecognized operation. Use 'lt', 'lte', 'gt', or 'gte'.")


### PR DESCRIPTION
### Quoi ?

Suite à #1090 il y avait une coquille dans le filtre
- réparé dans l'admin
- bougé la méthode dans un nouveau `tenders/utils.py`
- ajouté des tests