### PR TITLE
fix(Besoins): Correction sur le nombre d'occurrences en status Nouveau sur le filtre par type

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -244,11 +244,9 @@ class TenderQuerySet(models.QuerySet):
         )
 
     def unread(self, user):
-        limit_date = datetime.today()
         return (
-            self.filter(
-                tendersiae__siae__in=user.siaes.all(), validated_at__isnull=False, deadline_date__gt=limit_date
-            )
+            self.is_live()
+            .filter(tendersiae__siae__in=user.siaes.all())
             .filter(tendersiae__detail_display_date__isnull=True)
             .distinct()
         )

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.conf import settings
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
@@ -364,13 +362,9 @@ class User(AbstractUser):
 
     @property
     def tender_siae_unread_count(self):
-        from lemarche.tenders.models import TenderSiae
+        from lemarche.tenders.models import Tender
 
-        limit_date = datetime.today()
-        qs = TenderSiae.objects.filter(
-            siae__in=self.siaes.all(), tender__validated_at__isnull=False, tender__deadline_date__gt=limit_date
-        ).filter(detail_display_date__isnull=True)
-        return qs.count()
+        return Tender.objects.unread(self).count()
 
 
 @receiver(post_save, sender=User)

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -365,7 +365,7 @@ class TenderFilterForm(forms.Form):
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        stats = TenderSiae.objects.unread_stats(user=user)
+        stats = Tender.objects.unread_stats(user=user)
         new_choices = []
         for kind_key, kind_label in self.FORM_KIND_CHOICES:
             count_key = f"unread_count_{kind_key}_annotated"


### PR DESCRIPTION
### Quoi ?

Correction du nombre d'occurrence dans la liste déroulante et dans le compteur d'entête. 

### Pourquoi ?

Le distinct utilisé pour dédoublonner, dans le cas où l'utilisateur a plusieurs structures, produit uniquement des 1.

### Comment ?

En déplaçant le queryset sur Tender.

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/849f3137-a7b3-48d7-bdb1-9efc4baa5ea0)
