### PR TITLE
fix(Session): Stockage des sessions côté serveur

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -399,8 +399,9 @@ REDIS_DB = env.int("REDIS_DB", 1)
 REDIS_URL = env.str("REDIS_URL", "localhost")
 REDIS_PORT = env.int("REDIS_PORT", 6379)
 REDIS_PASSWORD = env.str("REDIS_PASSWORD", "")
+REDIS_CACHE_ENABLED = env.bool("REDIS_CACHE_ENABLED", False)
 
-if env.bool("REDIS_CACHE_ENABLED", False):
+if REDIS_CACHE_ENABLED:
     # use Redis cache backend (also needed for session storage perf)
     CACHES = {
         "default": {
@@ -437,7 +438,7 @@ SECURE_HSTS_SECONDS = 30
 
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", False)
 
-if env.bool("REDIS_CACHE_ENABLED", False):
+if REDIS_CACHE_ENABLED:
     # Session reads use the cache, or the database if the data has been evicted from the cache.
     # https://docs.djangoproject.com/en/5.0/topics/http/sessions/#using-database-backed-sessions
     SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -388,6 +388,36 @@ BREVO_TENDERS_MIN_AMOUNT_TO_SEND = env.int("BREVO_TENDERS_MIN_AMOUNT_TO_SEND", 3
 HUBSPOT_API_KEY = env.str("HUBSPOT_API_KEY", "set-it")
 HUBSPOT_IS_ACTIVATED = env.bool("HUBSPOT_IS_ACTIVATED", False)
 
+# Caching
+# https://docs.djangoproject.com/en/4.0/topics/cache/
+# ------------------------------------------------------------------------------
+
+# Redis database to use with async (must be different for each environement)
+# 1 <= REDIS_DB <= 100 (number of dbs available on CleverCloud)
+REDIS_DB = env.int("REDIS_DB", 1)
+# Complete URL (containing the instance password)
+REDIS_URL = env.str("REDIS_URL", "localhost")
+REDIS_PORT = env.int("REDIS_PORT", 6379)
+REDIS_PASSWORD = env.str("REDIS_PASSWORD", "")
+
+if env.bool("REDIS_CACHE_ENABLED", False):
+    # use Redis cache backend (also needed for session storage perf)
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": f"redis://:{REDIS_PASSWORD}@{REDIS_URL}:{REDIS_PORT}",
+        }
+    }
+else:
+    # Simple DB caching, we need it for Select2 (don't ask me why...)
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+            "LOCATION": "django_cache",
+        }
+    }
+
+SELECT2_CACHE_BACKEND = "default"
 
 # Security
 # ------------------------------------------------------------------------------
@@ -407,13 +437,19 @@ SECURE_HSTS_SECONDS = 30
 
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", False)
 
-SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+if env.bool("REDIS_CACHE_ENABLED", False):
+    # Session reads use the cache, or the database if the data has been evicted from the cache.
+    # https://docs.djangoproject.com/en/5.0/topics/http/sessions/#using-database-backed-sessions
+    SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
 
 SESSION_COOKIE_HTTPONLY = True
 
 SESSION_COOKIE_SECURE = True
 
-SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_COOKIE_AGE = env.int("SESSION_COOKIE_AGE", 604800)  # one week
+
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 
 X_FRAME_OPTIONS = "DENY"
 
@@ -650,17 +686,6 @@ MESSAGE_TAGS = {
 # Async Configuration Options: Huey
 # Workers are run in prod via `CC_WORKER_COMMAND = django-admin run_huey`.
 # ------------------------------------------------------------------------------
-
-# Redis server URL:
-# Provided by the Redis addon (itou-redis)
-# Redis database to use with async (must be different for each environement)
-# 1 <= REDIS_DB <= 100 (number of dbs available on CleverCloud)
-REDIS_DB = env.int("REDIS_DB", 1)
-# Complete URL (containing the instance password)
-REDIS_URL = env.str("REDIS_URL", "localhost")
-REDIS_PORT = env.int("REDIS_PORT", 6379)
-REDIS_PASSWORD = env.str("REDIS_PASSWORD", "")
-
 CONNECTION_MODES_HUEY = {
     # immediate mode
     "direct": {"immediate": True},
@@ -699,21 +724,6 @@ if CONNECTION_MODE_TASKS in ("sqlite", "redis") and CC_WORKER_ENV:
         "connection": CONF_HUEY.get("connection"),
         "consumer": {"workers": 2, "worker_type": "thread"},
     }
-
-
-# Caching
-# https://docs.djangoproject.com/en/4.0/topics/cache/
-# ------------------------------------------------------------------------------
-
-# Simple DB caching, we need it for Select2 (don't ask me why...)
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "django_cache",
-    }
-}
-
-SELECT2_CACHE_BACKEND = "default"
 
 
 # Logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - env.docker.local
     ports:
       - "${POSTGRESQL_PORT:-5432}:5432"
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - 6379:6379
   app:
     build:
         context: .

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -58,7 +58,7 @@ class SiaeSearchNumQueriesTest(TestCase):
 
     def test_search_num_queries(self):
         url = reverse("siae:search_results")
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(12):
             response = self.client.get(url)
             siaes = list(response.context["siaes"])
             self.assertEqual(len(siaes), 20)


### PR DESCRIPTION
### Quoi ?

Changement de la façon de stocker les sessions.

### Pourquoi ?

Le stockage de session dans le cookie (`signed_cookies`) semble être la source de multiples erreurs:
- erreur CSRF dans le dépôt de besoin
- erreur 502 Bad gateway dans le dépôt de besoin
- prévisualisation des pages Wagtail
- erreur CSRF dans la validation des besoins

Les limitations de `signed_cookies` sont désormais décrite [ici](https://docs.djangoproject.com/en/5.0/topics/http/sessions/#using-cookie-based-sessions).

### Comment ?

En changeant le `SESSION_ENGINE` au profit de `cached_db`. Les écritures de sessions sont appliquées à la fois au cache et à la base de données et les lectures de sessions utilisent d’abord le cache.

### Autre

L'activation du cache pour la session est soumis à la variable d'environnement `REDIS_CACHE_ENABLED`. Si elle n'est pas fournit, les sessions sont stockées uniquement en base de données (comportement par défaut de Django). 