### PR TITLE
feat(Besoins): Admin : filtre de la liste par bizdev

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -413,7 +413,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        # qs = qs.with_tender_stats()
+        qs = qs.with_tender_stats()
         return qs
 
     def get_readonly_fields(self, request, obj=None):

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -413,7 +413,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.with_tender_stats()
+        # qs = qs.with_tender_stats()
         return qs
 
     def get_readonly_fields(self, request, obj=None):

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -108,6 +108,21 @@ class AuthorKindFilter(admin.SimpleListFilter):
         return queryset
 
 
+class UserAdminFilter(admin.SimpleListFilter):
+    title = "Suivi bizdev"
+    parameter_name = "admins"
+
+    def lookups(self, request, model_admin):
+        admins = User.objects.is_admin_bizdev().values("id", "first_name")
+        return [(admin["id"], admin["first_name"]) for admin in admins]
+
+    def queryset(self, request, queryset):
+        lookup_value = self.value()
+        if lookup_value:
+            queryset = queryset.filter(admins__id__exact=lookup_value)
+        return queryset
+
+
 class TenderNoteInline(GenericTabularInline):
     model = Note
     fields = ["text", "author", "created_at", "updated_at"]
@@ -177,6 +192,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "start_working_date",
         ResponseKindFilter,
         "siae_transactioned",
+        UserAdminFilter,
     ]
     advanced_filter_fields = (
         "kind",

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -114,12 +114,17 @@ class UserAdminFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         admins = User.objects.is_admin_bizdev().values("id", "first_name")
-        return [(admin["id"], admin["first_name"]) for admin in admins]
+        admins_choices = [(admin["id"], admin["first_name"]) for admin in admins]
+        admins_choices += [("None", "Sans bizdev")]
+        return admins_choices
 
     def queryset(self, request, queryset):
         lookup_value = self.value()
         if lookup_value:
-            queryset = queryset.filter(admins__id__exact=lookup_value)
+            if lookup_value == "None":
+                queryset = queryset.filter(admins__isnull=True)
+            else:
+                queryset = queryset.filter(admins__id__exact=lookup_value)
         return queryset
 
 

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -21,7 +21,7 @@ class UserQueryset(models.QuerySet):
     """
 
     def is_admin_bizdev(self):
-        return self.filter(kind=user_constants.KIND_ADMIN, position="Bizdev", is_staff=True)
+        return self.filter(kind=user_constants.KIND_ADMIN, position__iexact="Bizdev", is_staff=True)
 
     def has_company(self):
         return self.filter(company__isnull=False).distinct()

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -20,6 +20,9 @@ class UserQueryset(models.QuerySet):
     Custom queryset with additional filtering methods for users.
     """
 
+    def is_admin_bizdev(self):
+        return self.filter(kind=user_constants.KIND_ADMIN, position="Bizdev", is_staff=True)
+
     def has_company(self):
         return self.filter(company__isnull=False).distinct()
 
@@ -87,6 +90,9 @@ class UserManager(BaseUserManager):
             raise ValueError("Un superuser doit avoir is_superuser=True.")
 
         return self.create_user(email, password, **extra_fields)
+
+    def is_admin_bizdev(self):
+        return self.get_queryset().is_admin_bizdev()
 
     def has_company(self):
         return self.get_queryset().has_company()

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from lemarche.companies.factories import CompanyFactory
 from lemarche.favorites.factories import FavoriteListFactory
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.tenders.factories import TenderFactory
@@ -49,10 +50,22 @@ class UserModelQuerysetTest(TestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
 
+    def test_is_admin_bizdev(self):
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True)
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="BizDev")
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="Bizdev")
+        self.assertEqual(User.objects.count(), 1 + 3)
+        self.assertEqual(User.objects.is_admin_bizdev().count(), 2)
+
+    def test_has_company(self):
+        user_2 = UserFactory()
+        CompanyFactory(users=[user_2])
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_company().count(), 1)
+
     def test_has_siae(self):
         user_2 = UserFactory()
-        siae = SiaeFactory()
-        siae.users.add(user_2)
+        SiaeFactory(users=[user_2])
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_siae().count(), 1)
 
@@ -75,8 +88,7 @@ class UserModelQuerysetTest(TestCase):
 
     def test_with_siae_stats(self):
         user_2 = UserFactory()
-        siae = SiaeFactory()
-        siae.users.add(user_2)
+        SiaeFactory(users=[user_2])
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.with_siae_stats().filter(id=self.user.id).first().siae_count_annotated, 0)
         self.assertEqual(User.objects.with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1)


### PR DESCRIPTION
### Quoi ?

Grâce à #1113 et le nouveau champ M2M `Tender.admins`, on souhaite maintenant filtrer la liste des besoins par les bizdev rattachés.

- un bizdev = un User avec `kind=ADMIN` & `position=Bizdev`
- possibilité aussi de filtrer sur les besoins sans admin

### Capture d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/e6877d1d-0553-4899-a4fc-65c628332b47)
