### PR TITLE
feat(Admin): Secteurs : afficher le nombre de besoins concernés

### DIFF
--- a/lemarche/sectors/admin.py
+++ b/lemarche/sectors/admin.py
@@ -24,13 +24,20 @@ class SectorGroupAdmin(admin.ModelAdmin):
         url = reverse("admin:sectors_sector_changelist") + f"?group__id__exact={sector_group.id}"
         return format_html(f'<a href="{url}">{sector_group.sector_count_annotated}</a>')
 
-    sector_count_annotated_with_link.short_description = "Nombre de secteurs d'activité"
+    sector_count_annotated_with_link.short_description = "Secteurs d'activité"
     sector_count_annotated_with_link.admin_order_field = "sector_count_annotated"
 
 
 @admin.register(Sector, site=admin_site)
 class SectorAdmin(admin.ModelAdmin):
-    list_display = ["id", "name", "siae_count_annotated_with_link", "group", "created_at"]
+    list_display = [
+        "id",
+        "name",
+        "siae_count_annotated_with_link",
+        "tender_count_annotated_with_link",
+        "group",
+        "created_at",
+    ]
     list_filter = ["group"]
     search_fields = ["id", "name"]
     search_help_text = "Cherche sur les champs : ID, Nom"
@@ -41,11 +48,19 @@ class SectorAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.with_siae_stats()
+        qs = qs.with_tender_stats()
         return qs
 
     def siae_count_annotated_with_link(self, sector):
         url = reverse("admin:siaes_siae_changelist") + f"?sectors__id__exact={sector.id}"
         return format_html(f'<a href="{url}">{sector.siae_count_annotated}</a>')
 
-    siae_count_annotated_with_link.short_description = "Nombre de structures rattachées"
+    siae_count_annotated_with_link.short_description = "Structures rattachées"
     siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"
+
+    def tender_count_annotated_with_link(self, sector):
+        url = reverse("admin:tenders_tender_changelist") + f"?sectors__id__exact={sector.id}"
+        return format_html(f'<a href="{url}">{sector.tender_count_annotated}</a>')
+
+    tender_count_annotated_with_link.short_description = "Besoins concernés"
+    tender_count_annotated_with_link.admin_order_field = "tender_count_annotated"

--- a/lemarche/sectors/factories.py
+++ b/lemarche/sectors/factories.py
@@ -24,3 +24,8 @@ class SectorFactory(DjangoModelFactory):
     def siaes(self, create, extracted, **kwargs):
         if extracted:
             self.siaes.add(*extracted)
+
+    @factory.post_generation
+    def tenders(self, create, extracted, **kwargs):
+        if extracted:
+            self.tenders.add(*extracted)

--- a/lemarche/sectors/models.py
+++ b/lemarche/sectors/models.py
@@ -55,6 +55,9 @@ class SectorQuerySet(models.QuerySet):
     def with_siae_stats(self):
         return self.annotate(siae_count_annotated=Count("siaes", distinct=True))
 
+    def with_tender_stats(self):
+        return self.annotate(tender_count_annotated=Count("tenders", distinct=True))
+
 
 class Sector(models.Model):
     name = models.CharField(verbose_name="Nom", max_length=255)

--- a/lemarche/sectors/tests.py
+++ b/lemarche/sectors/tests.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from lemarche.sectors.factories import SectorFactory, SectorGroupFactory
 from lemarche.sectors.models import Sector, SectorGroup
 from lemarche.siaes.factories import SiaeFactory
+from lemarche.tenders.factories import TenderFactory
 
 
 class SectorGroupModelTest(TestCase):
@@ -51,6 +52,8 @@ class SectorQuerysetModelTest(TestCase):
     def setUpTestData(cls):
         cls.siae_1 = SiaeFactory()
         cls.siae_2 = SiaeFactory()
+        cls.tender_1 = TenderFactory()
+        cls.tender_2 = TenderFactory()
         cls.sector_group_1 = SectorGroupFactory(name="Informatique")
         cls.sector_group_2 = SectorGroupFactory(name="Bricolage")
         cls.sector_1_1 = SectorFactory(name="Développement de logiciel", group=cls.sector_group_1)
@@ -58,7 +61,9 @@ class SectorQuerysetModelTest(TestCase):
         cls.sector_1_3 = SectorFactory(name="Autre", group=cls.sector_group_1)
         cls.sector_2_1 = SectorFactory(name="Plomberie", group=cls.sector_group_2)
         cls.sector_2_2 = SectorFactory(name="Autre (Bricolage)", group=cls.sector_group_2)
-        cls.sector_3 = SectorFactory(name="Un secteur seul", group=None, siaes=[cls.siae_1, cls.siae_2])
+        cls.sector_3 = SectorFactory(
+            name="Un secteur seul", group=None, siaes=[cls.siae_1, cls.siae_2], tenders=[cls.tender_1, cls.tender_2]
+        )
 
     def test_form_filter_queryset(self):
         sectors = Sector.objects.form_filter_queryset()
@@ -75,3 +80,8 @@ class SectorQuerysetModelTest(TestCase):
         sector_queryset = Sector.objects.with_siae_stats()
         self.assertEqual(sector_queryset.get(id=self.sector_1_1.id).siae_count_annotated, 0)
         self.assertEqual(sector_queryset.get(id=self.sector_3.id).siae_count_annotated, 2)
+
+    def test_with_tender_stats(self):
+        sector_queryset = Sector.objects.with_tender_stats()
+        self.assertEqual(sector_queryset.get(id=self.sector_1_1.id).tender_count_annotated, 0)
+        self.assertEqual(sector_queryset.get(id=self.sector_3.id).tender_count_annotated, 2)


### PR DESCRIPTION
### Quoi ?

Mini ajout dans la page admin des secteurs : 
- on avait déjà le nombre de structures rattachés
- j'ai ajouté le nombre de besoins concernés

### Pourquoi ?

Demande admin d'avoir les top secteurs