### PR TITLE
fix(Emails): Template Transactional: remove result() call

### DIFF
--- a/lemarche/conversations/models.py
+++ b/lemarche/conversations/models.py
@@ -290,14 +290,14 @@ class TemplateTransactional(models.Model):
                 "from_name": from_name,
             }
             if self.source == conversation_constants.SOURCE_MAILJET:
-                result = api_mailjet.send_transactional_email_with_template(**args)
+                api_mailjet.send_transactional_email_with_template(**args)
             elif self.source == conversation_constants.SOURCE_BREVO:
-                result = api_brevo.send_transactional_email_with_template(**args)
+                api_brevo.send_transactional_email_with_template(**args)
             # create log
             self.create_send_log(
                 recipient_content_object=recipient_content_object,
                 parent_content_object=parent_content_object,
-                extra_data={"source": self.source, "args": args, "response": result()},
+                extra_data={"source": self.source, "args": args},  # "response": result()
             )
 
 


### PR DESCRIPTION
Suite à #1337

### Quoi ?

Répare un bug sur la création de logs suite à l'envoi de mails grâce à Template Transactional

### Pourquoi ?

- on suppose que c'est un problème d'asynchrone, huey n'a pas encore renvoyé la réponse, donc `result() = None`
- https://huey.readthedocs.io/en/latest/api.html#Huey.result
- `TypeError : 'NoneType' object is not callable`