### PR TITLE
feat: suppression de la limite du nombre de page d'accueil

### DIFF
--- a/lemarche/cms/models.py
+++ b/lemarche/cms/models.py
@@ -152,7 +152,6 @@ class PaidArticleList(ArticleList):
 
 
 class HomePage(Page):
-    max_count = 3
     banner_title = models.CharField(
         default="Votre recherche de prestataires inclusifs est chronophage ?", max_length=120
     )
@@ -216,6 +215,7 @@ class HomePage(Page):
         FieldPanel("content"),
     ]
 
+    page_description = "Use this page type like a landing page"
     parent_page_types = ["wagtailcore.Page", "cms.HomePage"]
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

Suppression de la limite du nombre de page de type HomePage et ajout d'une description du type.

### Pourquoi ?

Pour pouvoir créer des pages d'atterrissage à souhait.

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/7b9397c0-6613-4ff8-b000-0c2f723989f1)
