### PR TITLE
ci: Ajout d'une commande pour copier les images de démonstration

### DIFF
--- a/lemarche/cms/management/commands/populate_demo_images.py
+++ b/lemarche/cms/management/commands/populate_demo_images.py
@@ -1,0 +1,34 @@
+import os
+
+from django.core.files.storage import default_storage
+
+from lemarche.utils.commands import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Script to copy images in Django storage system, to use them in fixtures for example
+
+    Usage:
+    python manage.py populate_demo_images --images_demo=lemarche/fixtures/django/images/ --folder=original_images
+    """
+
+    help = "Ajoute des images de démonstrations au système de stockage de Django"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--images_demo", dest="images_demo", type=str, help="Chemin du dossier contenant les images de démo"
+        )
+        parser.add_argument(
+            "--folder", dest="folder", type=str, help="Chemin du dossier de destination", default="original_images"
+        )
+
+    def handle(self, *args, **options):
+        images_folder = options["images_demo"]
+        dest_folder = options["folder"]
+
+        for image_name in os.listdir(images_folder):
+            image_path = f"{dest_folder}/{image_name}"
+            if not default_storage.exists(image_path):
+                with open(os.path.join(images_folder, image_name), "rb") as image_file:
+                    default_storage.save(image_path, image_file)


### PR DESCRIPTION
### Quoi ?

Création d'une commande permettant de copier des images présentes dans le répertoire de code vers le système de fichier de Django. 

### Pourquoi ?

Afin de pouvoir utiliser les images dans les `fixtures`.

Exemple d'une fixture Wagtail Image utilisable après un `python manage.py populate_demo_images --images_demo=lemarche/fixtures/django/images/ --folder=original_images` : 

`[{
  "model": "wagtailimages.image",
  "pk": 1,
  "fields": {
    "collection": 1,
    "title": "hp-logos-labels.min.09f76cdcd009",
    "file": "original_images/hp-logos-labels.min.09f76cdcd009.png",
    "width": 855,
    "height": 677,
    "created_at": "2024-03-22T09:32:26.912Z",
    "uploaded_by_user": 1,
    "focal_point_x": null,
    "focal_point_y": null,
    "focal_point_width": null,
    "focal_point_height": null,
    "file_size": 50853,
    "file_hash": "c964b28980ef0211f6941fef4d4f0970ffe362aa"
  }
}
]`

### Comment ?

En utilisant l'utilitaire "default_system".