### PR TITLE
feat(Besoins): Ordonner les besoins par date de publication

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -195,13 +195,10 @@ class TenderQuerySet(models.QuerySet):
             )
         )
 
-    def order_by_deadline_date(self, limit_date=datetime.today()):
+    def order_by_last_published(self, limit_date=datetime.today()):
         return self.with_deadline_date_is_outdated(limit_date=limit_date).order_by(
-            "deadline_date_is_outdated_annotated", "deadline_date", "-updated_at"
+            "deadline_date_is_outdated_annotated", "-published_at", "-updated_at"
         )
-
-    def order_by_last_published(self):
-        return self.order_by("-published_at", "-updated_at")
 
     def with_question_stats(self):
         return self.annotate(question_count_annotated=Count("questions", distinct=True))

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -480,12 +480,6 @@ class TenderModelQuerysetOrderTest(TestCase):
         self.assertEqual(tender_queryset.count(), 3)
         self.assertEqual(tender_queryset.first().id, self.tender_3.id)
 
-    def test_order_by_deadline_date(self):
-        tender_queryset = Tender.objects.order_by_deadline_date()
-        self.assertEqual(tender_queryset.count(), 3)
-        self.assertEqual(tender_queryset.first().id, self.tender_2.id)
-        self.assertEqual(tender_queryset.last().id, self.tender_3.id)
-
     def test_order_by_last_published(self):
         tender_queryset = Tender.objects.order_by_last_published()
         self.assertEqual(tender_queryset.count(), 3)

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -67,7 +67,7 @@ class DashboardHomeView(LoginRequiredMixin, DetailView):
             if siaes:
                 context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes).order_by_last_published()[:3]
         else:
-            context["last_3_tenders"] = Tender.objects.filter(author=user).order_by_deadline_date()[:3]
+            context["last_3_tenders"] = Tender.objects.filter(author=user).order_by_last_published()[:3]
             context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
             context["siae_count"] = Siae.objects.is_live().count()
             context["tender_count"] = Tender.objects.sent().count() + 30  # historic number (before form)

--- a/lemarche/www/dashboard_networks/views.py
+++ b/lemarche/www/dashboard_networks/views.py
@@ -97,7 +97,7 @@ class DashboardNetworkTenderListView(NetworkMemberRequiredMixin, ListView):
         qs = qs.prefetch_many_to_many().select_foreign_keys()
         qs = qs.filter_with_siaes(self.network_siaes)
         qs = qs.with_network_siae_stats(self.network_siaes)
-        qs = qs.order_by_deadline_date()
+        qs = qs.order_by_last_published()
         return qs
 
     def get_context_data(self, **kwargs):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -303,7 +303,7 @@ class TenderListView(LoginRequiredMixin, ListView):
                 qs = qs.filter(kind=kind)
 
         qs = qs.prefetch_many_to_many().select_foreign_keys()
-        qs = qs.order_by_deadline_date()
+        qs = qs.order_by_last_published()
         return qs
 
     def get(self, request, status=None, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

Changement de l'ordre des dépôts de besoins pour afficher les plus récemment publiés en premier.
Les besoins clôturées doivent rester en bas de liste.

### Pourquoi ?

Pour rendre la consultation plus simple pour les structures et être plus cohérent avec les 3 besoins remontés sur le tableau de bord.

### Comment ?

En changeant de Queryset et en supprimant celui sur les dates de clôture qui n'est donc plus utilisé.

### Captures d'écran

![image](https://github.com/gip-inclusion/le-marche/assets/17601807/3b12e9c6-d33e-4ae5-972b-4e378466d233)
