### PR TITLE
feat(Besoins): Permettre à une structure contactée de décliner dès l'e-mail

### DIFF
--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -66,14 +66,16 @@
 {% endblock %}
 
 {% block modals %}
-{% if not siae_has_detail_contact_click_date %}
-    {% include "auth/_login_or_signup_siae_tender_modal.html" %}
-{% endif %}
-{% if not siae_has_detail_cocontracting_click_date %}
-    {% include "tenders/_detail_contact_click_confirm_modal.html" %}
-{% endif %}
-{% if not siae_has_detail_not_interested_click_date %}
-    {% include "tenders/_detail_not_interested_click_confirm_modal.html" %}
+{% if user.is_authenticated or siae_id %}
+    {% if not siae_has_detail_contact_click_date %}
+        {% include "auth/_login_or_signup_siae_tender_modal.html" %}
+    {% endif %}
+    {% if not siae_has_detail_cocontracting_click_date %}
+        {% include "tenders/_detail_contact_click_confirm_modal.html" %}
+    {% endif %}
+    {% if not siae_has_detail_not_interested_click_date %}
+        {% include "tenders/_detail_not_interested_click_confirm_modal.html" %}
+    {% endif %}
 {% endif %}
 {% endblock %}
 

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -66,9 +66,15 @@
 {% endblock %}
 
 {% block modals %}
-{% include "auth/_login_or_signup_siae_tender_modal.html" %}
-{% include "tenders/_detail_contact_click_confirm_modal.html" %}
-{% include "tenders/_detail_not_interested_click_confirm_modal.html" %}
+{% if not siae_has_detail_contact_click_date %}
+    {% include "auth/_login_or_signup_siae_tender_modal.html" %}
+{% endif %}
+{% if not siae_has_detail_cocontracting_click_date %}
+    {% include "tenders/_detail_contact_click_confirm_modal.html" %}
+{% endif %}
+{% if not siae_has_detail_not_interested_click_date %}
+    {% include "tenders/_detail_not_interested_click_confirm_modal.html" %}
+{% endif %}
 {% endblock %}
 
 {% block extra_js %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -78,6 +78,19 @@
 {% endblock %}
 
 {% block extra_js %}
+{% if not siae_has_detail_not_interested_click_date %}
+    <script type="text/javascript">
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('not_interested') && urlParams.get('not_interested') === 'True') {
+            // why click() instead of OpenBootstrapModal('#detail_not_interested_click_confirm_modal') ?
+            // why setTimeout ?
+            // --> to have the siae_id set in the modal
+            setTimeout(function() {
+                document.querySelector('#show-tender-not-interested-modal-btn').click();
+            }, 100);
+        }
+    </script>
+{% endif %}
 {% if TALLY_NPS_FORM_ID and show_nps %}
     <script async type="text/javascript" src="https://tally.so/widgets/embed.js"></script>
     <script type="text/javascript">

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -190,6 +190,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             "TENDER_AMOUNT": tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": f"{get_object_share_url(tender)}?siae_id={siae.id}",
+            "TENDER_NOT_INTERESTED_URL": f"{get_object_share_url(tender)}?siae_id={siae.id}&not_interested=True",
         }
 
         api_mailjet.send_transactional_email_with_template(

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -511,7 +511,7 @@ class TenderDetailNotInterestedClickView(SiaeUserRequiredOrSiaeIdParamMixin, Det
     Endpoint to handle 'not interested' button click
     """
 
-    template_name = "tenders/_detail_not_interested_click_confirm.html"
+    template_name = "tenders/_detail_not_interested_click_confirm_modal.html"
     model = Tender
 
     def get_object(self):


### PR DESCRIPTION
### Quoi ?

Actuellement, une structure contactée a l'information qu'elle peut décliner (pas intéressée) sur la page détail du besoin.

### Pourquoi ?

Avoir d'avantage de structures qui partagent leur non intérêt (et feedback) au lieu de devoir les relancer.

### Comment ?

En cliquant sur NON, le popup s'affichera directement à l'utilisateur

- on rajoute un bouton dans cet e-mail
- le lien amène toujours vers la page détail du besoin, mais affiche directement le popup (grâce à un bout de JS + `not_interested=True` dans l'url)
- le workflow est ensuite identique au fonctionnement actuel

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/f21be4ac-c456-430b-837a-74a2643f398b)
