### PR TITLE
feat(Structures): SiaeActivity : afficher les activités dans la fiche

### DIFF
--- a/lemarche/templates/dashboard/_siae_activity_card.html
+++ b/lemarche/templates/dashboard/_siae_activity_card.html
@@ -1,4 +1,4 @@
-{% load static siae_sectors_display %}
+{% load siae_sectors_display %}
 
 <div class="bg-white d-block rounded-lg shadow-lg p-3 mb-3">
     <div class="row">

--- a/lemarche/templates/dashboard/siae_edit_activities.html
+++ b/lemarche/templates/dashboard/siae_edit_activities.html
@@ -17,7 +17,7 @@
     <div class="row mb-3 mb-lg-5">
         {% for activity in siae.activities.all %}
             <div class="col-12 col-lg-8">
-                {% include "dashboard/_siae_activity_card.html" with activity=activity %}
+                {% include "siaes/_siae_activity_card.html" with activity=activity %}
             </div>
         {% endfor %}
     </div>

--- a/lemarche/templates/dashboard/siae_edit_activities_create.html
+++ b/lemarche/templates/dashboard/siae_edit_activities_create.html
@@ -41,7 +41,7 @@
                     {% if activity %}
                         <div class="row mb-3 mb-lg-5">
                             <div class="col-12 col-lg-8">
-                                {% include "dashboard/_siae_activity_card.html" with activity=activity hide_actions=True %}
+                                {% include "siaes/_siae_activity_card.html" with activity=activity hide_actions=True %}
                             </div>
                         </div>
                     {% endif %}

--- a/lemarche/templates/siaes/_siae_activity_card.html
+++ b/lemarche/templates/siaes/_siae_activity_card.html
@@ -3,22 +3,7 @@
 <div class="bg-white d-block rounded-lg shadow-lg p-3 mb-3">
     <div class="row">
         <div class="col-12 col-lg-8">
-            <p class="h4 lh-sm">{{ activity.sector_group }}</p>
-
-            <ul>
-                {% siae_sectors_display activity display_max=6 output_format='li' %}
-            </ul>
-
-            <p class="mb-0">
-                <i class="ri-briefcase-4-line mr-1"></i>
-                <span class="sr-only">Type(s) de prestation :</span>
-                <span>{{ activity.presta_type_display }}</span>
-            </p>
-            <p class="mb-0">
-                <i class="ri-map-2-line"></i>
-                <span class="sr-only">Intervient sur : {{ siae.geo_range_pretty_title }}</span>
-                <span>{{ siae.geo_range_pretty_display }}</span>
-            </p>
+            {% include "siaes/_siae_activity_content.html" with activity=activity with_collapse=with_collapse %}
         </div>
 
         {% if not hide_actions %}

--- a/lemarche/templates/siaes/_siae_activity_content.html
+++ b/lemarche/templates/siaes/_siae_activity_content.html
@@ -1,0 +1,18 @@
+{% load siae_sectors_display %}
+
+<p class="h4 lh-sm">{{ activity.sector_group }}</p>
+
+<ul>
+    {% siae_sectors_display activity display_max=6 output_format='li' %}
+</ul>
+
+<p class="mb-0">
+    <i class="ri-briefcase-4-line mr-1"></i>
+    <span class="sr-only">Type(s) de prestation :</span>
+    <span>{{ activity.presta_type_display }}</span>
+</p>
+<p class="mb-0">
+    <i class="ri-map-2-line"></i>
+    <span class="sr-only">Intervient sur : {{ siae.geo_range_pretty_title }}</span>
+    <span>{{ siae.geo_range_pretty_display }}</span>
+</p>

--- a/lemarche/templates/siaes/_siae_activity_content.html
+++ b/lemarche/templates/siaes/_siae_activity_content.html
@@ -1,18 +1,28 @@
 {% load siae_sectors_display %}
 
-<p class="h4 lh-sm">{{ activity.sector_group }}</p>
-
-<ul>
-    {% siae_sectors_display activity display_max=6 output_format='li' %}
-</ul>
-
-<p class="mb-0">
-    <i class="ri-briefcase-4-line mr-1"></i>
-    <span class="sr-only">Type(s) de prestation :</span>
-    <span>{{ activity.presta_type_display }}</span>
+<p class="h4 lh-sm">
+    {% if with_collapse %}
+        <a href="#collapseSiaeActiviyContent{{ activity.id }}" class="text-decoration-none has-collapse-caret collapsed" data-toggle="collapse">
+            {{ activity.sector_group }}
+        </a>
+    {% else %}
+        {{ activity.sector_group }}
+    {% endif %}
 </p>
-<p class="mb-0">
-    <i class="ri-map-2-line"></i>
-    <span class="sr-only">Intervient sur : {{ siae.geo_range_pretty_title }}</span>
-    <span>{{ siae.geo_range_pretty_display }}</span>
-</p>
+
+<div id="collapseSiaeActiviyContent{{ activity.id }}" class="{% if with_collapse %}pb-3 collapse{% endif %}">
+    <ul style="padding-left:1.5rem">
+        {% siae_sectors_display activity display_max=6 output_format='li' %}
+    </ul>
+
+    <p class="mb-0">
+        <i class="ri-briefcase-4-line mr-1"></i>
+        <span class="sr-only">Type(s) de prestation :</span>
+        <span>{{ activity.presta_type_display }}</span>
+    </p>
+    <p class="mb-0">
+        <i class="ri-map-2-line"></i>
+        <span class="sr-only">Intervient sur : {{ siae.geo_range_pretty_title }}</span>
+        <span>{{ siae.geo_range_pretty_display }}</span>
+    </p>
+</div>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -91,11 +91,18 @@
                             </div>
                             <div class="il-r">
                                 <h3 class="h2 mb-1 mt-1">Secteurs d'activité</h3>
-                                <ul>
-                                    {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
-                                </ul>
-                                {% if not siae.sector_count %}
-                                    <p>Non renseigné</p>
+                                {% if user.is_authenticated and user.is_admin %}
+                                    {% for activity in siae.activities.all %}
+                                        {% include "siaes/_siae_activity_content.html" with activity=activity %}
+                                    {% endfor %}
+                                {% else %}
+                                    {% if not siae.sector_count %}
+                                        <p>Non renseigné</p>
+                                    {% else %}
+                                        <ul>
+                                            {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
+                                        </ul>
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         </div>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -93,7 +93,7 @@
                                 <h3 class="h2 mb-1 mt-1">Secteurs d'activité</h3>
                                 {% if user.is_authenticated and user.is_admin %}
                                     {% for activity in siae.activities.all %}
-                                        {% include "siaes/_siae_activity_content.html" with activity=activity %}
+                                        {% include "siaes/_siae_activity_content.html" with activity=activity with_collapse=True %}
                                     {% endfor %}
                                 {% else %}
                                     {% if not siae.sector_count %}
@@ -129,7 +129,7 @@
                                             </li>
                                         {% endfor %}
                                         </ul>
-                                        <div class="collapse" id="collapseMoreRefClients">
+                                        <div id="collapseMoreRefClients" class="collapse">
                                             <ul class="list-unstyled row row-cols-3 align-items-center mb-0">
                                             {% for image in siae.client_references.all|slice:"6:" %}
                                                 <li class="col">


### PR DESCRIPTION
### Quoi ?

Dans la continuité de #1266, afficher les activités coté fiche structure.

J'ai réutilisé le template `_siae_activity_card.html` existant

### Captures d'écran

![Screenshot from 2024-06-26 16-45-06](https://github.com/gip-inclusion/le-marche/assets/7147385/604e399d-d394-4a37-ae85-81f0a098d62b)
