### PR TITLE
fix(Brevo): Admin : afficher les identifiants (contact_id, deal_id, company_id)

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -188,9 +188,10 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
             "tender_detail_display_count_annotated_with_link",
             "tender_detail_contact_click_count_annotated_with_link",
             "tender_detail_not_interested_count_annotated_with_link",
-            "logs_display",
+            "brevo_company_id",
             "extra_data_display",
             "import_raw_object_display",
+            "logs_display",
         ]
     )
     formfield_overrides = {
@@ -324,15 +325,17 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         (
             "Stats",
             {
+                "classes": ["collapse"],
                 "fields": (
                     "signup_date",
                     "content_filled_basic_date",
-                    "logs_display",
+                    "brevo_company_id",
                     "extra_data_display",
-                )
+                ),
             },
         ),
-        ("Si importé", {"fields": ("import_raw_object_display",)}),
+        ("Si importé", {"classes": ["collapse"], "fields": ("import_raw_object_display",)}),
+        ("Logs", {"classes": ["collapse"], "fields": ("logs_display",)}),
         ("Dates", {"fields": ("created_at", "updated_at")}),
     ]
 

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -337,10 +337,11 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "siae_ai_count_annotated_with_link",
         "siae_transactioned_source",
         "siae_transactioned_last_updated",
-        "logs_display",
-        "extra_data_display",
         "source",
+        "brevo_deal_id",
+        "extra_data_display",
         "import_raw_object_display",
+        "logs_display",
     ]
     formfield_overrides = {
         models.TextField: {"widget": CKEditorWidget},
@@ -498,13 +499,14 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                     "marche_benefits",
                     "siae_list_last_seen_date",
                     "source",
-                    "logs_display",
+                    "brevo_deal_id",
                     "extra_data_display",
                 ),
             },
         ),
         ("Si importé", {"classes": ["collapse"], "fields": ("import_raw_object_display",)}),
-        ("Dates", {"classes": ["collapse"], "fields": ("created_at", "updated_at")}),
+        ("Logs", {"classes": ["collapse"], "fields": ("logs_display",)}),
+        ("Dates", {"fields": ("created_at", "updated_at")}),
     ]
 
     change_form_template = "tenders/admin_change_form.html"

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -192,6 +192,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
             "favorite_list_count_with_link",
             "image_url",
             "image_url_display",
+            "brevo_contact_id",
             "extra_data",
         ]
     )
@@ -255,11 +256,12 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         ("API", {"fields": ("api_key", "api_key_last_updated")}),
         (
             "Permissions",
-            {"fields": ("is_active", "is_staff", "is_superuser", "groups")},
+            {"classes": ["collapse"], "fields": ("is_active", "is_staff", "is_superuser", "groups")},
         ),
         (
             "Données C4 Cocorico",
             {
+                "classes": ["collapse"],
                 "fields": (
                     "c4_id",
                     "c4_website",
@@ -272,10 +274,16 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
                     "c4_id_card_verified",
                     "image_url",
                     "image_url_display",
-                )
+                ),
             },
         ),
-        ("Stats", {"fields": ("dashboard_last_seen_date", "tender_list_last_seen_date", "extra_data")}),
+        (
+            "Stats",
+            {
+                "classes": ["collapse"],
+                "fields": ("dashboard_last_seen_date", "tender_list_last_seen_date", "brevo_contact_id", "extra_data"),
+            },
+        ),
         (
             "Dates",
             {
@@ -287,6 +295,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
             },
         ),
     )
+
     add_fieldsets = (
         (
             None,


### PR DESCRIPTION
### Quoi ?

On a récemment créé des champs dédiés pour stocker les identifiants Brevo : 
- `Siae.brevo_company_id` : #1208
- `User.brevo_contact_id` : #1123
- `Tender.brevo_deal_id` : #1123

Mais ce champ n'était pas affiché dans l'admin.

J'en ai profité pour faire un peu de ménage (utiliser des collapse, déplacer les logs dans une section dédiée)