### PR TITLE
feat(Besoins): Détail : afficher l'entreprise de l'acheteur en gras

### DIFF
--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -17,7 +17,7 @@
             {% if tender.contact_company_name_display %}
                 <div class="col-md-4" title="Entreprise">
                     <i class="ri-building-4-line"></i>
-                    {{ tender.contact_company_name_display }}
+                    <strong>{{ tender.contact_company_name_display }}</strong>
                 </div>
             {% endif %}
             <div class="col-md-4" title="Lieu d'intervention">


### PR DESCRIPTION
### Pourquoi ?

Pour mettre le nom de l'entreprise en avant