### PR TITLE
feat(Besoins): changement de couleur des badgets des besoins clôturés

### DIFF
--- a/lemarche/templates/tenders/_closed_badge.html
+++ b/lemarche/templates/tenders/_closed_badge.html
@@ -1,11 +1,11 @@
 <p class="mb-1">
     {% if tender.deadline_date_is_outdated_annotated %}
-        <span class="badge badge-xs badge-base badge-pill badge-{{ tender.kind|lower }}">
+        <span class="badge badge-xs badge-pill badge-nuance-08 font-weight-bold">
             {{ tender_kind_display|default:tender.get_kind_display }} clôturé{% if tender.kind == "QUOTE" %}e{% endif %}
             le {{ tender.deadline_date|default:"" }}
         </span>
     {% else %}
-        <span class="badge badge-base badge-pill mr-1 badge-{{ tender.kind|lower }}">
+        <span class="badge badge-xs badge-pill mr-1 badge-{{ tender.kind|lower }} font-weight-bold">
             {% if tender.kind == "PROJ" %}
                 {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
             {% else %}


### PR DESCRIPTION
### Quoi ?

Peu importe le type de besoins, les badges sont de la même couleur une fois clôturés.

### Pourquoi ?

Plus lisible

### Comment ?

Classe CSS existante

### Captures d'écran

Avant : 

![screenshot-marche localhost_8880-2024 06 05-17_36_18](https://github.com/gip-inclusion/le-marche/assets/17601807/1bd122b7-5af9-419a-ad29-4f3fbf61e48b)

Après :

![screenshot-marche localhost_8880-2024 06 05-17_35_34](https://github.com/gip-inclusion/le-marche/assets/17601807/adbfe91f-e72e-4dc5-93dd-2dbcbb972ea1)
