### PR TITLE
fix(Entreprises): ajuste le script de rattachement des utilisateurs en fonction de leur email (ajoute un @)

### DIFF
--- a/lemarche/companies/management/commands/set_company_users.py
+++ b/lemarche/companies/management/commands/set_company_users.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         for company in companies_with_email_domain_list:
             company_email_domain_list_users = list()
             for company_email_domain in company.email_domain_list:
-                company_email_domain_users = User.objects.filter(email__iendswith=company_email_domain)
+                company_email_domain_users = User.objects.filter(email__iendswith=f"@{company_email_domain}")
                 company_email_domain_list_users += company_email_domain_users
             if not options["dry_run"]:
                 if options["only_add"]:

--- a/lemarche/companies/management/commands/set_company_users.py
+++ b/lemarche/companies/management/commands/set_company_users.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         for company in companies_with_email_domain_list:
             company_email_domain_list_users = list()
             for company_email_domain in company.email_domain_list:
-                company_email_domain_users = User.objects.filter(email__iendswith=f"@{company_email_domain}")
+                company_email_domain_users = User.objects.has_email_domain(company_email_domain)
                 company_email_domain_list_users += company_email_domain_users
             if not options["dry_run"]:
                 if options["only_add"]:

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -43,6 +43,11 @@ class UserQueryset(models.QuerySet):
     def has_api_key(self):
         return self.filter(api_key__isnull=False)
 
+    def has_email_domain(self, email_domain):
+        if not email_domain.startswith("@"):
+            email_domain = f"@{email_domain}"
+        return self.filter(email__iendswith=email_domain)
+
     def with_siae_stats(self):
         return self.prefetch_related("siaes").annotate(siae_count_annotated=Count("siaes", distinct=True))
 
@@ -113,6 +118,9 @@ class UserManager(BaseUserManager):
 
     def has_api_key(self):
         return self.get_queryset().has_api_key()
+
+    def has_email_domain(self, email_domain):
+        return self.get_queryset().has_email_domain(email_domain)
 
     def with_siae_stats(self):
         return self.get_queryset().with_siae_stats()

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -91,7 +91,8 @@ class UserModelQuerysetTest(TestCase):
         UserFactory(email="test@plateau-urbain.fr")
         self.assertEqual(User.objects.count(), 1 + 2)
         for EMAIL_DOMAIN in ["ain.fr", "@ain.fr"]:
-            self.assertEqual(User.objects.has_email_domain(email_domain=EMAIL_DOMAIN).count(), 1)
+            with self.subTest(email_domain=EMAIL_DOMAIN):
+                self.assertEqual(User.objects.has_email_domain(email_domain=EMAIL_DOMAIN).count(), 1)
 
     def test_with_siae_stats(self):
         user_2 = UserFactory()

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -86,6 +86,13 @@ class UserModelQuerysetTest(TestCase):
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_api_key().count(), 1)
 
+    def test_has_email_domain(self):
+        UserFactory(email="test@ain.fr")
+        UserFactory(email="test@plateau-urbain.fr")
+        self.assertEqual(User.objects.count(), 1 + 2)
+        for EMAIL_DOMAIN in ["ain.fr", "@ain.fr"]:
+            self.assertEqual(User.objects.has_email_domain(email_domain=EMAIL_DOMAIN).count(), 1)
+
     def test_with_siae_stats(self):
         user_2 = UserFactory()
         SiaeFactory(users=[user_2])


### PR DESCRIPTION
### Quoi ?

Suite à #830

Il y avait un border case mal géré, on ne prenait pas toujours en compte l'intégralité du nom de domaine de l'e-mail de l'utilisateur
- ajouté un queryset `has_email_domain` sur le modèle `User`
- ajouté des tests