### PR TITLE
fix(wagtail): add csrf trusted origins to fix wagtail preview

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -14,6 +14,10 @@ ALLOWED_HOSTS = [
     "bitoubi-django.cleverapps.io",
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    "https://lemarche.inclusion.beta.gouv.fr",
+]
+
 SECURE_SSL_REDIRECT = env.str("SECURE_SSL_REDIRECT", True)
 
 MEDIA_URL = f"https://{S3_STORAGE_ENDPOINT_DOMAIN}/"  # noqa


### PR DESCRIPTION
### Quoi ?

Ajout du nom de domaine de production aux domaines de confiance CSRF.

### Pourquoi ?

Pour débloquer la prévisualisation Wagtail en production

### Comment ?

Avec la variable `CSRF_TRUSTED_ORIGINS`.