### PR TITLE
feat(Besoins): Formulaire : si un lien externe est fourni, alors forcer le choix de réponse

### DIFF
--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -146,8 +146,17 @@ class TenderCreateViewTest(TestCase):
     def test_tender_wizard_form_external_link_validation(self):
         self.client.force_login(self.user_buyer)
         tenders_step_data = self._generate_fake_data_form(_step_1={"general-kind": tender_constants.KIND_TENDER})
-        # set an external_link with a wrong format
+        # set a wrong external_link (should be a valid url)
         tenders_step_data[1]["detail-external_link"] = "test"
+        with self.assertRaises(AssertionError):
+            self._check_every_step(tenders_step_data, final_redirect_page=reverse("siae:search_results"))
+
+    def test_tender_wizard_form_tender_with_external_link_response_kind_validation(self):
+        self.client.force_login(self.user_buyer)
+        tenders_step_data = self._generate_fake_data_form(_step_1={"general-kind": tender_constants.KIND_TENDER})
+        tenders_step_data[1]["detail-external_link"] = "example.com"
+        # set a wrong reponse_kind (should have RESPONSE_KIND_EXTERNAL)
+        tenders_step_data[2]["contact-response_kind"] = []
         with self.assertRaises(AssertionError):
             self._check_every_step(tenders_step_data, final_redirect_page=reverse("siae:search_results"))
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -112,6 +112,7 @@ class TenderCreateMultiStepView(SessionWizardView):
             if self.instance.id:
                 kwargs["questions_list"] = list(self.instance.questions_list())
         if step == self.STEP_CONTACT:
+            kwargs["kind"] = self.get_cleaned_data_for_step(self.STEP_GENERAL).get("kind")
             kwargs["external_link"] = self.get_cleaned_data_for_step(self.STEP_DETAIL).get("external_link")
             kwargs["user"] = self.request.user
         return kwargs


### PR DESCRIPTION
### Quoi ?

Si `kind` = TENDER & `external_link` est rempli, alors `response_kind` doit contenir RESPONSE_KIND_EXTERNAL

### Pourquoi ?

Pour que le lien externe s'affiche bien aux structures