### PR TITLE
fix(API): mise à jour du lien vers api.gouv

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -520,7 +520,7 @@ API_ENTREPRISE_TOKEN = env.str("API_ENTREPRISE_TOKEN", "")
 #   if SIAE.is_QPV was update after `today-API_QPV_RELATIVE_DAYS_TO_UPDATE`, we call the API to QPV
 API_QPV_RELATIVE_DAYS_TO_UPDATE = env.int("API_QPV_RELATIVE_DAYS_TO_UPDATE", 60)
 
-API_GOUV_URL = "https://api.gouv.fr/les-api/api-structures-inclusion"
+API_GOUV_URL = "https://api.gouv.fr/les-api/api-marche-inclusion"
 
 # API Mailjet
 # We also use the master api key (with the second api key), because we separate the sending message from application

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -23,7 +23,7 @@
 {% block content %}
 <section class="pt-4 pb-6 pb-lg-8">
     <div class="container">
-        <h1 class="h1-hero"><strong>API du marché de l'inclusion</strong></h1>
+        <h1 class="h1-hero"><strong>API du Marché de l'inclusion</strong></h1>
         <h2 class="h2">L'API met à disposition le répertoire qualifié des structures d'insertion par l'activité économique.</h2>
 
         <div class="row mt-5">


### PR DESCRIPTION
### Quoi ?

On a fait des modifications sur la présentation de notre API, le lien a changé coté api.gouv

Ancien lien : https://api.gouv.fr/les-api/api-structures-inclusion
Nouveau lien : https://api.gouv.fr/les-api/api-marche-inclusion

cf https://github.com/betagouv/api.gouv.fr/pull/1309