### PR TITLE
fix(Besoins): ne pas autoriser le ré-envoi si la date de clôture est dépassée

### DIFF
--- a/lemarche/templates/tenders/admin_change_form.html
+++ b/lemarche/templates/tenders/admin_change_form.html
@@ -48,10 +48,10 @@ No need to repeat them under fieldsets!
                     <p><i>Envoyé le {{ original.first_sent_at }}.</i></p>
                     <input type="submit" name="_restart_tender" value="Renvoyer aux structures" {% if original.deadline_date_outdated %}disabled{% endif %} />
                     {% if original.deadline_date_outdated %}
-                        <p><i>date de clôture dépassée ({{ original.deadline_date }})</i></p>
+                        <p><i>Date de clôture dépassée ({{ original.deadline_date }})</i></p>
                     {% endif %}
                     {% if original.start_working_date_outdated %}
-                        <p><i>date de début des prestation dépassée ({{ original.start_working_date }})</i></p>
+                        <p><i>Date idéale de début des prestations dépassée ({{ original.start_working_date }})</i></p>
                     {% endif %}
                 {% endif %}
             {% else %}

--- a/lemarche/templates/tenders/admin_change_form.html
+++ b/lemarche/templates/tenders/admin_change_form.html
@@ -41,16 +41,22 @@ No need to repeat them under fieldsets!
                 <input type="submit" class="button" name="_calculate_tender" value="Sauvegarder et chercher les structures correspondantes" />
             </div>
         {% endif %}
-        <div class="submit-row">
+        <div class="submit-row" style="display:block">
             {% if original.validated_at %}
-                <i>Validé le {{ original.validated_at }}.&nbsp;</i>
+                <p><i>Validé le {{ original.validated_at }}.</i></p>
                 {% if original.first_sent_at %}
-                    <i>Envoyé le {{ original.first_sent_at }}.</i>
-                    <input type="submit" class="button" name="_restart_tender" value="Renvoyer aux structures" />
+                    <p><i>Envoyé le {{ original.first_sent_at }}.</i></p>
+                    <input type="submit" name="_restart_tender" value="Renvoyer aux structures" {% if original.deadline_date_outdated %}disabled{% endif %} />
+                    {% if original.deadline_date_outdated %}
+                        <p><i>date de clôture dépassée ({{ original.deadline_date }})</i></p>
+                    {% endif %}
+                    {% if original.start_working_date_outdated %}
+                        <p><i>date de début des prestation dépassée ({{ original.start_working_date }})</i></p>
+                    {% endif %}
                 {% endif %}
             {% else %}
-                <input type="submit" class="button" name="_validate_tender" value="Valider (sauvegarder) et envoyer aux structures" />
-                <i>L'envoi des besoins 'validés' se fait toutes les 5 minutes, du Lundi au Vendredi, entre 9h et 17h</i>
+                <p><i>L'envoi des besoins 'validés' se fait toutes les 5 minutes, du Lundi au Vendredi, entre 9h et 17h</i></p>
+                <input type="submit" name="_validate_tender" value="Valider (sauvegarder) et envoyer aux structures 🚀" />
             {% endif %}
         </div>
     {% endif %}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -903,6 +903,12 @@ class Tender(models.Model):
             return True
         return False
 
+    @cached_property
+    def start_working_date_outdated(self):
+        if self.start_working_date and self.start_working_date < timezone.now().date():
+            return True
+        return False
+
     @property
     def hubspot_deal_id(self):
         return self.extra_data.get("hubspot_deal_id")

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -65,7 +65,7 @@ class TenderModelPropertyTest(TestCase):
             # coords=Point(5.8862, 45.1106),
         )
 
-    def test_sectors_list(self):
+    def test_sectors_list_property(self):
         sector_group = SectorGroupFactory(name="Bricolage")
         sector_1 = SectorFactory(name="Autre", group=sector_group)
         sector_2 = SectorFactory(name="Un secteur", group=sector_group)
@@ -78,7 +78,7 @@ class TenderModelPropertyTest(TestCase):
         self.assertEqual(tender_with_sectors.sectors_list()[0], sector_2.name)  # Autre at the end
         self.assertEqual(tender_with_sectors.sectors_list_string(), "Un secteur, Autre")
 
-    def test_perimeters_list(self):
+    def test_perimeters_list_property(self):
         tender_whithout_perimeters = TenderFactory()
         self.assertEqual(len(tender_whithout_perimeters.perimeters_list()), 0)
         self.assertEqual(tender_whithout_perimeters.perimeters_list_string, "")
@@ -89,7 +89,7 @@ class TenderModelPropertyTest(TestCase):
         self.assertEqual(tender_with_perimeters.perimeters_list()[0], self.grenoble_perimeter.name)
         self.assertEqual(tender_with_perimeters.perimeters_list_string, "Grenoble, Chamrousse")
 
-    def test_location_display(self):
+    def test_location_display_property(self):
         tender_country_area = TenderFactory(title="Besoin 1", is_country_area=True)
         self.assertEqual(tender_country_area.location_display, "France entière")
         tender_location = TenderFactory(title="Besoin 2", location=self.grenoble_perimeter)
@@ -100,7 +100,7 @@ class TenderModelPropertyTest(TestCase):
         self.assertTrue("Grenoble" in tender_with_perimeters.location_display)
         self.assertTrue("Chamrousse" in tender_with_perimeters.location_display)
 
-    def test_questions_list(self):
+    def test_questions_list_property(self):
         tender_without_questions = TenderFactory()
         self.assertEqual(len(tender_without_questions.questions_list()), 0)
         tender_with_questions = TenderFactory()
@@ -109,7 +109,23 @@ class TenderModelPropertyTest(TestCase):
         self.assertEqual(len(tender_with_questions.questions_list()), 2)
         self.assertEqual(tender_with_questions.questions_list()[0].get("text"), tender_question_1.text)
 
-    def test_status(self):
+    def test_deadline_date_outdated_property(self):
+        tender_without_deadline_date = TenderFactory(deadline_date=None)
+        tender_not_outdated = TenderFactory(deadline_date=date_next_week.date())
+        tender_outdated = TenderFactory(deadline_date=date_last_week.date())
+        self.assertFalse(tender_without_deadline_date.deadline_date_outdated)
+        self.assertFalse(tender_not_outdated.deadline_date_outdated)
+        self.assertTrue(tender_outdated.deadline_date_outdated)
+
+    def test_start_working_date_outdated(self):
+        tender_without_start_working_date = TenderFactory(start_working_date=None)
+        tender_not_outdated = TenderFactory(start_working_date=date_next_week.date())
+        tender_outdated = TenderFactory(start_working_date=date_last_week.date())
+        self.assertFalse(tender_without_start_working_date.start_working_date_outdated)
+        self.assertFalse(tender_not_outdated.start_working_date_outdated)
+        self.assertTrue(tender_outdated.start_working_date_outdated)
+
+    def test_status_property(self):
         tender_draft = TenderFactory(status=tender_constants.STATUS_DRAFT)
         tender_pending_validation = TenderFactory(status=tender_constants.STATUS_PUBLISHED)
         tender_validated_half = TenderFactory(status=tender_constants.STATUS_VALIDATED)
@@ -121,7 +137,7 @@ class TenderModelPropertyTest(TestCase):
         self.assertTrue(tender_validated_full.is_validated)
         self.assertTrue(tender_sent.is_sent)
 
-    def test_amount_display(self):
+    def test_amount_display_property(self):
         tender_with_amount = TenderFactory(amount=tender_constants.AMOUNT_RANGE_0_1, accept_share_amount=True)
         tender_with_amount_2 = TenderFactory(amount=tender_constants.AMOUNT_RANGE_10_15, accept_share_amount=True)
         tender_with_amount_exact = TenderFactory(


### PR DESCRIPTION
### Quoi ?

En partie lié à #1175

Les admin peuvent décider de ré-envoyer des besoins, mais on ne vérifie pas la date de clôture.

Grâce à cette PR
- on désactive le bouton une fois la date de clôture dépassée
- on rappelle la date de clôture et de début des prestations
- on ajoute des tests sur ces 2 property

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/7147385/4f59f44a-658d-46d8-8206-22e57138c052)
