### PR TITLE
fix(Besoins): Admin : filtre vraiment la liste des utilisateurs sur les bizdev

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -547,11 +547,6 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 readonly_fields.append("slug")
         return readonly_fields
 
-    def formfield_for_manytomany(self, db_field, request, **kwargs):
-        if db_field.name == "admins":
-            kwargs["queryset"] = User.objects.filter(kind=User.KIND_ADMIN)
-        return super().formfield_for_manytomany(db_field, request, **kwargs)
-
     def save_model(self, request, obj: Tender, form, change):
         """
         Set Tender author on create

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -340,7 +340,6 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         queryset, use_distinct = super().get_search_results(request, queryset, search_term)
         pattern = r"^\/admin\/autocomplete\/\?.*app_label=tenders&model_name=tender&field_name=admins$"
         if re.search(pattern, request.get_full_path()):
-            print("get_search_results users matched")
             queryset = queryset.filter(kind=User.KIND_ADMIN)
         return queryset, use_distinct
 

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -1,3 +1,5 @@
+import re
+
 from ckeditor.widgets import CKEditorWidget
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
@@ -327,6 +329,20 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         qs = qs.with_siae_stats()
         qs = qs.with_tender_stats()
         return qs
+
+    def get_search_results(self, request, queryset, search_term):
+        """
+        We have a usecase where we want to return only admins
+        We need to match strings like:
+        - /admin/autocomplete/?app_label=tenders&model_name=tender&field_name=admins
+        - /admin/autocomplete/?term=raph&app_label=tenders&model_name=tender&field_name=admins
+        """
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        pattern = r"^\/admin\/autocomplete\/\?.*app_label=tenders&model_name=tender&field_name=admins$"
+        if re.search(pattern, request.get_full_path()):
+            print("get_search_results users matched")
+            queryset = queryset.filter(kind=User.KIND_ADMIN)
+        return queryset, use_distinct
 
     def save_formset(self, request, form, formset, change):
         """


### PR DESCRIPTION
### Quoi ?

Suite à #1134, l'autocomplete des utilisateurs ne filtrait pas sur les admins

Réparé en utilisant la bonne méthode : `get_search_results`
- https://stackoverflow.com/questions/48152908/how-to-filter-choices-in-django2s-autocomplete-fields
- https://forum.djangoproject.com/t/django-admin-autocomplete-field-search-customization/7455/8