### PR TITLE
fix: Uniformisation de la hauteur des blocs du carousel

### DIFF
--- a/lemarche/static/itou_marche/sections/_home.scss
+++ b/lemarche/static/itou_marche/sections/_home.scss
@@ -113,10 +113,12 @@
 .multiCarousel .multiCarousel-inner {
 	transition: 1s ease all;
 	float: left;
+	display: flex;
 }
 
 .multiCarousel .multiCarousel-inner .item {
 	float: left;
+	display: flex;
 }
 
 .multiCarousel .multiCarousel-inner .item>div {


### PR DESCRIPTION
### Quoi ?

Correction du flex

### Pourquoi ?

Pour avoir des blocs de la même hauteur, plus harmonieux visuellement

### Comment ?

Ajout de la propriété `flex` aux items du carousel et à l'élément contenant.

### Captures d'écran

Avant :

![screenshot-lemarche inclusion beta gouv fr-2024 05 21-10_38_37](https://github.com/gip-inclusion/le-marche/assets/17601807/f27847b2-8c4d-4550-9f59-bde1339e05b3)

Après :

![screenshot-marche localhost_8880-2024 05 21-10_39_30](https://github.com/gip-inclusion/le-marche/assets/17601807/5b237aaa-a5af-410b-a6eb-ebaa02752f3f)


