### PR TITLE
feat(Entreprises): commande interactive pour créer de nouvelles entreprises à partir des infos des acheteurs

### DIFF
--- a/lemarche/companies/management/commands/create_companies.py
+++ b/lemarche/companies/management/commands/create_companies.py
@@ -1,0 +1,86 @@
+import operator
+from functools import reduce
+
+from django.db.models import Q
+
+from lemarche.companies.models import Company
+from lemarche.users.models import User
+
+# from lemarche.utils.apis import api_slack
+from lemarche.utils.commands import BaseCommand
+
+
+GENERIC_EMAIL_DOMAIN_SUFFIX_LIST = [
+    "gmail.com",
+    "orange.fr",
+    "wanadoo.fr",
+    "hotmail.fr",
+    "hotmail.com",
+    "live.fr",
+    "yahoo.fr",
+    "yahoo.com",
+    "outlook.fr",
+    "outlook.com",
+    "laposte.net",
+    "free.fr",
+    "sfr.fr",
+    "icloud.com",
+    "yandex.com",
+    "msn.com",
+    "cegetel.net",
+    "bbox.fr",
+    "yopmail.com",
+    "neuf.fr",
+    "numericable.fr",
+    "gmx.fr",
+    "googlemail.com",
+]
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+    - poetry run python manage.py create_companies
+    """
+
+    def handle(self, *args, **options):
+        self.stdout_info("-" * 80)
+
+        user_buyer_without_company = User.objects.filter(kind="BUYER", company_id__isnull=True)
+        self.stdout_info(f"Users without company: {user_buyer_without_company.count()}")
+        user_buyer_without_company_with_tender = user_buyer_without_company.filter(tenders__isnull=False)
+        self.stdout_info(f"Users without company with tender: {user_buyer_without_company_with_tender.count()}")
+
+        user_qs = (
+            user_buyer_without_company.filter(
+                reduce(operator.and_, (~Q(email__endswith=x) for x in GENERIC_EMAIL_DOMAIN_SUFFIX_LIST))
+            )
+            .exclude(company_name__icontains="particulier")
+            .exclude(company_name="")
+        )
+        self.stdout_info(f"Users final queryset (extra filtering): {user_qs.count()}")
+        companies_created = 0
+
+        for user in user_qs:
+            user_email_suffix = user.email.split("@")[1]
+            # check that no company already exist
+            company_qs = Company.objects.filter(email_domain_list__contains=[user_email_suffix])
+            if not company_qs.count():
+                result = input(f"Create company: {user_email_suffix} / {user.company_name} ? (y/n) ")
+                if result == "y":
+                    company = Company.objects.create(name=user.company_name, email_domain_list=[user_email_suffix])
+                    company.users.add(user)
+                    self.stdout_info(f"Company created for {user_email_suffix}")
+                    companies_created += 1
+            elif company_qs.count() == 1:
+                company = company_qs.first()
+                company.users.add(user)
+                self.stdout_info(f"User added to existing company {company.name}")
+
+        msg_success = [
+            "----- Create companies -----",
+            f"Done! Processed {user_qs.count()} users without company",
+            f"Created {companies_created} companies",
+        ]
+        self.stdout_messages_success(msg_success)
+        # api_slack.send_message_to_channel("\n".join(msg_success))

--- a/lemarche/companies/management/commands/create_companies.py
+++ b/lemarche/companies/management/commands/create_companies.py
@@ -5,8 +5,7 @@ from django.db.models import Q
 
 from lemarche.companies.models import Company
 from lemarche.users.models import User
-
-# from lemarche.utils.apis import api_slack
+from lemarche.utils.apis import api_slack
 from lemarche.utils.commands import BaseCommand
 from lemarche.utils.emails import GENERIC_EMAIL_DOMAIN_SUFFIX_LIST
 
@@ -53,10 +52,8 @@ class Command(BaseCommand):
             # check that no company already exist
             company_qs = Company.objects.filter(email_domain_list__contains=[user_email_suffix])
             if not company_qs.count():
-                result = input(f"Create company: {user_email_suffix} / {user.company_name} ? (y/n/id) ")
-                if result == "n":
-                    pass
-                elif result == "y":
+                result = input(f"Create company: {user_email_suffix} / {user.company_name} ? (y/<id>/n) ")
+                if result == "y":
                     company = Company.objects.create(name=user.company_name, email_domain_list=[user_email_suffix])
                     company.users.add(user)
                     self.stdout_info(f"Company created for {user_email_suffix}")
@@ -67,6 +64,8 @@ class Command(BaseCommand):
                     company.save()
                     company.users.add(user)
                     self.stdout_info(f"User added to existing company {company.name} (and email_domain_list updated)")
+                else:
+                    pass
 
             elif company_qs.count() == 1:
                 company = company_qs.first()
@@ -79,4 +78,4 @@ class Command(BaseCommand):
             f"Created {companies_created} companies",
         ]
         self.stdout_messages_success(msg_success)
-        # api_slack.send_message_to_channel("\n".join(msg_success))
+        api_slack.send_message_to_channel("\n".join(msg_success))

--- a/lemarche/companies/management/commands/create_companies.py
+++ b/lemarche/companies/management/commands/create_companies.py
@@ -8,33 +8,7 @@ from lemarche.users.models import User
 
 # from lemarche.utils.apis import api_slack
 from lemarche.utils.commands import BaseCommand
-
-
-GENERIC_EMAIL_DOMAIN_SUFFIX_LIST = [
-    "gmail.com",
-    "orange.fr",
-    "wanadoo.fr",
-    "hotmail.fr",
-    "hotmail.com",
-    "live.fr",
-    "yahoo.fr",
-    "yahoo.com",
-    "outlook.fr",
-    "outlook.com",
-    "laposte.net",
-    "free.fr",
-    "sfr.fr",
-    "icloud.com",
-    "yandex.com",
-    "msn.com",
-    "cegetel.net",
-    "bbox.fr",
-    "yopmail.com",
-    "neuf.fr",
-    "numericable.fr",
-    "gmx.fr",
-    "googlemail.com",
-]
+from lemarche.utils.emails import GENERIC_EMAIL_DOMAIN_SUFFIX_LIST
 
 
 class Command(BaseCommand):

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -9,6 +9,33 @@ from lemarche.utils.apis import api_brevo, api_hubspot, api_mailjet
 from lemarche.utils.constants import EMAIL_SUBJECT_PREFIX
 
 
+GENERIC_EMAIL_DOMAIN_SUFFIX_LIST = [
+    "gmail.com",
+    "orange.fr",
+    "wanadoo.fr",
+    "hotmail.fr",
+    "hotmail.com",
+    "live.fr",
+    "yahoo.fr",
+    "yahoo.com",
+    "outlook.fr",
+    "outlook.com",
+    "laposte.net",
+    "free.fr",
+    "sfr.fr",
+    "icloud.com",
+    "yandex.com",
+    "msn.com",
+    "cegetel.net",
+    "bbox.fr",
+    "yopmail.com",
+    "neuf.fr",
+    "numericable.fr",
+    "gmx.fr",
+    "googlemail.com",
+]
+
+
 def anonymize_email(email):
     email_split = email.split("@")
     email_username = email_split[0]


### PR DESCRIPTION
### Quoi ?

A partir de la liste des acheteurs (en filtrant sur ceux qui ne sont pas encore rattachés à une entreprise + qui ont une adresse e-mail non-générique), on créé de nouvelles entreprises
- en utilisant le champ `User.company_name`
- en demandant confirmation à chaque fois 