### PR TITLE
fix(API): Exclure les structures OPCS des résultats

### DIFF
--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -16,7 +16,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     Données d'une structure d'insertion par l'activité économique (SIAE).
     """
 
-    queryset = Siae.objects.prefetch_many_to_many()
+    queryset = Siae.objects.api_query_set()
     serializer_class = SiaeListSerializer
     filter_class = SiaeFilter
 
@@ -37,7 +37,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
             token = request.GET.get("token", None)
             if not token:
                 serializer = SiaeListSerializer(
-                    Siae.objects.all()[:10],
+                    self.get_queryset()[:10],
                     many=True,
                 )
                 return Response(serializer.data)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -181,6 +181,9 @@ class SiaeQuerySet(models.QuerySet):
     def prefetch_many_to_one(self):
         return self.prefetch_related("offers", "client_references", "labels_old", "images")
 
+    def api_query_set(self):
+        return self.exclude(kind="OPCS").prefetch_many_to_many()
+
     def search_query_set(self):
         return self.is_live().exclude(kind="OPCS").prefetch_many_to_many()
 


### PR DESCRIPTION
### Quoi ?

On les avait caché de la recherche (ici #334), mais pas de l'API