### PR TITLE
fix(Emails): ajout de valeur par défaut pour subject

### DIFF
--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -124,7 +124,7 @@ def send_transactional_email_with_template(
     recipient_email: str,
     recipient_name: str,
     variables: dict,
-    subject: str,
+    subject=None,
     from_email=settings.DEFAULT_FROM_EMAIL,
     from_name=settings.DEFAULT_FROM_NAME,
 ):

--- a/lemarche/utils/apis/api_mailjet.py
+++ b/lemarche/utils/apis/api_mailjet.py
@@ -99,7 +99,7 @@ def send_transactional_email_with_template(
     recipient_email: str,
     recipient_name: str,
     variables: dict,
-    subject: str,
+    subject=None,
     from_email=settings.DEFAULT_FROM_EMAIL,
     from_name=settings.DEFAULT_FROM_NAME,
     client=None,


### PR DESCRIPTION
### Quoi ?

Similaire à #1204
Dans la PR #1034 j'avais enlevé les valeurs par défaut de `subject` pour `api_mailjet` et `api_brevo`

Or cela génère des erreurs coté Sentry

Je revert, car je ne sais pas quels sont les impacts exacts, et si les envois sont cassés depuis 1 semaine ???

Sachant que cela sera de toute façon supprimé par la fin de la migration vers TemplateTransactional (cf #1193)