### PR TITLE
fix: Répare l'affichage des numéros de téléphone (suite au changement de format)

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -24,7 +24,7 @@ from lemarche.siaes.tasks import set_siae_coords
 from lemarche.stats.models import Tracker
 from lemarche.users.models import User
 from lemarche.utils.constants import DEPARTMENTS_PRETTY, RECALCULATED_FIELD_HELP_TEXT, REGIONS_PRETTY
-from lemarche.utils.data import round_by_base
+from lemarche.utils.data import phone_number_display, round_by_base
 from lemarche.utils.fields import ChoiceArrayField
 from lemarche.utils.urls import get_object_admin_url
 from lemarche.utils.validators import validate_naf, validate_post_code, validate_siret
@@ -167,6 +167,10 @@ class SiaeGroup(models.Model):
         self.set_slug()
         self.set_last_updated_fields()
         super().save(*args, **kwargs)
+
+    @property
+    def contact_phone_display(self):
+        return phone_number_display(self.contact_phone)
 
 
 class SiaeQuerySet(models.QuerySet):
@@ -1079,6 +1083,10 @@ class Siae(models.Model):
         if self.contact_first_name and self.contact_last_name:
             return f"{self.contact_first_name.upper()[:1]}. {self.contact_last_name.upper()}"
         return ""
+
+    @property
+    def contact_phone_display(self):
+        return phone_number_display(self.contact_phone)
 
     @property
     def geo_range_pretty_display(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -41,6 +41,7 @@ from lemarche.utils.constants import (
     MARCHE_BENEFIT_CHOICES,
     RECALCULATED_FIELD_HELP_TEXT,
 )
+from lemarche.utils.data import phone_number_display
 from lemarche.utils.fields import ChoiceArrayField
 from lemarche.utils.urls import get_object_admin_url
 from lemarche.utils.validators import OptionalSchemeURLValidator
@@ -778,6 +779,10 @@ class Tender(models.Model):
     @cached_property
     def contact_full_name(self) -> str:
         return f"{self.contact_first_name} {self.contact_last_name}"
+
+    @property
+    def contact_phone_display(self):
+        return phone_number_display(self.contact_phone)
 
     def contact_company_name_display(self) -> str:
         if self.contact_company_name:

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -13,6 +13,7 @@ from phonenumber_field.modelfields import PhoneNumberField
 
 from lemarche.stats.models import StatsUser
 from lemarche.users import constants as user_constants
+from lemarche.utils.data import phone_number_display
 from lemarche.utils.emails import anonymize_email
 
 
@@ -353,6 +354,10 @@ class User(AbstractUser):
         elif self.partner_kind:
             kind_detail_display_string += f" : {self.get_partner_kind_display()}"
         return kind_detail_display_string
+
+    @property
+    def phone_display(self):
+        return phone_number_display(self.phone)
 
     @property
     def has_siae(self):

--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -92,7 +92,7 @@ def create_or_update_company(siae):
             "address_post_code": siae.post_code,
             "address_city": siae.city,
             "contact_email": siae.contact_email,
-            "contact_phone": siae.contact_phone,
+            "contact_phone": siae.contact_phone_display,
             "domain": siae.website,
             "logo_url": siae.logo_url,
             "geo_range": siae.geo_range,

--- a/lemarche/utils/apis/api_hubspot.py
+++ b/lemarche/utils/apis/api_hubspot.py
@@ -88,7 +88,7 @@ def add_user_to_crm(user):
         company=user.company_name,
         firstname=user.first_name,
         lastname=user.last_name,
-        phone=str(user.phone),
+        phone=user.phone_display,
         website=user.c4_website,
     )
     if result and result.id:

--- a/lemarche/utils/data.py
+++ b/lemarche/utils/data.py
@@ -64,3 +64,15 @@ def phone_number_is_valid(phone_number):
         return phonenumbers.is_valid_number(phonenumbers.parse(phone_number))
     except phonenumbers.phonenumberutil.NumberParseException:
         return False
+
+
+def phone_number_display(phone_number_model_field):
+    """
+    https://django-phonenumber-field.readthedocs.io/en/latest/reference.html
+    phone.as_international --> +33 1 23 45 67 89
+    phone.as_national --> 01 23 45 67 89
+    phone.as_e164 --> +33123456789
+    phone.as_rfc3966 --> tel:+33-1-23-45-67-89
+    str(phone) --> +33123456789
+    """
+    return phone_number_model_field.as_e164

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -69,6 +69,9 @@ def generate_siae_row(siae: Siae, siae_field_list):
         # ManyToManyFields
         elif field_name == "sectors":
             col_value = siae.sectors_full_list_string()
+        # Complex fields
+        elif field_name == "contact_phone":
+            col_value = siae.contact_phone_display
         # Custom fields
         elif field_name == "Inscrite":
             col_value = "Oui" if siae.user_count else "Non"

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -698,7 +698,7 @@ def send_super_siaes_email_to_author(tender: Tender, top_siaes: list[Siae]):
                     "name": siae.name_display,
                     "kind": siae.get_kind_display(),
                     "contact_name": siae.contact_full_name,
-                    "contact_phone": siae.contact_phone,
+                    "contact_phone": siae.contact_phone_display,
                     "contact_email": siae.contact_email,
                 }
             )

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -133,7 +133,7 @@ class TenderCreateViewTest(TestCase):
         self.assertEqual(tender.contact_first_name, self.user_buyer.first_name)
         self.assertEqual(tender.contact_last_name, self.user_buyer.last_name)
         self.assertEqual(tender.contact_email, self.user_buyer.email)
-        self.assertEqual(tender.contact_phone, self.user_buyer.phone)
+        self.assertEqual(tender.contact_phone_display, self.user_buyer.phone_display)
 
     def test_tender_wizard_form_not_created(self):
         self.client.force_login(self.user_buyer)


### PR DESCRIPTION
### Quoi ?

Suite à #1215, #1221 & #1224. Lié à #1232

il y a des erreurs quand on souhaite serializé le champ `PhoneNumberField`. J'ai rajouté une property pour chaque modèle concerné qui explicite la stringification