### PR TITLE
feat(Besoins): Filtre par type de structure dans le ciblage des structures par recherche sémantique

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1186,6 +1186,7 @@ class Siae(models.Model):
             "id": self.id,
             "name": self.name,
             "website": self.website if self.website else "",
+            "kind": self.kind,
         }
         if self.latitude and self.longitude:
             metadata["geo_location"] = {

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -716,9 +716,10 @@ class Tender(models.Model):
                     geo_distance=self.distance_location,
                     geo_lat=self.location.coords.y,
                     geo_lon=self.location.coords.x,
+                    siae_kinds=self.siae_kind,
                 )
             else:
-                siae_ids = api_elasticsearch.siaes_similarity_search(self.description)
+                siae_ids = api_elasticsearch.siaes_similarity_search(self.description, siae_kinds=self.siae_kind)
 
             siaes_had_found_by_ia = Siae.objects.filter(id__in=siae_ids)
             siaes_had_found_by_ia_too = []

--- a/lemarche/utils/apis/api_elasticsearch.py
+++ b/lemarche/utils/apis/api_elasticsearch.py
@@ -12,7 +12,7 @@ URL_WITH_USER = (
 )
 
 
-def siaes_similarity_search(search_text: str, search_filter: dict = {}):
+def siaes_similarity_search(search_text: str, search_filter: list = [], siae_kinds: list = []):
     """Performs semantic search with Elasticsearch as a vector db
 
     Args:
@@ -21,6 +21,10 @@ def siaes_similarity_search(search_text: str, search_filter: dict = {}):
     Returns:
         list: list of siaes id that match the search query
     """
+
+    if siae_kinds:
+        search_filter.append({"terms": {"metadata.kind.keyword": siae_kinds}})
+
     db = ElasticsearchStore(
         embedding=OpenAIEmbeddings(),
         es_user=settings.ELASTICSEARCH_USERNAME,
@@ -40,7 +44,7 @@ def siaes_similarity_search(search_text: str, search_filter: dict = {}):
 
 
 def siaes_similarity_search_with_geo_distance(
-    search_text: str, geo_distance: int = None, geo_lat: float = None, geo_lon: float = None
+    search_text: str, geo_distance: int = None, geo_lat: float = None, geo_lon: float = None, siae_kinds: list = []
 ):
     search_filter = []
     if geo_distance and geo_lat and geo_lon:
@@ -56,10 +60,10 @@ def siaes_similarity_search_with_geo_distance(
             }
         ]
 
-    return siaes_similarity_search(search_text, search_filter)
+    return siaes_similarity_search(search_text, search_filter, siae_kinds)
 
 
-def siaes_similarity_search_with_city(search_text: str, city: Perimeter):
+def siaes_similarity_search_with_city(search_text: str, city: Perimeter, siae_kinds: list = []):
     search_filter = [
         {
             "bool": {
@@ -88,4 +92,4 @@ def siaes_similarity_search_with_city(search_text: str, city: Perimeter):
             }
         }
     ]
-    return siaes_similarity_search(search_text, search_filter)
+    return siaes_similarity_search(search_text, search_filter, siae_kinds)


### PR DESCRIPTION
### Quoi ?

Le ciblage IA tient compte des types de structure sélectionnés dans l'admin du besoin.

### Pourquoi ?

Pour est cohérent avec le ciblage classique.

### Comment ?

En ajoutant le type de structure aux metadatas des documents elasticsearch et en ajoutant le filtre.

### Captures d'écran

Type de structure dans l'admin : 

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/3125aa14-1f1c-4572-a987-03c1ca51360c)


### Autre

⚠️ l'indexation doit être refaite après la mise en prod.

Je l'ai faite sur la recette jetable.
