### PR TITLE
feat(Home): La page d'accueil d'un utilisateur d'une structure doit être celle dédiée aux ESI

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -865,7 +865,7 @@ WAGTAILADMIN_BASE_URL = DEPLOY_URL or "http://localhost/"
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 
 # Specific home page is setted here to avoid one query on every page
-SIAE_HOME_PAGE = "/accueil-structure/"
+SIAE_HOME_PAGE = env.str("SIAE_HOME_PAGE", "/accueil-structure/")
 
 # Increase throttling to avoid Bad request errors when saving large pages
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-number-fields

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -205,6 +205,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 # custom
                 "lemarche.utils.settings_context_processors.expose_settings",
+                "lemarche.utils.home_page_context_processors.home_page",
             ],
         },
     },
@@ -862,6 +863,9 @@ WAGTAILEMBEDS_RESPONSIVE_HTML = True
 WAGTAILADMIN_BASE_URL = DEPLOY_URL or "http://localhost/"
 
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
+
+# Specific home page is setted here to avoid one query on every page
+SIAE_HOME_PAGE = "/accueil-structure"
 
 # Increase throttling to avoid Bad request errors when saving large pages
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-number-fields

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -865,7 +865,7 @@ WAGTAILADMIN_BASE_URL = DEPLOY_URL or "http://localhost/"
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 
 # Specific home page is setted here to avoid one query on every page
-SIAE_HOME_PAGE = "/accueil-structure"
+SIAE_HOME_PAGE = "/accueil-structure/"
 
 # Increase throttling to avoid Bad request errors when saving large pages
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-number-fields

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">API</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/auth/login.html
+++ b/lemarche/templates/auth/login.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Connexion</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/auth/password_reset.html
+++ b/lemarche/templates/auth/password_reset.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Réinitialisation du mot de passe</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/auth/password_reset_confirm.html
+++ b/lemarche/templates/auth/password_reset_confirm.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Saisissez un nouveau mot de passe</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/auth/password_reset_sent.html
+++ b/lemarche/templates/auth/password_reset_sent.html
@@ -9,7 +9,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Réinitialisation du mot de passe</li>
                     </ol>
                 </nav>
@@ -37,7 +37,7 @@
                     <li>vérifiez qu'il n'y a pas d'erreur dans votre e-mail</li>
                 </ul>
                 <p class="mt-3 mt-lg-5">
-                    <a href="{% url 'wagtail_serve' '' %}" class="btn btn-link btn-ico pl-0">
+                    <a href="{{ HOME_PAGE_PATH }}" class="btn btn-link btn-ico pl-0">
                         <i class="ri-arrow-go-back-line ri-lg"></i>
                         <span>Revenir à la page principale</span>
                     </a>

--- a/lemarche/templates/auth/signup.html
+++ b/lemarche/templates/auth/signup.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Inscription</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/cms/article_list.html
+++ b/lemarche/templates/cms/article_list.html
@@ -11,7 +11,7 @@
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
-                                <a href="{% url 'wagtail_serve' '' %}">Accueil</a>
+                                <a href="{{ HOME_PAGE_PATH }}">Accueil</a>
                             </li>
                             <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
                         </ol>

--- a/lemarche/templates/cms/article_page.html
+++ b/lemarche/templates/cms/article_page.html
@@ -16,7 +16,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% slugurl 'ressources' %}">Ressources</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ page.title }}">{{ page.title }}</li>
                     </ol>

--- a/lemarche/templates/cms/paid_article_list.html
+++ b/lemarche/templates/cms/paid_article_list.html
@@ -11,7 +11,7 @@
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
-                                <a href="{% url 'wagtail_serve' '' %}">Accueil</a>
+                                <a href="{{ HOME_PAGE_PATH }}">Accueil</a>
                             </li>
                             <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
                         </ol>

--- a/lemarche/templates/cms/static/decouvrir-inclusion.html
+++ b/lemarche/templates/cms/static/decouvrir-inclusion.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">C'est quoi l'inclusion ?</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/cms/static/filiere_recyclage.html
+++ b/lemarche/templates/cms/static/filiere_recyclage.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Filière : recyclage</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/cms/static/filiere_restauration.html
+++ b/lemarche/templates/cms/static/filiere_restauration.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                    <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Filière : restauration</li>
                 </ol>
                 </nav>

--- a/lemarche/templates/cms/static/valoriser-achats.html
+++ b/lemarche/templates/cms/static/valoriser-achats.html
@@ -11,7 +11,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Auditer et valoriser vos achats</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -12,7 +12,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Tableau de bord</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -11,7 +11,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Tableau de bord</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/dashboard/profile_edit.html
+++ b/lemarche/templates/dashboard/profile_edit.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Modifier mon profil</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/dashboard/siae_edit_base.html
+++ b/lemarche/templates/dashboard/siae_edit_base.html
@@ -10,7 +10,7 @@
             <div class="col-12 col-lg">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name_display }} : modifier">{{ siae.name_display }} : modifier</li>
                     </ol>

--- a/lemarche/templates/dashboard/siae_search_adopt_confirm.html
+++ b/lemarche/templates/dashboard/siae_search_adopt_confirm.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_siaes:siae_search_by_siret' %}">Rechercher ma structure</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Vérifier ma structure</li>

--- a/lemarche/templates/dashboard/siae_search_by_siret.html
+++ b/lemarche/templates/dashboard/siae_search_by_siret.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Rechercher ma structure</li>
                     </ol>

--- a/lemarche/templates/dashboard/siae_users.html
+++ b/lemarche/templates/dashboard/siae_users.html
@@ -10,7 +10,7 @@
             <div class="col-12 col-lg">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name }} : collaborateurs">{{ siae.name }} : collaborateurs</li>
                     </ol>

--- a/lemarche/templates/favorites/dashboard_favorite_list.html
+++ b/lemarche/templates/favorites/dashboard_favorite_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Liste d'achat favoris</li>
                     </ol>

--- a/lemarche/templates/favorites/dashboard_favorite_list_detail.html
+++ b/lemarche/templates/favorites/dashboard_favorite_list_detail.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_favorites:list' %}">Liste d'achat favoris</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ favorite_list.name }}">{{ favorite_list.name }}</li>

--- a/lemarche/templates/includes/_header_for_buyers.html
+++ b/lemarche/templates/includes/_header_for_buyers.html
@@ -1,5 +1,5 @@
 <div id="header-for-buyers" class="text-center p-3 bg-marche-lightest">
     <p class="mb-0">
-        Vous êtes acheteur ? <a id="header-for-buyers-link" href="{% url 'wagtail_serve' '' %}" class="font-weight-bold">Cliquez ici</a>
+        Vous êtes acheteur ? <a id="header-for-buyers-link" href="{{ HOME_PAGE_PATH }}" class="font-weight-bold">Cliquez ici</a>
     </p>
 </div>

--- a/lemarche/templates/includes/_header_for_siaes.html
+++ b/lemarche/templates/includes/_header_for_siaes.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 <div id="header-for-siaes" class="text-center p-3 bg-marche-lightest">
     <p class="mb-0">
-        Vous êtes une structure inclusive (SIAE, EA, ESAT) ? <a id="header-for-siaes-link" href="{% slugurl 'accueil-structure' %}" class="font-weight-bold">Cliquez ici</a>
+        Vous êtes une structure inclusive (SIAE, EA, ESAT) ? <a id="header-for-siaes-link" href="{{ SIAE_HOME_PAGE }}" class="font-weight-bold">Cliquez ici</a>
     </p>
 </div>

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -8,7 +8,7 @@
                     <strong>Accès rapides</strong>
                     <div class="s-footer-quick__gridlist">
                         <ul>
-                            <li><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                            <li><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                             <li><a href="{% url 'tenders:create' %}">Publier un besoin d'achat</li>
                             <li><a href="{% url 'siae:search_results' %}">Rechercher un prestataire</a></li>
                             <li><a href="{% url 'siae:search_results' %}">Moteur de recherche multicritères</a></li>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -19,10 +19,10 @@
             <div class="s-header__container container">
                 <div class="s-header__row row">
                     <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pr-0">
-                        <a href="{% url 'wagtail_serve' '' %}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
+                        <a href="{{ HOME_PAGE_PATH }}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
                     </div>
                     <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
-                        <a href="{% url 'wagtail_serve' '' %}"><img src="{% static_theme_images 'logo-marche-inclusion.svg' %}" alt="Le marché de l'inclusion"></a>
+                        <a href="{{ HOME_PAGE_PATH }}"><img src="{% static_theme_images 'logo-marche-inclusion.svg' %}" alt="Le marché de l'inclusion"></a>
                     </div>
                     <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
                         <nav role="navigation" id="nav-primary" aria-label="Navigation principale">

--- a/lemarche/templates/layouts/_header_nav_secondary_items.html
+++ b/lemarche/templates/layouts/_header_nav_secondary_items.html
@@ -1,6 +1,6 @@
 <ul>
 	<li>
-		<a href="{% url 'wagtail_serve' '' %}" class="{% if request.path == '/' %}is-active{% endif %}">Accueil</a>
+		<a href="{{ HOME_PAGE_PATH }}" class="{% if request.path == HOME_PAGE_PATH %}is-active{% endif %}">Accueil</a>
 	</li>
 	<li>
 		<a href="/ressources/quest-ce-quun-prestataire-inclusif/" id="header-ressource-prestataire" class="{% if request.path == '/ressources/quest-ce-quun-prestataire-inclusif/' %}is-active{% endif %}">

--- a/lemarche/templates/networks/dashboard_network_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Mes adhérents</li>

--- a/lemarche/templates/networks/dashboard_network_siae_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_tender_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:siae_list' network.slug %}">Mes adhérents</a></li>

--- a/lemarche/templates/networks/dashboard_network_tender_detail.html
+++ b/lemarche/templates/networks/dashboard_network_tender_detail.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:tender_list' network.slug %}">Opportunités commerciales</a></li>

--- a/lemarche/templates/networks/dashboard_network_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Opportunités commerciales</li>

--- a/lemarche/templates/networks/dashboard_network_tender_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_siae_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:tender_list' network.slug %}">Opportunités commerciales</a></li>

--- a/lemarche/templates/pages/accessibilite.html
+++ b/lemarche/templates/pages/accessibilite.html
@@ -10,7 +10,7 @@
 			<div class="col-12">
 				<nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
 					<ol class="breadcrumb">
-						<li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+						<li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
 						<li class="breadcrumb-item active" aria-current="page">Accessibilité</li>
 					</ol>
 				</nav>

--- a/lemarche/templates/pages/company-reference-calculator.html
+++ b/lemarche/templates/pages/company-reference-calculator.html
@@ -13,7 +13,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Découvrez si votre entreprise est déjà cliente d'un prestataire inclusif</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/contact.html
+++ b/lemarche/templates/pages/contact.html
@@ -13,7 +13,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Formulaire de contact</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/decouvrir-inclusion.html
+++ b/lemarche/templates/pages/decouvrir-inclusion.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">C'est quoi l'inclusion ?</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/filiere_recyclage.html
+++ b/lemarche/templates/pages/filiere_recyclage.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Filière : recyclage</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/filiere_restauration.html
+++ b/lemarche/templates/pages/filiere_restauration.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                    <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Filière : restauration</li>
                 </ol>
                 </nav>

--- a/lemarche/templates/pages/flatpage_template.html
+++ b/lemarche/templates/pages/flatpage_template.html
@@ -12,7 +12,7 @@
                 <div class="col-12">
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                            <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                             <li class="breadcrumb-item active" aria-current="page"title="{{ flatpage.title }}">{{ flatpage.title }}</li>
                         </ol>
                     </nav>

--- a/lemarche/templates/pages/groupements.html
+++ b/lemarche/templates/pages/groupements.html
@@ -14,7 +14,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Groupements</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/impact-calculator.html
+++ b/lemarche/templates/pages/impact-calculator.html
@@ -13,7 +13,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Calibrer votre achat socialement responsable</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/partenaires.html
+++ b/lemarche/templates/pages/partenaires.html
@@ -11,7 +11,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Partenaires</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/social-impact-for-buyers.html
+++ b/lemarche/templates/pages/social-impact-for-buyers.html
@@ -13,7 +13,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Calculer l'impact social d'un achat inclusif</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/stats.html
+++ b/lemarche/templates/pages/stats.html
@@ -13,7 +13,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Statistiques</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/pages/valoriser-achats.html
+++ b/lemarche/templates/pages/valoriser-achats.html
@@ -14,7 +14,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Auditer et valoriser vos achats</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -18,7 +18,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'siae:search_results' %}?{{ current_search_query }}" title="Revenir aux résultats de recherche">Recherche</a></li>
                         <li class="breadcrumb-item active" aria-current="page"title="{{ siae.name_display }}">{{ siae.name_display }}</li>
                     </ol>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -15,7 +15,7 @@
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
-                                <a href="{% url 'wagtail_serve' '' %}">Accueil</a>
+                                <a href="{{ HOME_PAGE_PATH }}">Accueil</a>
                             </li>
                             <li class="breadcrumb-item active" aria-current="page">Recherche</li>
                         </ol>

--- a/lemarche/templates/tenders/create_base.html
+++ b/lemarche/templates/tenders/create_base.html
@@ -9,7 +9,7 @@
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
-                                <a href="{% url 'wagtail_serve' '' %}">Accueil</a>
+                                <a href="{{ HOME_PAGE_PATH }}">Accueil</a>
                             </li>
                             {% if user.is_authenticated %}
                                 <li class="breadcrumb-item">

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         {% if user.is_authenticated %}
                             <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">{{ parent_title }}</a></li>

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ page_title }}">{{ page_title }}</li>
                     </ol>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Mes besoins</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>

--- a/lemarche/templates/tenders/survey_transactioned_detail.html
+++ b/lemarche/templates/tenders/survey_transactioned_detail.html
@@ -10,7 +10,7 @@
             <div class="col-12">
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{{ HOME_PAGE_PATH }}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">{{ parent_title }}</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>

--- a/lemarche/utils/home_page_context_processors.py
+++ b/lemarche/utils/home_page_context_processors.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.urls import reverse_lazy
+
+from lemarche.users.models import User
+
+
+def home_page(request):
+    """
+    Put things into the context to make them available in templates.
+    https://docs.djangoproject.com/en/4.2/ref/templates/api/#using-requestcontext
+    """
+
+    home_page = reverse_lazy("wagtail_serve", args=("",))
+    if request.user.is_authenticated and request.user.kind == User.KIND_SIAE:
+        home_page = settings.SIAE_HOME_PAGE
+
+    return {"HOME_PAGE_PATH": home_page}

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -29,4 +29,5 @@ def expose_settings(request):
         "TYPEFORM_GROUPEMENT_AJOUT": settings.TYPEFORM_GROUPEMENT_AJOUT,
         "FORM_PARTENAIRES": settings.FORM_PARTENAIRES,
         "MTCAPTCHA_PUBLIC_KEY": settings.MTCAPTCHA_PUBLIC_KEY,
+        "SIAE_HOME_PAGE": settings.SIAE_HOME_PAGE,
     }

--- a/lemarche/www/pages/tests.py
+++ b/lemarche/www/pages/tests.py
@@ -25,8 +25,9 @@ class PagesHeaderLinkTest(TestCase):
 
         # top header banner
         self.assertContains(response, "Vous êtes une structure inclusive")
-        self.assertContains(response, "/accueil-structure/")
+        self.assertContains(response, "header-for-siaes-link")
         self.assertNotContains(response, "Vous êtes acheteur")
+        self.assertNotContains(response, "header-for-buyers-link")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
@@ -49,8 +50,9 @@ class PagesHeaderLinkTest(TestCase):
 
         # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
-        self.assertNotContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "header-for-siaes-link")
         self.assertContains(response, "Vous êtes acheteur")
+        self.assertContains(response, "header-for-buyers-link")
 
         self.assertContains(response, "Publier un besoin d")
         self.assertContains(response, reverse("tenders:create"))
@@ -74,8 +76,9 @@ class PagesHeaderLinkTest(TestCase):
 
         # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
-        self.assertNotContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "header-for-siaes-link")
         self.assertNotContains(response, "Vous êtes acheteur")
+        self.assertNotContains(response, "header-for-buyers-link")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))
@@ -99,8 +102,9 @@ class PagesHeaderLinkTest(TestCase):
 
         # top header banner
         self.assertNotContains(response, "Vous êtes une structure inclusive")
-        self.assertNotContains(response, "/accueil-structure/")
+        self.assertNotContains(response, "header-for-siaes-link")
         self.assertNotContains(response, "Vous êtes acheteur")
+        self.assertNotContains(response, "header-for-buyers-link")
 
         self.assertContains(response, "Publier un besoin d'achat")
         self.assertContains(response, reverse("tenders:create"))

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -36,7 +36,7 @@ class SiaeSearchNumQueriesTest(TestCase):
 
     def test_search_num_queries(self):
         url = reverse("siae:search_results")
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(8):
             response = self.client.get(url)
             siaes = list(response.context["siaes"])
             self.assertEqual(len(siaes), 20)


### PR DESCRIPTION
### Quoi ?

Suite à #1141.
Changement de la page d'accueil pour les utilisateurs  des ESI.

### Pourquoi ?

Pour que les utilisateurs puissent accéder directement à leur page d'accueil

### Comment ?

Avec un `precessor` afin de ne pas alourdir le code des templates.
L'URL de la page d'accueil est déplacer dans les settings pour limiter les requêtes juste pour ça.
