### PR TITLE
refactor(Emails): enlève les logs en double suite à TemplateTransactionalSendLogs

### DIFF
--- a/lemarche/siaes/tasks.py
+++ b/lemarche/siaes/tasks.py
@@ -1,5 +1,4 @@
 from django.urls import reverse_lazy
-from django.utils import timezone
 from huey.contrib.djhuey import task
 
 from lemarche.conversations.models import TemplateTransactional
@@ -47,6 +46,8 @@ def send_completion_reminder_email_to_siae(siae):
                 "SIAE_USER_FIRST_NAME": siae_user.first_name,
                 "SIAE_ID": siae.id,
                 "SIAE_NAME": siae.name_display,
+                "SIAE_CONTACT_EMAIL": siae.contact_email,
+                "SIAE_SECTOR_COUNT": siae.sector_count,
                 "SIAE_URL": get_object_share_url(siae),
                 "SIAE_EDIT_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard_siaes:siae_edit_contact', args=[siae.slug])}",  # noqa
             }
@@ -58,18 +59,3 @@ def send_completion_reminder_email_to_siae(siae):
                 recipient_content_object=siae_user,
                 parent_content_object=siae,
             )
-
-        # log email
-        log_item = {
-            "action": "email_completion_reminder",
-            "email_template": email_template.code,
-            "email_to": recipient_list,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-            "metadata": {
-                "sector_count": siae.sector_count,
-                "contact_email": True if len(siae.contact_email) else False,
-            },
-        }
-        siae.logs.append(log_item)
-        siae.save()

--- a/lemarche/www/dashboard_siaes/tasks.py
+++ b/lemarche/www/dashboard_siaes/tasks.py
@@ -1,5 +1,4 @@
 from django.urls import reverse_lazy
-from django.utils import timezone
 
 from lemarche.conversations.models import TemplateTransactional
 from lemarche.utils.emails import whitelist_recipient_list
@@ -35,17 +34,6 @@ def send_siae_user_request_email_to_assignee(siae_user_request):
             parent_content_object=siae_user_request,
         )
 
-        # log email
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        siae_user_request.logs.append(log_item)
-        siae_user_request.save()
-
 
 def send_siae_user_request_response_email_to_initiator(siae_user_request):
     """
@@ -80,17 +68,6 @@ def send_siae_user_request_response_email_to_initiator(siae_user_request):
                 recipient_content_object=siae_user_request.initiator,
                 parent_content_object=siae_user_request,
             )
-
-            # log email
-            log_item = {
-                "action": "email_sent",
-                "email_template": email_template.code,
-                "email_to": recipient_email,
-                # "email_body": email_body,
-                "email_timestamp": timezone.now().isoformat(),
-            }
-            siae_user_request.logs.append(log_item)
-            siae_user_request.save()
 
 
 def send_siae_user_request_reminder_3_days_emails(siae_user_request):
@@ -129,17 +106,6 @@ def send_siae_user_request_reminder_3_days_email_to_assignee(siae_user_request):
             parent_content_object=siae_user_request,
         )
 
-        # log email
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        siae_user_request.logs.append(log_item)
-        siae_user_request.save()
-
 
 def send_siae_user_request_reminder_3_days_email_to_initiator(siae_user_request):
     email_template = TemplateTransactional.objects.get(code="SIAEUSERREQUEST_REMINDER_1_INITIATOR")
@@ -165,17 +131,6 @@ def send_siae_user_request_reminder_3_days_email_to_initiator(siae_user_request)
             recipient_content_object=siae_user_request.initiator,
             parent_content_object=siae_user_request,
         )
-
-        # log email
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        siae_user_request.logs.append(log_item)
-        siae_user_request.save()
 
 
 def send_siae_user_request_reminder_8_days_emails(siae_user_request):
@@ -214,17 +169,6 @@ def send_siae_user_request_reminder_8_days_email_to_assignee(siae_user_request):
             parent_content_object=siae_user_request,
         )
 
-        # log email
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        siae_user_request.logs.append(log_item)
-        siae_user_request.save()
-
 
 def send_siae_user_request_reminder_8_days_email_to_initiator(siae_user_request):
     email_template = TemplateTransactional.objects.get(code="SIAEUSERREQUEST_REMINDER_2_INITIATOR")
@@ -251,14 +195,3 @@ def send_siae_user_request_reminder_8_days_email_to_initiator(siae_user_request)
             recipient_content_object=siae_user_request.initiator,
             parent_content_object=siae_user_request,
         )
-
-        # log email
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        siae_user_request.logs.append(log_item)
-        siae_user_request.save()

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -144,6 +144,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, re
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": tender_url,
             "TENDER_NOT_INTERESTED_URL": tender_not_interested_url,
+            "TENDERSIAE_ID": tendersiae.id,
         }
 
         email_template.send_transactional_email(
@@ -157,14 +158,6 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, re
 
         # update tendersiae
         tendersiae.email_send_date = timezone.now()
-        log_item = {
-            "action": "email_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            "email_subject": email_subject,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        tendersiae.logs.append(log_item)
         tendersiae.save()
 
 
@@ -178,7 +171,7 @@ def send_tender_emails_to_partners(tender: Tender):
     if partners_count > 0:
         email_subject = f"{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
         for partner in partners:
-            send_tender_email_to_partner(email_subject, tender, partner)
+            send_tender_email_to_partner(tender, partner, email_subject)
 
             # log email batch
             log_item = {
@@ -191,7 +184,7 @@ def send_tender_emails_to_partners(tender: Tender):
             tender.save()
 
 
-def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: PartnerShareTender):
+def send_tender_email_to_partner(tender: Tender, partner: PartnerShareTender, email_subject: str):
     recipient_list = whitelist_recipient_list(partner.contact_email_list)
     if recipient_list:
         variables = {
@@ -291,6 +284,7 @@ def send_tender_contacted_reminder_email_to_siae(tendersiae: TenderSiae, email_t
             "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
+            "TENDERSIAE_ID": tendersiae.id,
         }
 
         email_template.send_transactional_email(
@@ -300,17 +294,6 @@ def send_tender_contacted_reminder_email_to_siae(tendersiae: TenderSiae, email_t
             recipient_content_object=tendersiae.siae,
             parent_content_object=tendersiae,
         )
-
-        # log email
-        log_item = {
-            "action": f"email_siae_contacted_reminder_{days_since_email_send_date}d",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        tendersiae.logs.append(log_item)
-        tendersiae.save()
 
 
 def send_tender_interested_reminder_email_to_siaes(
@@ -368,6 +351,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
+            "TENDERSIAE_ID": tendersiae.id,
         }
 
         email_template.send_transactional_email(
@@ -378,44 +362,33 @@ def send_tender_interested_reminder_email_to_siae(
             parent_content_object=tendersiae,
         )
 
-        # log email
-        log_item = {
-            "action": f"email_siae_interested_reminder_{days_since_detail_contact_click_date}d",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        tendersiae.logs.append(log_item)
-        tendersiae.save()
-
 
 def send_confirmation_published_email_to_author(tender: Tender):
     """
     Send email to the author when the tender is published to the siaes
     """
-    if not tender.contact_notifications_disabled:
-        email_template = TemplateTransactional.objects.get(code="TENDERS_AUTHOR_CONFIRMATION_VALIDATED")
-        recipient_list = whitelist_recipient_list([tender.author.email])
-        if len(recipient_list):
-            recipient_email = recipient_list[0]
-            recipient_name = tender.author.full_name
+    email_template = TemplateTransactional.objects.get(code="TENDERS_AUTHOR_CONFIRMATION_VALIDATED")
+    recipient_list = whitelist_recipient_list([tender.author.email])
+    if len(recipient_list):
+        recipient_email = recipient_list[0]
+        recipient_name = tender.author.full_name
 
-            variables = {
-                "TENDER_ID": tender.id,
-                "TENDER_TITLE": tender.title,
-                "TENDER_KIND": tender.get_kind_display(),
-                "TENDER_KIND_LOWER": tender.get_kind_display().lower(),
-                "TENDER_SECTORS": tender.sectors_list_string(),
-                "TENDER_PERIMETERS": tender.location_display,
-                "TENDER_AMOUNT": tender.amount_display,
-                "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
-                "TENDER_AUTHOR_ID": tender.author.id,
-                "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
-                "TENDER_NB_MATCH": tender.siaes.count(),
-                "TENDER_URL": get_object_share_url(tender),
-            }
+        variables = {
+            "TENDER_ID": tender.id,
+            "TENDER_TITLE": tender.title,
+            "TENDER_KIND": tender.get_kind_display(),
+            "TENDER_KIND_LOWER": tender.get_kind_display().lower(),
+            "TENDER_SECTORS": tender.sectors_list_string(),
+            "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_AMOUNT": tender.amount_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
+            "TENDER_AUTHOR_ID": tender.author.id,
+            "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
+            "TENDER_NB_MATCH": tender.siaes.count(),
+            "TENDER_URL": get_object_share_url(tender),
+        }
 
+        if not tender.contact_notifications_disabled:
             email_template.send_transactional_email(
                 recipient_email=recipient_email,
                 recipient_name=recipient_name,
@@ -423,17 +396,6 @@ def send_confirmation_published_email_to_author(tender: Tender):
                 recipient_content_object=tender.author,
                 parent_content_object=tender,
             )
-
-            # log email
-            log_item = {
-                "action": "email_publish_confirmation",
-                "email_template": email_template.code,
-                "email_to": recipient_email,
-                # "email_body": email_body,
-                "email_timestamp": timezone.now().isoformat(),
-            }
-            tender.logs.append(log_item)
-            tender.save()
 
 
 def send_siae_interested_email_to_author(tender: Tender):
@@ -472,7 +434,7 @@ def send_siae_interested_email_to_author(tender: Tender):
 
         if should_send_email:
             recipient_list = whitelist_recipient_list([tender.author.email])  # tender.contact_email ?
-            if len(recipient_list) and not tender.contact_notifications_disabled:
+            if len(recipient_list):
                 recipient_email = recipient_list[0]
                 recipient_name = tender.author.full_name
 
@@ -484,24 +446,14 @@ def send_siae_interested_email_to_author(tender: Tender):
                     "TENDER_SIAE_INTERESTED_LIST_URL": f"{get_object_share_url(tender)}/prestataires",  # noqa
                 }
 
-                email_template.send_transactional_email(
-                    recipient_email=recipient_email,
-                    recipient_name=recipient_name,
-                    variables=variables,
-                    recipient_content_object=tender.author,
-                    parent_content_object=tender,
-                )
-
-                # log email
-                log_item = {
-                    "action": "email_siae_interested",
-                    "email_template": email_template.code,
-                    "email_to": recipient_email,
-                    # "email_body": email_body,
-                    "email_timestamp": timezone.now().isoformat(),
-                }
-                tender.logs.append(log_item)
-                tender.save()
+                if not tender.contact_notifications_disabled:
+                    email_template.send_transactional_email(
+                        recipient_email=recipient_email,
+                        recipient_name=recipient_name,
+                        variables=variables,
+                        recipient_content_object=tender.author,
+                        parent_content_object=tender,
+                    )
 
 
 def notify_admin_tender_created(tender: Tender):
@@ -534,7 +486,7 @@ def notify_admin_tender_created(tender: Tender):
 
 def send_tenders_author_feedback_or_survey(tender: Tender, kind="feedback_30d"):
     recipient_list = whitelist_recipient_list([tender.author.email])
-    if len(recipient_list) and not tender.contact_notifications_disabled:
+    if len(recipient_list):
         recipient_email = recipient_list[0]
         recipient_name = tender.author.full_name
 
@@ -564,24 +516,14 @@ def send_tenders_author_feedback_or_survey(tender: Tender, kind="feedback_30d"):
         else:
             email_template = TemplateTransactional.objects.get(code="TENDERS_AUTHOR_FEEDBACK_30D")
 
-        email_template.send_transactional_email(
-            recipient_email=recipient_email,
-            recipient_name=recipient_name,
-            variables=variables,
-            recipient_content_object=tender.author,
-            parent_content_object=tender,
-        )
-
-        # log email
-        log_item = {
-            "action": f"email_{kind}_sent",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            # "email_body": email_body,
-            "email_timestamp": timezone.now().isoformat(),
-        }
-        tender.logs.append(log_item)
-        tender.save()
+        if not tender.contact_notifications_disabled:
+            email_template.send_transactional_email(
+                recipient_email=recipient_email,
+                recipient_name=recipient_name,
+                variables=variables,
+                recipient_content_object=tender.author,
+                parent_content_object=tender,
+            )
 
 
 def send_tenders_siaes_survey(tender: Tender, kind="transactioned_question_7d"):
@@ -648,15 +590,6 @@ def send_tenders_siae_survey(tendersiae: TenderSiae, kind="transactioned_questio
 
             # update tendersiae
             tendersiae.survey_transactioned_send_date = timezone.now()
-            # log email
-            log_item = {
-                "action": f"email_{kind}_sent",
-                "email_template": email_template.code,
-                "email_to": recipient_email,
-                # "email_body": email_body,
-                "email_timestamp": timezone.now().isoformat(),
-            }
-            tendersiae.logs.append(log_item)
             tendersiae.save()
 
 
@@ -688,7 +621,7 @@ def notify_admin_siae_wants_cocontracting(tender: Tender, siae: Siae):
 def send_super_siaes_email_to_author(tender: Tender, top_siaes: list[Siae]):
     email_template = TemplateTransactional.objects.get(code="TENDERS_AUTHOR_SUPER_SIAES")
     recipient_list = whitelist_recipient_list([tender.author.email])
-    if len(recipient_list) and not tender.contact_notifications_disabled:
+    if len(recipient_list):
         recipient_email = recipient_list[0]
         recipient_name = tender.author.full_name
 
@@ -717,21 +650,11 @@ def send_super_siaes_email_to_author(tender: Tender, top_siaes: list[Siae]):
                 }
             )
 
-        email_template.send_transactional_email(
-            recipient_email=recipient_email,
-            recipient_name=recipient_name,
-            variables=variables,
-            recipient_content_object=tender.author,
-            parent_content_object=tender,
-        )
-
-        # log email
-        log_item = {
-            "action": "email_super_siaes",
-            "email_template": email_template.code,
-            "email_to": recipient_email,
-            "email_timestamp": timezone.now().isoformat(),
-            "email_variables": variables,
-        }
-        tender.logs.append(log_item)
-        tender.save()
+        if not tender.contact_notifications_disabled:
+            email_template.send_transactional_email(
+                recipient_email=recipient_email,
+                recipient_name=recipient_name,
+                variables=variables,
+                recipient_content_object=tender.author,
+                parent_content_object=tender,
+            )

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -79,13 +79,14 @@ def send_tender_emails_to_siaes(tender: Tender):
     siae_users_send_count = 0
 
     for siae in siaes:
+        tendersiae = TenderSiae.objects.get(tender=tender, siae=siae)
         # send to siae 'contact_email'
-        send_tender_email_to_siae(tender, siae, email_subject)
+        send_tender_email_to_siae(tendersiae, email_subject)
         # also send to the siae's user(s) 'email' (if its value is different)
         for user in siae.users.all():
             siae_users_count += 1
             if user.email != siae.contact_email:
-                send_tender_email_to_siae(tender, siae, email_subject, recipient_to_override=user)
+                send_tender_email_to_siae(tendersiae, email_subject, recipient_to_override=user)
                 siae_users_send_count += 1
 
     # log email batch
@@ -112,36 +113,37 @@ def send_tender_emails_to_siaes(tender: Tender):
 
 
 # @task()
-def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, recipient_to_override: User = None):
+def send_tender_email_to_siae(tendersiae: TenderSiae, email_subject: str, recipient_to_override: User = None):
     email_template = TemplateTransactional.objects.get(code="TENDERS_SIAE_PRESENTATION")
-    tendersiae = TenderSiae.objects.get(tender=tender, siae=siae)
     # override siae.contact_email if email_to_override is provided
-    email_to = recipient_to_override.email if recipient_to_override else siae.contact_email
+    email_to = recipient_to_override.email if recipient_to_override else tendersiae.siae.contact_email
     recipient_list = whitelist_recipient_list([email_to])
     if len(recipient_list):
         recipient_email = recipient_list[0]
-        recipient_name = siae.contact_email_name_display
+        recipient_name = tendersiae.siae.contact_email_name_display
 
-        tender_url = f"{get_object_share_url(tender)}?siae_id={siae.id}"
-        tender_not_interested_url = f"{get_object_share_url(tender)}?siae_id={siae.id}&not_interested=True"
+        tender_url = f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}"
+        tender_not_interested_url = (
+            f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&not_interested=True"
+        )
         if recipient_to_override:
             tender_url += f"&user_id={recipient_to_override.id}"
             tender_not_interested_url += f"&user_id={recipient_to_override.id}"
 
         variables = {
-            "SIAE_ID": siae.id,
-            "SIAE_CONTACT_FIRST_NAME": siae.contact_first_name,
-            "SIAE_SECTORS": siae.sectors_list_string(),
-            "SIAE_PERIMETER": siae.geo_range_pretty_display,
-            "TENDER_ID": tender.id,
-            "TENDER_TITLE": tender.title,
-            "TENDER_AUTHOR_COMPANY": tender.author.company_name,
-            "TENDER_KIND": tender.get_kind_display(),
-            "TENDER_KIND_LOWER": tender.get_kind_display().lower(),
-            "TENDER_SECTORS": tender.sectors_list_string(),
-            "TENDER_PERIMETERS": tender.location_display,
-            "TENDER_AMOUNT": tender.amount_display,
-            "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
+            "SIAE_ID": tendersiae.siae.id,
+            "SIAE_CONTACT_FIRST_NAME": tendersiae.siae.contact_first_name,
+            "SIAE_SECTORS": tendersiae.siae.sectors_list_string(),
+            "SIAE_PERIMETER": tendersiae.siae.geo_range_pretty_display,
+            "TENDER_ID": tendersiae.tender.id,
+            "TENDER_TITLE": tendersiae.tender.title,
+            "TENDER_AUTHOR_COMPANY": tendersiae.tender.author.company_name,
+            "TENDER_KIND": tendersiae.tender.get_kind_display(),
+            "TENDER_KIND_LOWER": tendersiae.tender.get_kind_display().lower(),
+            "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
+            "TENDER_PERIMETERS": tendersiae.tender.location_display,
+            "TENDER_AMOUNT": tendersiae.tender.amount_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": tender_url,
             "TENDER_NOT_INTERESTED_URL": tender_not_interested_url,
             "TENDERSIAE_ID": tendersiae.id,
@@ -152,7 +154,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, re
             recipient_name=recipient_name,
             variables=variables,
             subject=email_subject,
-            recipient_content_object=recipient_to_override if recipient_to_override else siae,
+            recipient_content_object=recipient_to_override if recipient_to_override else tendersiae.siae,
             parent_content_object=tendersiae,
         )
 
@@ -188,6 +190,7 @@ def send_tender_email_to_partner(tender: Tender, partner: PartnerShareTender, em
     recipient_list = whitelist_recipient_list(partner.contact_email_list)
     if recipient_list:
         variables = {
+            "PARTNER_ID": partner.id,
             "TENDER_ID": tender.id,
             "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
@@ -285,6 +288,7 @@ def send_tender_contacted_reminder_email_to_siae(tendersiae: TenderSiae, email_t
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
             "TENDERSIAE_ID": tendersiae.id,
+            "DAYS_SINCE_EMAIL_SEND_DATE": days_since_email_send_date,
         }
 
         email_template.send_transactional_email(
@@ -352,6 +356,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_object_share_url(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
             "TENDERSIAE_ID": tendersiae.id,
+            "DAYS_SINCE_DETAIL_CONTACT_SEND_DATE": days_since_detail_contact_click_date,
         }
 
         email_template.send_transactional_email(
@@ -567,6 +572,7 @@ def send_tenders_siae_survey(tendersiae: TenderSiae, kind="transactioned_questio
                 "TENDER_AUTHOR_ID": tendersiae.tender.author.id,
                 "TENDER_AUTHOR_FULL_NAME": tendersiae.tender.contact_full_name,
                 "TENDER_AUTHOR_COMPANY": tendersiae.tender.author.company_name,
+                "TENDERSIAE_ID": tendersiae.id,
             }
 
             user_sesame_query_string = sesame_get_query_string(user)  # TODO: sesame scope parameter
@@ -606,6 +612,7 @@ def notify_admin_siae_wants_cocontracting(tender: Tender, siae: Siae):
         "SIAE_NAME": siae.name,
         "SIAE_CONTACT_EMAIL": siae.contact_email,
         "SIAE_SIRET": siae.siret,
+        # "TENDERSIAE_ID": tendersiae.id,
     }
     email_body = render_to_string("tenders/cocontracting_notification_email_admin_body.txt", variables)
     send_mail_async(


### PR DESCRIPTION
### Quoi ?

Suite à https://github.com/gip-inclusion/le-marche/pull/1337
On n'a plus besoin de logger en JSON les metadatas des mails envoyés