### PR TITLE
feat: Changer url de la page "Auditer vos achats"

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -10,9 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
+import datetime
 import locale
 import os
-import datetime
 
 import environ
 from django.contrib.messages import constants as messages
@@ -841,8 +841,9 @@ WAGTAILADMIN_BASE_URL = DEPLOY_URL or "http://localhost/"
 
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 
-# Specific home page is setted here to avoid one query on every page
+# Specific home and purchasing impact page is setted here to avoid queries on every page
 SIAE_HOME_PAGE = env.str("SIAE_HOME_PAGE", "/accueil-structure/")
+PURCHASING_IMPACT_PAGE = env.str("PURCHASING_IMPACT_PAGE", "/impact-rse/")
 
 # Increase throttling to avoid Bad request errors when saving large pages
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-number-fields

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -12,7 +12,7 @@
                             <li><a href="{% url 'tenders:create' %}">Publier un besoin d'achat</li>
                             <li><a href="{% url 'siae:search_results' %}">Rechercher un prestataire</a></li>
                             <li><a href="{% url 'siae:search_results' %}">Moteur de recherche multicritères</a></li>
-                            <li><a href="{% url 'pages:valoriser_achats' %}">Auditer vos achats</a></li>
+                            <li><a href="{{ PURCHASING_IMPACT_PAGE }}">Auditer vos achats</a></li>
                         </ul>
                         <ul>
                             <li><a href="{% url 'pages:impact_calculator' %}">Calibrer vos achats</a></li>

--- a/lemarche/templates/layouts/_header_nav_secondary_items.html
+++ b/lemarche/templates/layouts/_header_nav_secondary_items.html
@@ -16,7 +16,7 @@
 			<a href="{% url 'tenders:create' %}" id="header-dropdown-tender-create-btn" class="dropdown-item">
 				Sourcing inversé
 			</a>
-			<a href="{% url 'pages:valoriser_achats' %}" id="header-valoriser" class="dropdown-item">
+			<a href="{{ PURCHASING_IMPACT_PAGE }}" id="header-valoriser" class="dropdown-item">
 				Auditer vos achats
 			</a>
 			<a href="{% url 'pages:impact_calculator' %}" id="header-calibrer" class="dropdown-item">

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -30,4 +30,5 @@ def expose_settings(request):
         "FORM_PARTENAIRES": settings.FORM_PARTENAIRES,
         "MTCAPTCHA_PUBLIC_KEY": settings.MTCAPTCHA_PUBLIC_KEY,
         "SIAE_HOME_PAGE": settings.SIAE_HOME_PAGE,
+        "PURCHASING_IMPACT_PAGE": settings.PURCHASING_IMPACT_PAGE,
     }


### PR DESCRIPTION
### Quoi ?

Changement du lien "Auditer vos achats" dans le menu d'entête et dans le pied de page

### Pourquoi ?

Pour tester la nouvelle page "Impact RSE"

### Comment ?

En passant par une variable settings, d'une part pour éviter les requêtes, le lien étant sur toutes les pages. Mais également pour pouvoir le changer avec une variable d'environnement.
