### PR TITLE
fix(Emails): ajout de valeurs par défaut pour from_email & from_name

### DIFF
--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -125,8 +125,8 @@ def send_transactional_email_with_template(
     recipient_name: str,
     variables: dict,
     subject: str,
-    from_email: str,
-    from_name: str,
+    from_email=settings.DEFAULT_FROM_EMAIL,
+    from_name=settings.DEFAULT_FROM_NAME,
 ):
     api_client = get_api_client()
     api_instance = sib_api_v3_sdk.TransactionalEmailsApi(api_client)

--- a/lemarche/utils/apis/api_mailjet.py
+++ b/lemarche/utils/apis/api_mailjet.py
@@ -100,8 +100,8 @@ def send_transactional_email_with_template(
     recipient_name: str,
     variables: dict,
     subject: str,
-    from_email: str,
-    from_name: str,
+    from_email=settings.DEFAULT_FROM_EMAIL,
+    from_name=settings.DEFAULT_FROM_NAME,
     client=None,
 ):
     data = {


### PR DESCRIPTION
### Quoi ?

Dans la PR #1034 j'avais enlevé les valeurs par défaut de `from_email` & `from_name` pour `api_mailjet` et `api_brevo`

Or cela génère des erreurs coté Sentry

Je revert, car je ne sais pas quels sont les impacts exacts, et si les envois sont cassés depuis 1 semaine ???

Sachant que cela sera de toute façon supprimé par la fin de la migration vers TemplateTransactional (cf #1193)