### PR TITLE
feat(Brevo): méthode pour lier des Contacts (User) à une Company (Siae)

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -770,7 +770,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
             if obj.amount_int > settings.BREVO_TENDERS_MIN_AMOUNT_TO_SEND:
                 api_brevo.create_deal(tender=obj, owner_email=request.user.email)
                 # we link deal(tender) with author contact
-                api_brevo.link_deal_with_list_contact(tender=obj)
+                api_brevo.link_deal_with_contact_list(tender=obj)
                 self.message_user(request, "Ce dépôt de besoin a été synchronisé avec Brevo")
             self.message_user(request, "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
             return HttpResponseRedirect(".")


### PR DESCRIPTION
### Quoi ?

Nouvelle méthode `api_brevo.link_company_with_contact_list` pour pouvoir rattacher les utilisateurs à leur structure sur Brevo

Similaire à #1123 qui ajoutait `api_brevo.link_deal_with_list_contact`