### PR TITLE
fix(Hubspot): Répare la création de contact (suite au changement de format du numéro de téléphone)

### DIFF
--- a/lemarche/utils/apis/api_hubspot.py
+++ b/lemarche/utils/apis/api_hubspot.py
@@ -88,7 +88,7 @@ def add_user_to_crm(user):
         company=user.company_name,
         firstname=user.first_name,
         lastname=user.last_name,
-        phone=user.phone,
+        phone=str(user.phone),
         website=user.c4_website,
     )
     if result and result.id:


### PR DESCRIPTION
### Quoi ?

Suite à #1215 le format de `User.phone` a changé, et il doit être converti en string pour être envoyé à des API tierces