### PR TITLE
refactor(Emails): ajout de tests de validation sur les TemplateTransactional

### DIFF
--- a/lemarche/conversations/tests.py
+++ b/lemarche/conversations/tests.py
@@ -108,11 +108,16 @@ class TemplateTransactionalModelSaveTest(TransactionTestCase):
     def setUpTestData(cls):
         pass
 
+    def test_template_transactional_field_rules(self):
+        self.assertRaises(IntegrityError, TemplateTransactionalFactory, source=None)
+
     def test_template_transactional_validation_on_save(self):
         TemplateTransactionalFactory(
             mailjet_id=None, brevo_id=None, source=conversation_constants.SOURCE_BREVO, is_active=False
         )
-        self.assertRaises(IntegrityError, TemplateTransactionalFactory, source=None)
+        TemplateTransactionalFactory(
+            mailjet_id=None, brevo_id=123, source=conversation_constants.SOURCE_BREVO, is_active=True
+        )
         self.assertRaises(
             ValidationError,
             TemplateTransactionalFactory,

--- a/lemarche/conversations/tests.py
+++ b/lemarche/conversations/tests.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 
-from django.test import TestCase
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 
 from lemarche.conversations import constants as conversation_constants
-from lemarche.conversations.factories import ConversationFactory
+from lemarche.conversations.factories import ConversationFactory, TemplateTransactionalFactory
 from lemarche.conversations.models import Conversation, TemplateTransactional
 from lemarche.siaes.factories import SiaeFactory
 
@@ -99,3 +101,31 @@ class TemplateTransactionalModelTest(TestCase):
         self.assertEqual(self.tt_inactive.get_template_id, self.tt_inactive.mailjet_id)
         self.assertEqual(self.tt_active_mailjet.get_template_id, self.tt_active_mailjet.mailjet_id)
         self.assertEqual(self.tt_active_brevo.get_template_id, self.tt_active_brevo.brevo_id)
+
+
+class TemplateTransactionalModelSaveTest(TransactionTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        pass
+
+    def test_template_transactional_validation_on_save(self):
+        TemplateTransactionalFactory(
+            mailjet_id=None, brevo_id=None, source=conversation_constants.SOURCE_BREVO, is_active=False
+        )
+        self.assertRaises(IntegrityError, TemplateTransactionalFactory, source=None)
+        self.assertRaises(
+            ValidationError,
+            TemplateTransactionalFactory,
+            mailjet_id=123,
+            brevo_id=None,
+            source=conversation_constants.SOURCE_BREVO,
+            is_active=True,
+        )
+        self.assertRaises(
+            ValidationError,
+            TemplateTransactionalFactory,
+            mailjet_id=None,
+            brevo_id=123,
+            source=conversation_constants.SOURCE_MAILJET,
+            is_active=True,
+        )

--- a/lemarche/utils/data.py
+++ b/lemarche/utils/data.py
@@ -96,3 +96,18 @@ def phone_number_display(phone_number_model_field):
         return phone_number_model_field.as_e164
     except AttributeError:
         return phone_number_model_field
+
+
+def add_validation_error(dict, key, value):
+    """
+    Build a dictionary of validation errors
+    {"field1": ["error1", "error2"], "field2": ["error1"]}
+    """
+    if key not in dict:
+        dict[key] = value
+    else:
+        if type(dict[key]) is list:
+            dict[key] += [value]
+        if type(dict[key]) is str:
+            dict[key] = [dict[key], value]
+    return dict

--- a/lemarche/www/dashboard_siaes/tests.py
+++ b/lemarche/www/dashboard_siaes/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from lemarche.conversations.models import TemplateTransactional
+from lemarche.conversations.factories import TemplateTransactionalFactory
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.siaes.models import SiaeUser
 from lemarche.users.factories import UserFactory
@@ -19,7 +19,7 @@ class DashboardSiaeSearchAdoptViewTest(TestCase):
         cls.siae_with_user = SiaeFactory()
         cls.siae_with_user.users.add(cls.user_siae)
         cls.siae_without_user = SiaeFactory()
-        TemplateTransactional.objects.create(code="SIAEUSERREQUEST_ASSIGNEE")
+        TemplateTransactionalFactory(code="SIAEUSERREQUEST_ASSIGNEE")
 
     def test_anonymous_user_cannot_adopt_siae(self):
         url = reverse("dashboard_siaes:siae_search_by_siret")


### PR DESCRIPTION
### Quoi ?

Suite à la création du modèle `TemplateTransactional` dans #1018

Ajout de validations à la sauvegarde du modèle, pour s'assurer qu'il n'y a pas d'emails actifs sans mailjet_id ou brevo_id (en fonction de la source)


