### PR TITLE
fix(Structures): afficher seulement aux admins l'information que la structure n'est pas encore inscrite

### DIFF
--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -15,6 +15,11 @@
                     <div class="col-sm-12">
                         <h1 class="h2 mb-0">
                             {{ siae.name_display }}
+                            {% if user.is_authenticated and user.is_admin and not siae.user_count %}
+                                <span class="badge badge-base rounded-pill text-warning fs-sm">
+                                    pas encore inscrite
+                                </span>
+                            {% endif %}
                         </h1>
                         {% if siae.super_badge %}
                             <span class="badge badge-base rounded-pill super-badge-badge text-primary mt-2 font-weight-bold">
@@ -22,7 +27,7 @@
                                 Super prestataire
                             </span>
                         {% endif %}
-                        <p class="mt-3 mb-1 font-italic">(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</p>
+                        <p class="mt-3 mb-2 font-italic">(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</p>
                         {% if user.is_authenticated %}
                             {% if siae.in_user_favorite_list_count_annotated %}
                                 <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -14,7 +14,7 @@
             <div class="col">
                 <h2 class="h4 mb-0">
                     {{ siae.name_display }}
-                    {% if not siae.user_count %}
+                    {% if user.is_authenticated and user.is_admin and not siae.user_count %}
                         <span class="fs-sm font-weight-normal">(bientôt inscrite sur le marché)</span>
                     {% endif %}
                 </h2>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -15,7 +15,9 @@
                 <h2 class="h4 mb-0">
                     {{ siae.name_display }}
                     {% if user.is_authenticated and user.is_admin and not siae.user_count %}
-                        <span class="fs-sm font-weight-normal">(bientôt inscrite sur le marché)</span>
+                        <span class="badge badge-base rounded-pill text-warning fs-sm">
+                            pas encore inscrite
+                        </span>
                     {% endif %}
                 </h2>
                 {% if siae.super_badge %}

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -39,16 +39,16 @@ class SiaeSearchDisplayResultsTest(TestCase):
         url = reverse("siae:search_results")
         # anonymous
         response = self.client.get(url)
-        self.assertNotContains(response, "bientôt inscrite")
+        self.assertNotContains(response, "pas encore inscrite")
         # other users
         for user in [self.user_buyer, self.user_partner, self.user_siae]:
             self.client.force_login(user)
             response = self.client.get(url)
-            self.assertNotContains(response, "bientôt inscrite")
+            self.assertNotContains(response, "pas encore inscrite")
         # admin
         self.client.force_login(self.user_admin)
         response = self.client.get(url)
-        self.assertContains(response, "bientôt inscrite")
+        self.assertContains(response, "pas encore inscrite")
 
 
 class SiaeSearchNumQueriesTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Quelques modifications d'affichage et de wording sur le fait que la structure ne soit pas encore inscrite sur le marché
- le message "bientôt inscrite sur le marché" s'affiche que pour les admins
- il s'affiche aussi sur la page détail
- renommé à "pas encore inscrite" 
- ajouté un test :) 

### Captures d'écran

pour un utilisateur admin

|page|Avant|Après|
|---|---|---|
|Résultats de recherche|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/981ceb49-a399-4eca-a1f7-690727f1f401)|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/859f295a-f329-4ceb-86ae-4e53d0c3f662)|
|Page détail (nouveau)|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/b90d9c85-978d-49a4-a6e9-134497b1a7fe)|![image](https://github.com/gip-inclusion/le-marche/assets/7147385/71839e9a-83cf-4abf-b216-9a70c586037c)|