### PR TITLE
fix(Besoins): améliore la définition d'un besoin non dépassé

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -95,7 +95,7 @@ class TenderQuerySet(models.QuerySet):
         )
 
     def is_not_outdated(self):
-        return self.filter(deadline_date__gte=datetime.today())
+        return self.filter(Q(deadline_date__isnull=True) | Q(deadline_date__gte=datetime.today()))
 
     def is_live(self):
         return self.sent().is_not_outdated()

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -361,10 +361,11 @@ class TenderModelQuerysetTest(TestCase):
         self.assertEqual(Tender.objects.validated_sent_batch().count(), 1)
 
     def test_is_not_outdated(self):
+        TenderFactory(deadline_date=None)
         TenderFactory(deadline_date=timezone.now() + timedelta(days=1))
         TenderFactory(deadline_date=timezone.now() - timedelta(days=1))
         # TenderFactory(deadline_date=None)  # cannot be None
-        self.assertEqual(Tender.objects.is_not_outdated().count(), 1)
+        self.assertEqual(Tender.objects.is_not_outdated().count(), 1 + 1)
 
     def test_is_live(self):
         TenderFactory(deadline_date=timezone.now() + timedelta(days=1))


### PR DESCRIPTION
### Quoi ?

Suite au fix dans #1175 
Il manquait de prendre en compte les besoins sans date de clôture (ça existe !)