### PR TITLE
feat(Besoins): Admin : Connaitre le nombre de besoins déposés par chaque entreprise

### DIFF
--- a/lemarche/companies/admin.py
+++ b/lemarche/companies/admin.py
@@ -41,12 +41,22 @@ class HasEmailDomainFilter(admin.SimpleListFilter):
 
 @admin.register(Company, site=admin_site)
 class CompanyAdmin(admin.ModelAdmin, DynamicArrayMixin):
-    list_display = ["id", "name", "user_count_annotated_with_link", "created_at"]
+    list_display = [
+        "id",
+        "name",
+        "user_count_annotated_with_link",
+        "user_tender_count_annotated_with_link",
+        "created_at",
+    ]
     list_filter = [HasUserFilter, HasEmailDomainFilter]
     search_fields = ["id", "name"]
     search_help_text = "Cherche sur les champs : ID, Nom"
 
-    readonly_fields = ["logo_url_display", "user_count_annotated_with_link", "created_at", "updated_at"]
+    readonly_fields = [
+        "logo_url_display",
+        "user_count_annotated_with_link",
+        "user_tender_count_annotated_with_link",
+    ] + Company.READONLY_FIELDS
 
     fieldsets = (
         (
@@ -57,6 +67,7 @@ class CompanyAdmin(admin.ModelAdmin, DynamicArrayMixin):
         ),
         ("Logo", {"fields": ("logo_url", "logo_url_display")}),
         ("Utilisateurs", {"fields": ("user_count_annotated_with_link",)}),
+        ("Besoins", {"fields": ("user_tender_count_annotated_with_link",)}),
         ("Dates", {"fields": ("created_at", "updated_at")}),
     )
 
@@ -93,5 +104,12 @@ class CompanyAdmin(admin.ModelAdmin, DynamicArrayMixin):
         url = reverse("admin:users_user_changelist") + f"?company__id__exact={company.id}"
         return format_html(f'<a href="{url}">{company.user_count_annotated}</a>')
 
-    user_count_annotated_with_link.short_description = "Nombre d'utilisateurs rattachés"
+    user_count_annotated_with_link.short_description = "Utilisateurs rattachés"
     user_count_annotated_with_link.admin_order_field = "user_count_annotated"
+
+    def user_tender_count_annotated_with_link(self, company):
+        url = reverse("admin:tenders_tender_changelist") + f"?author__company_id__exact={company.id}"
+        return format_html(f'<a href="{url}">{company.user_tender_count_annotated}</a>')
+
+    user_tender_count_annotated_with_link.short_description = "Besoins déposés par les utilisateurs"
+    user_tender_count_annotated_with_link.admin_order_field = "user_tender_count_annotated"

--- a/lemarche/companies/models.py
+++ b/lemarche/companies/models.py
@@ -13,10 +13,16 @@ class CompanyQuerySet(models.QuerySet):
         return self.exclude(email_domain_list=[])
 
     def with_user_stats(self):
-        return self.annotate(user_count_annotated=Count("users", distinct=True))
+        return self.annotate(user_count_annotated=Count("users", distinct=True)).annotate(
+            user_tender_count_annotated=Count("users__tenders", distinct=True)
+        )
 
 
 class Company(models.Model):
+    FIELDS_STATS_COUNT = ["user_count"]
+    FIELDS_STATS_TIMESTAMPS = ["created_at", "updated_at"]
+    READONLY_FIELDS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS
+
     name = models.CharField(verbose_name="Nom", max_length=255)
     slug = models.SlugField(verbose_name="Slug", max_length=255, unique=True)
     description = models.TextField(verbose_name="Description", blank=True)

--- a/lemarche/companies/tests.py
+++ b/lemarche/companies/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from lemarche.companies.factories import CompanyFactory
 from lemarche.companies.models import Company
+from lemarche.tenders.factories import TenderFactory
 from lemarche.users.factories import UserFactory
 
 
@@ -22,10 +23,16 @@ class CompanyQuerysetTest(TestCase):
     def setUpTestData(cls):
         cls.user_1 = UserFactory()
         cls.user_2 = UserFactory()
+        TenderFactory(author=cls.user_1)
+        TenderFactory(author=cls.user_1)
         cls.company_with_users = CompanyFactory(users=[cls.user_1, cls.user_2])
         cls.company = CompanyFactory()
 
     def test_with_user_stats(self):
         company_queryset = Company.objects.with_user_stats()
+        # user_count
         self.assertEqual(company_queryset.get(id=self.company.id).user_count_annotated, 0)
         self.assertEqual(company_queryset.get(id=self.company_with_users.id).user_count_annotated, 2)
+        # user_tender_count
+        self.assertEqual(company_queryset.get(id=self.company.id).user_tender_count_annotated, 0)
+        self.assertEqual(company_queryset.get(id=self.company_with_users.id).user_tender_count_annotated, 2)


### PR DESCRIPTION
### Quoi ?

Dans le modèle `Company`, j'ai enrichi le queryset `with_user_stats`, pour avoir une nouvelle info `user_tender_count_annotated`

Et j'affiche ca dans l'admin :)

### Screenshot

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/9c01685c-7cd6-4eb7-8475-b44774bc44e9)

### Todo (futur)

avoir aussi un champ `user_tender_count` pour avoir ce chiffre dans Metabase ?