### PR TITLE
feat(Besoins): mettre à jour automatiquement la date de transaction

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -873,7 +873,7 @@ class Siae(models.Model):
         """
         https://stackoverflow.com/a/23363123
         """
-        super(Siae, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         for field_name in self.TRACK_UPDATE_FIELDS:
             setattr(self, f"__previous_{field_name}", getattr(self, field_name))
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1770,12 +1770,16 @@ class TenderDetailSurveyTransactionedViewTest(TestCase):
         # full form displayed (but should never happen)
 
     def test_update_tender_stats_on_tender_survey_transactioned_answer_true(self):
+        self.assertIsNone(Tender.objects.get(id=self.tender.id).survey_transactioned_answer)
+        self.assertIsNone(Tender.objects.get(id=self.tender.id).siae_transactioned)
+        self.assertIsNone(Tender.objects.get(id=self.tender.id).siae_transactioned_last_updated)
         # load with answer 'True': partial form
         url = self.url + self.user_buyer_1_sesame_query_string + "&answer=True"
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(Tender.objects.get(id=self.tender.id).survey_transactioned_answer)
         self.assertTrue(Tender.objects.get(id=self.tender.id).siae_transactioned)
+        self.assertIsNotNone(Tender.objects.get(id=self.tender.id).siae_transactioned_last_updated)
         # fill in form
         response = self.client.post(
             url, data={"survey_transactioned_amount": 1000, "survey_transactioned_feedback": "Feedback"}, follow=True

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -616,13 +616,11 @@ class TenderDetailSurveyTransactionedView(SesameTenderAuthorRequiredMixin, Updat
             if survey_transactioned_answer in ["True", "False"]:
                 # transform survey_transactioned_answer into bool
                 survey_transactioned_answer = survey_transactioned_answer == "True"
-                # update survey_transactioned_answer
-                Tender.objects.filter(id=self.object.id).update(
-                    survey_transactioned_answer=survey_transactioned_answer,
-                    survey_transactioned_answer_date=timezone.now(),
-                    siae_transactioned=survey_transactioned_answer,
-                    updated_at=timezone.now(),
-                )
+                # update tender
+                self.object.survey_transactioned_answer = survey_transactioned_answer
+                self.object.survey_transactioned_answer_date = timezone.now()
+                self.object.siae_transactioned = survey_transactioned_answer
+                self.object.save()
             else:
                 pass
                 # TODO or not? "answer" should always be passed
@@ -683,12 +681,10 @@ class TenderDetailSiaeSurveyTransactionedView(SesameSiaeMemberRequiredMixin, Upd
             if survey_transactioned_answer in ["True", "False"]:
                 # transform survey_transactioned_answer into bool
                 survey_transactioned_answer = survey_transactioned_answer == "True"
-                # update survey_transactioned_answer
-                TenderSiae.objects.filter(id=self.object.id).update(
-                    survey_transactioned_answer=survey_transactioned_answer,
-                    survey_transactioned_answer_date=timezone.now(),
-                    updated_at=timezone.now(),
-                )
+                # update tender
+                self.object.survey_transactioned_answer = survey_transactioned_answer
+                self.object.survey_transactioned_answer_date = timezone.now()
+                self.object.save()
             else:
                 pass
                 # TODO or not? "answer" should always be passed


### PR DESCRIPTION
### Quoi ?

Suite de #1116

Dès que le champ `siae_transactioned` change, on met à jour `siae_transactioned_last_updated`

### Comment ?

Grâce à un mécanisme similaire au modèle `Siae`, avec `TRACK_UPDATE_FIELDS` 
- note : cela marche que avec des `save()`, pas des bulk `update()`