### PR TITLE
fix: L'image de la section Ecosystème ne change pas

### DIFF
--- a/lemarche/templates/cms/streams/section_ecosystem.html
+++ b/lemarche/templates/cms/streams/section_ecosystem.html
@@ -1,10 +1,10 @@
-{% load static %}
+{% load wagtailimages_tags %}
 
 <section class="bg-gray-light py-5">
     <div class="container">
         <div class="row">
             <div class="col-sm-6 col-md-8 my-sm-auto">
-                <img src="{% static 'images/hp-logos-labels.min.png' %}" class="img-fluid" loading="lazy" alt="Logos de différents labels et certifications">
+                {% image self.image original class="card-img-top" class="img-fluid" loading="lazy" %}
             </div>
             <div class="col-sm-6 col-md-4 my-4 my-sm-auto">
                 <h2 class="h2 mb-3 mb-lg-5">{{self.title}}</h2>

--- a/lemarche/templates/cms/streams/section_studies_cases_tenders_case.html
+++ b/lemarche/templates/cms/streams/section_studies_cases_tenders_case.html
@@ -1,8 +1,8 @@
-{% load wagtailcore_tags  wagtailimages_tags %}
+{% load wagtailimages_tags %}
 
 <div class="col-sm-6 col-md-3 my-4 my-sm-auto">
     <div class="card c-card has-one-link-inside">
-        {% image self.image original class="card-img-top" alt="" %}
+        {% image self.image original class="card-img-top" %}
         <div class="card-body">
             <a href="{{ self.link }}" class="btn btn-link text-left pl-0 stretched-link">
                 {{ self.title }}

--- a/lemarche/templates/cms/streams/section_testimonials.html
+++ b/lemarche/templates/cms/streams/section_testimonials.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
-<section class="s-hp-slider-partners-tenders bg-gray-light">
+<section class="s-hp-slider-partners-tenders">
     <div class="s-hp-slider-partners-tenders__container container">
         <div class="s-hp-slider-partners__row row">
             <div class="col-12">


### PR DESCRIPTION
### Quoi ?

L'image de la section écosystème est restée en statique :

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/379c6ddd-bcf8-41b1-8b52-ee099ced7eff)

Les alt des images de l'étude de cas était écrasé.

Et un fond gris qui n'est pas souhaitable.