### PR TITLE
fix(Admin): autoriser la suppression des SiaeUserRequest & TemplateTransactionalSendLog

### DIFF
--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -202,9 +202,6 @@ class TemplateTransactionalSendLogAdmin(admin.ModelAdmin):
     def has_change_permission(self, request, obj=None):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     def recipient_object_id_with_link(self, obj):
         if obj.recipient_content_type and obj.recipient_object_id:
             if obj.recipient_content_type.model == "tender":

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -716,9 +716,6 @@ class SiaeUserRequestAdmin(admin.ModelAdmin):
     def has_change_permission(self, request, obj=None):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     def parent_transactional_send_logs_count_with_link(self, obj):
         url = (
             reverse("admin:conversations_templatetransactionalsendlog_changelist")


### PR DESCRIPTION
### Quoi ?

On les avait mis en readonly, mais ca empêchait leur suppression (en particulier dans le cas d'un CASCADE, où l'on souhaite supprimer un utilisateur)