### PR TITLE
feat(Besoins): mettre à jour l'utilisateur de la mise en relation

### DIFF
--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -347,7 +347,7 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotSentMixin, DetailView):
         self.user_id = request.GET.get("user_id", None)
         # update 'email_link_click_date'
         if self.siae_id:
-            if self.user_id:
+            if self.user_id:  # TODO: check if user in siae ?
                 TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
                     user_id=self.user_id, email_link_click_date=timezone.now(), updated_at=timezone.now()
                 )

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -358,7 +358,7 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotSentMixin, DetailView):
                     self.is_new_for_siaes = True and not self.object.deadline_date_outdated
                     for siae in user.siaes.all():
                         TenderSiae.objects.create(
-                            tender=self.object, siae=siae, source=tender_constants.TENDER_SIAE_SOURCE_LINK
+                            tender=self.object, siae=siae, user=user, source=tender_constants.TENDER_SIAE_SOURCE_LINK
                         )
                 # update stats
                 TenderSiae.objects.filter(
@@ -445,7 +445,7 @@ class TenderDetailContactClickStatView(SiaeUserRequiredOrSiaeIdParamMixin, Updat
                 if user.is_authenticated:
                     TenderSiae.objects.filter(
                         tender=self.object, siae__in=user.siaes.all(), detail_contact_click_date__isnull=True
-                    ).update(detail_contact_click_date=timezone.now(), updated_at=timezone.now())
+                    ).update(user=user, detail_contact_click_date=timezone.now(), updated_at=timezone.now())
                 else:
                     TenderSiae.objects.filter(
                         tender=self.object, siae_id=int(siae_id), detail_contact_click_date__isnull=True
@@ -531,6 +531,7 @@ class TenderDetailNotInterestedClickView(SiaeUserRequiredOrSiaeIdParamMixin, Det
                 TenderSiae.objects.filter(
                     tender=self.object, siae__in=user.siaes.all(), detail_not_interested_click_date__isnull=True
                 ).update(
+                    user=user,
                     detail_not_interested_feedback=self.request.POST.get("detail_not_interested_feedback", ""),
                     detail_not_interested_click_date=timezone.now(),
                     updated_at=timezone.now(),

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -348,13 +348,13 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotSentMixin, DetailView):
         # update 'email_link_click_date'
         if self.siae_id:
             if self.user_id:  # TODO: check if user in siae ?
-                TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
-                    user_id=self.user_id, email_link_click_date=timezone.now(), updated_at=timezone.now()
-                )
+                TenderSiae.objects.filter(
+                    tender=self.object, siae_id=int(self.siae_id), email_link_click_date=None
+                ).update(user_id=int(self.user_id), email_link_click_date=timezone.now(), updated_at=timezone.now())
             else:
-                TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
-                    email_link_click_date=timezone.now(), updated_at=timezone.now()
-                )
+                TenderSiae.objects.filter(
+                    tender=self.object, siae_id=int(self.siae_id), email_link_click_date=None
+                ).update(email_link_click_date=timezone.now(), updated_at=timezone.now())
         # update 'detail_display_date'
         if user.is_authenticated:
             if user.kind == User.KIND_SIAE:

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -344,11 +344,17 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotSentMixin, DetailView):
         self.object = self.get_object()
         user = self.request.user
         self.siae_id = request.GET.get("siae_id", None)
+        self.user_id = request.GET.get("user_id", None)
         # update 'email_link_click_date'
         if self.siae_id:
-            TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
-                email_link_click_date=timezone.now(), updated_at=timezone.now()
-            )
+            if self.user_id:
+                TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
+                    user_id=self.user_id, email_link_click_date=timezone.now(), updated_at=timezone.now()
+                )
+            else:
+                TenderSiae.objects.filter(tender=self.object, siae_id=self.siae_id, email_link_click_date=None).update(
+                    email_link_click_date=timezone.now(), updated_at=timezone.now()
+                )
         # update 'detail_display_date'
         if user.is_authenticated:
             if user.kind == User.KIND_SIAE:


### PR DESCRIPTION
### Quoi ?

Suite à #1143, lorsqu'on connait l'utilisateur, on le met à jour

### Comment ?

Lors du clic dans l'e-mail envoyé aux structures (et aux utilisateurs de cette structure) : 
- si l'utilisateur est connecté, alors on rajoute l'info
- si l'utilisateur est anonyme, mais qu'on a son `user_id`, alors on rajoute l'info
