### PR TITLE
feat: Ajout d'un bandeau pour inciter les structures à visiter leur page d'accueil

### DIFF
--- a/lemarche/static/itou_marche/base/_custom.scss
+++ b/lemarche/static/itou_marche/base/_custom.scss
@@ -19,7 +19,8 @@ a.disabled {
 }
 
 #header-notice,
-#header-env-notice {
+#header-env-notice,
+#header-for-siaes {
     border-radius: 0;
     border: none !important;
     margin: 0;

--- a/lemarche/static/itou_marche/base/_custom.scss
+++ b/lemarche/static/itou_marche/base/_custom.scss
@@ -20,7 +20,8 @@ a.disabled {
 
 #header-notice,
 #header-env-notice,
-#header-for-siaes {
+#header-for-siaes,
+#header-for-buyers {
     border-radius: 0;
     border: none !important;
     margin: 0;

--- a/lemarche/templates/includes/_header_for_buyers.html
+++ b/lemarche/templates/includes/_header_for_buyers.html
@@ -1,0 +1,5 @@
+<div id="header-for-buyers" class="text-center p-3 bg-marche-lightest">
+    <p class="mb-0">
+        Vous êtes acheteur ? <a href="{% url 'wagtail_serve' '' %}" class="font-weight-bold">Cliquez ici</a>
+    </p>
+</div>

--- a/lemarche/templates/includes/_header_for_siaes.html
+++ b/lemarche/templates/includes/_header_for_siaes.html
@@ -1,0 +1,6 @@
+{% load wagtailcore_tags %}
+<div id="header-for-siaes" class="text-center p-3 bg-marche-lightest">
+    <p class="mb-0">
+        Vous êtes une structure inclusive (SIAE, EA, ESAT) ? <a href="{% slugurl 'accueil-structure' %}" class="font-weight-bold">Cliquez ici</a>
+    </p>
+</div>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -5,6 +5,10 @@
     {% include "includes/_header_env_notice.html" %}
 {% endif %}
 
+{% if not user.is_authenticated and page.slug != "accueil-structure" %}
+    {% include "includes/_header_for_siaes.html" %}
+{% endif %}
+
 <header role="banner" id="header">
     {% with tender_siae_unread_count=user.tender_siae_unread_count %}
         <section class="s-header">

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -5,8 +5,12 @@
     {% include "includes/_header_env_notice.html" %}
 {% endif %}
 
-{% if not user.is_authenticated and page.slug != "accueil-structure" %}
-    {% include "includes/_header_for_siaes.html" %}
+{% if not user.is_authenticated %}
+    {% if page.slug == "accueil-structure" %}
+        {% include "includes/_header_for_buyers.html" %}
+    {% else %}
+        {% include "includes/_header_for_siaes.html" %}
+    {% endif %}
 {% endif %}
 
 <header role="banner" id="header">

--- a/lemarche/www/pages/tests.py
+++ b/lemarche/www/pages/tests.py
@@ -23,6 +23,9 @@ class PagesHeaderLinkTest(TestCase):
     def test_anonymous_user_home(self):
         response = self.client.get("/")
 
+        self.assertContains(response, "Vous êtes une structure inclusive")
+        self.assertContains(response, "/accueil-structure/")
+
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
 
@@ -41,6 +44,9 @@ class PagesHeaderLinkTest(TestCase):
 
     def test_anonymous_user_home_for_siae(self):
         response = self.client.get("/accueil-structure/")
+
+        self.assertNotContains(response, "Vous êtes une structure inclusive")
+        self.assertNotContains(response, "/accueil-structure/")
 
         self.assertContains(response, "Publier un besoin d")
         self.assertContains(response, reverse("tenders:create"))
@@ -62,6 +68,9 @@ class PagesHeaderLinkTest(TestCase):
         self.client.force_login(self.siae_user)
         response = self.client.get("/")
 
+        self.assertNotContains(response, "Vous êtes une structure inclusive")
+        self.assertNotContains(response, "/accueil-structure/")
+
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
 
@@ -81,6 +90,9 @@ class PagesHeaderLinkTest(TestCase):
     def test_buyer_user_home(self):
         self.client.force_login(self.user_buyer)
         response = self.client.get("/")
+
+        self.assertNotContains(response, "Vous êtes une structure inclusive")
+        self.assertNotContains(response, "/accueil-structure/")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))

--- a/lemarche/www/pages/tests.py
+++ b/lemarche/www/pages/tests.py
@@ -23,8 +23,10 @@ class PagesHeaderLinkTest(TestCase):
     def test_anonymous_user_home(self):
         response = self.client.get("/")
 
+        # top header banner
         self.assertContains(response, "Vous êtes une structure inclusive")
         self.assertContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "Vous êtes acheteur")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
@@ -45,8 +47,10 @@ class PagesHeaderLinkTest(TestCase):
     def test_anonymous_user_home_for_siae(self):
         response = self.client.get("/accueil-structure/")
 
+        # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
         self.assertNotContains(response, "/accueil-structure/")
+        self.assertContains(response, "Vous êtes acheteur")
 
         self.assertContains(response, "Publier un besoin d")
         self.assertContains(response, reverse("tenders:create"))
@@ -68,8 +72,10 @@ class PagesHeaderLinkTest(TestCase):
         self.client.force_login(self.siae_user)
         response = self.client.get("/")
 
+        # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
         self.assertNotContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "Vous êtes acheteur")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
@@ -91,8 +97,10 @@ class PagesHeaderLinkTest(TestCase):
         self.client.force_login(self.user_buyer)
         response = self.client.get("/")
 
+        # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
         self.assertNotContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "Vous êtes acheteur")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -36,7 +36,7 @@ class SiaeSearchNumQueriesTest(TestCase):
 
     def test_search_num_queries(self):
         url = reverse("siae:search_results")
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
             siaes = list(response.context["siaes"])
             self.assertEqual(len(siaes), 20)


### PR DESCRIPTION
### Quoi ?

Ajout d'un bandeau avec lien (dépend de la PR #1156 )

### Pourquoi ?

Pour inciter les structures à visiter leur page d'accueil et les acheteurs la leur.

### Comment ?

Bandeau affiché qu'aux utilisateurs non connecté et changeant si on est sur la page d'accueil structure.

### Captures d'écran

Bandeau sur toutes les pages (si non connecté)

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/6403db6c-5307-49ec-8ed0-621029be0c5a)

Bandeau sur la page d'accueil structure (si non connecté)

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/88b044c7-ebcf-4460-9987-f708d8be525a)




