### PR TITLE
fix(Besoins): répare l'ouverture au clic de 2 liens dfférents

### DIFF
--- a/lemarche/static/js/utils.js
+++ b/lemarche/static/js/utils.js
@@ -27,6 +27,11 @@ window.addEventListener('DOMContentLoaded', function () {
         initSuperBadges();
     });
     initSuperBadges();
+
+    // some elements have their url in data-url attribute
+    $(document).on("click", ".with-data-url", function(e) {
+        window.location.href = $(this).data("url");
+    });
 });
 
 let toggleRequiredClasses = (toggle, element) => {

--- a/lemarche/templates/networks/dashboard_network_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_list.html
@@ -46,11 +46,3 @@
     </div>
 </section>
 {% endblock %}
-
-{% block extra_js %}
-<script type="text/javascript">
-    $(document).on("click", ".c-card--link", function(e) {
-        window.location.href = $(this).data("url");
-    });
-</script>
-{% endblock %}

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -1,9 +1,9 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
+<div class="card c-card c-card--marche siae-card">
     <div class="card-body">
         <div class="row">
-            <div class="col-md-8" style="border-right:1px solid;">
+            <div class="col-md-8 with-data-url" style="border-right:1px solid;cursor:pointer;" data-url="{% url 'tenders:detail' tender.slug %}">
                 <p class="mb-1">
                     {% include "tenders/_closed_badge.html" with tender=tender %}
                     {% if tender.is_draft %}
@@ -21,9 +21,7 @@
                     {% endif %}
                 </p>
 
-                <a href="{% url 'tenders:detail' tender.slug %}" class="text-decoration-none">
-                    <h2 class="py-2">{{ tender.title }}</h2>
-                </a>
+                <h2 class="py-2">{{ tender.title }}</h2>
 
                 <div class="row">
                     <div class="col-md-4">

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -1,9 +1,9 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'dashboard_networks:tender_detail' network.slug tender.slug %}">
+<div class="card c-card c-card--marche siae-card" role="button">
     <div class="card-body">
         <div class="row">
-            <div class="col-md-8" style="border-right:1px solid;">
+            <div class="col-md-8 with-data-url" style="border-right:1px solid;cursor:pointer;" data-url="{% url 'dashboard_networks:tender_detail' network.slug tender.slug %}">
                 <div class="row">
                     <div class="col-md-12">
                         <p class="mb-1">

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -130,11 +130,3 @@
     </div>
 </section>
 {% endblock %}
-
-{% block extra_js %}
-<script type="text/javascript">
-    $(document).on("click", ".c-card--link", function(e) {
-        window.location.href = $(this).data("url");
-    });
-</script>
-{% endblock %}


### PR DESCRIPTION
### Quoi ?

Actuellement, sur la page "liste de besoins", il y a un "conflit" de liens, ce qui provoque l'ouverture d'un onglet supplémentaire.

J'ai baissé d'un niveau le lien global (vers le détail du besoin), pour pas qu'il entre en conflit avec les stats (prestataires intéressés etc)