### PR TITLE
refactor(Périmètres): Pouvoir aussi filtrer les post_codes sur le insee_code

### DIFF
--- a/lemarche/perimeters/models.py
+++ b/lemarche/perimeters/models.py
@@ -27,12 +27,13 @@ class PerimeterQuerySet(models.QuerySet):
             .order_by("-similarity")
         )
 
-    def post_code_search(self, value):
+    def post_code_search(self, value, include_insee_code=False):
         # city post_code
         if len(value) == 5:
-            qs = self.filter(post_codes__contains=[value])
-            # if we wanted to allow search on insee_code as well
-            # return queryset.filter(Q(insee_code=value) | Q(post_codes__contains=[value]))
+            if include_insee_code:
+                qs = self.filter(Q(insee_code=value) | Q(post_codes__contains=[value]))
+            else:
+                qs = self.filter(post_codes__contains=[value])
         # department code or beginning of city post_code
         elif len(value) == 2:
             qs = self.filter(Q(insee_code=value) | Q(post_codes__0__startswith=value))

--- a/lemarche/perimeters/tests.py
+++ b/lemarche/perimeters/tests.py
@@ -88,3 +88,6 @@ class PerimeterQuerysetTest(TestCase):
         self.assertEqual(qs.first(), self.perimeter_city)
         qs = Perimeter.objects.post_code_search("38")
         self.assertEqual(qs.count(), 2)
+        qs = Perimeter.objects.post_code_search("38185", include_insee_code=True)
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first(), self.perimeter_city)


### PR DESCRIPTION
### Quoi ?

Suite de #1264

Rajouté une option pour pouvoir aussi inclure l'`insee_code` dans le filtre sur les `post_code`