### PR TITLE
fix(Besoins): évite d'envoyer des mails de relance aux structures pas intéressées

### DIFF
--- a/clevercloud/tenders_send_siae_contacted_reminder_emails.sh
+++ b/clevercloud/tenders_send_siae_contacted_reminder_emails.sh
@@ -20,5 +20,3 @@ fi
 cd $APP_HOME
 
 django-admin send_siae_contacted_reminder_emails --days-since-email-send-date 2
-django-admin send_siae_contacted_reminder_emails --days-since-email-send-date 3
-django-admin send_siae_contacted_reminder_emails --days-since-email-send-date 4

--- a/lemarche/tenders/management/commands/send_siae_contacted_reminder_emails.py
+++ b/lemarche/tenders/management/commands/send_siae_contacted_reminder_emails.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         self.stdout.write("Script to send Siae contacted reminder emails...")
 
         current_weekday = timezone.now().weekday()
-        if current_weekday >= 5:
+        if current_weekday > 4:
             self.stdout.write("Weekend... Stopping. Come back on Monday :)")
         else:
             self.stdout.write("-" * 80)
@@ -47,10 +47,9 @@ class Command(BaseCommand):
 
             lt_days_ago = timezone.now() - timedelta(days=options["days_since_email_send_date"])
             gte_days_ago = timezone.now() - timedelta(days=options["days_since_email_send_date"] + 1)
-            # Monday: special case (the script doesn't run on weekends)
-            # gte_days_ago = gte_days_ago+2 to account for Saturday & Sunday
+            # The script doesn't run on weekends
             if current_weekday == 0:
-                gte_days_ago = timezone.now() - timedelta(days=options["days_since_email_send_date"] + 1 + 2)
+                gte_days_ago = gte_days_ago - timedelta(days=2)
             tendersiae_contacted_reminder_list = TenderSiae.objects.email_click_reminder(
                 gte_days_ago=gte_days_ago, lt_days_ago=lt_days_ago
             )

--- a/lemarche/tenders/management/commands/send_siae_interested_reminder_emails.py
+++ b/lemarche/tenders/management/commands/send_siae_interested_reminder_emails.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         self.stdout.write("Script to send Siae interested reminder emails...")
 
         current_weekday = timezone.now().weekday()
-        if current_weekday >= 5:
+        if current_weekday > 4:
             self.stdout.write("Weekend... Stopping. Come back on Monday :)")
         else:
             self.stdout.write("-" * 80)
@@ -46,10 +46,10 @@ class Command(BaseCommand):
 
             lt_days_ago = timezone.now() - timedelta(days=options["days_since_detail_contact_click_date"])
             gte_days_ago = timezone.now() - timedelta(days=options["days_since_detail_contact_click_date"] + 1)
-            # Monday: special case (the script doesn't run during on weekends)
+            # Monday: special case (the script doesn't run on weekends)
             # gte_days_ago = gte_days_ago+2 to account for Saturday & Sunday
             if current_weekday == 0:
-                gte_days_ago = timezone.now() - timedelta(days=options["days_since_detail_contact_click_date"] + 1 + 2)
+                gte_days_ago = gte_days_ago - timedelta(days=2)
             tendersiae_interested_reminder_list = TenderSiae.objects.detail_contact_click_post_reminder(
                 gte_days_ago=gte_days_ago, lt_days_ago=lt_days_ago
             )


### PR DESCRIPTION
### Quoi ?

Ne pas envoyer l'email de relance aux structures concernées, si elles ont indiqué "pas intéressées"