### PR TITLE
feat: Ajout d'un sitemap

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -98,6 +98,7 @@ DJANGO_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
     "django.contrib.sites",
     "django.contrib.flatpages",
     "django.contrib.gis",

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path
-
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
@@ -23,7 +22,7 @@ urlpatterns = [
     path("profil/listes-dachats/", include("lemarche.www.dashboard_favorites.urls")),
     path("select2/", include("django_select2.urls")),
     # sitemap
-    path("sitemap.xml", sitemap, name="sitemap"), # appears above the default Wagtail page serving route
+    path("sitemap.xml", sitemap, name="sitemap"),  # appears above the default Wagtail page serving route
     # admin blog
     path("cms/", include(wagtailadmin_urls)),
     path("blog/", include("blog.urls")),

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path
+
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail_transfer import urls as wagtailtransfer_urls
 
@@ -20,6 +22,8 @@ urlpatterns = [
     path("profil/reseaux/", include("lemarche.www.dashboard_networks.urls")),
     path("profil/listes-dachats/", include("lemarche.www.dashboard_favorites.urls")),
     path("select2/", include("django_select2.urls")),
+    # sitemap
+    path("sitemap.xml", sitemap, name="sitemap"), # appears above the default Wagtail page serving route
     # admin blog
     path("cms/", include(wagtailadmin_urls)),
     path("blog/", include("blog.urls")),

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -35,6 +35,7 @@
                         <li><a class="fr-footer__top-link" href="https://github.com/gip-inclusion/le-marche" target="_blank" title="Github (lien externe)">Code source</a></li>
                         <li><a class="fr-footer__top-link" href="{% url 'api:home' %}">API</a></li>
                         <li><a class="fr-footer__top-link" href="{% url 'pages:stats' %}">Statistiques</a></li>
+                        <li><a class="fr-footer__top-link" href="{% url 'pages:plan-du-site' %}">Plan du site</a></li>
                     </ul>
                 </div>
             </div>

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -35,7 +35,6 @@
                         <li><a class="fr-footer__top-link" href="https://github.com/gip-inclusion/le-marche" target="_blank" title="Github (lien externe)">Code source</a></li>
                         <li><a class="fr-footer__top-link" href="{% url 'api:home' %}">API</a></li>
                         <li><a class="fr-footer__top-link" href="{% url 'pages:stats' %}">Statistiques</a></li>
-                        <li><a class="fr-footer__top-link" href="{% url 'pages:plan-du-site' %}">Plan du site</a></li>
                     </ul>
                 </div>
             </div>
@@ -68,6 +67,9 @@
         </div>
         <div class="fr-footer__bottom">
             <ul class="fr-footer__bottom-list">
+                <li class="fr-footer__bottom-item">
+                    <a class="fr-footer__bottom-link" href="{% url 'pages:plan-du-site' %}">Plan du site</a>
+                </li>
                 <li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" href="{% url 'pages:accessibilite' %}">Accessibilité : non conforme</a>
                 </li>

--- a/lemarche/templates/pages/plan_du_site.html
+++ b/lemarche/templates/pages/plan_du_site.html
@@ -1,0 +1,19 @@
+{% extends "layouts/base.html" %}
+{% load dsfr_tags process_dict static %}
+
+{% block page_title %}Plan du site{{ block.super }}{% endblock page_title %}
+
+{% block content %}
+<section class="fr-my-6v">
+    <div class="fr-container">
+        <h1>Plan du site</h1>
+        <ul>
+            {% for item in sitemap_urls %}
+                <li style="margin-left: {{ item.depth|add:1 }}em;">
+                    <a href="{{ item.url }}">{{ item.title }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+</section>
+{% endblock content %}

--- a/lemarche/www/pages/tests.py
+++ b/lemarche/www/pages/tests.py
@@ -1,16 +1,13 @@
+import xml.etree.ElementTree as ET
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
+from wagtail.models import Page as WagtailPage, Site
 
-from lemarche.pages.models import Page as FlatPage
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.users.factories import UserFactory
 from lemarche.users.models import User
-
-from wagtail.models import Page as WagtailPage
-from wagtail.models import Site
-
-import xml.etree.ElementTree as ET
 
 
 class PagesHeaderLinkTest(TestCase):

--- a/lemarche/www/pages/tests.py
+++ b/lemarche/www/pages/tests.py
@@ -1,9 +1,16 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
+from lemarche.pages.models import Page as FlatPage
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.users.factories import UserFactory
 from lemarche.users.models import User
+
+from wagtail.models import Page as WagtailPage
+from wagtail.models import Site
+
+import xml.etree.ElementTree as ET
 
 
 class PagesHeaderLinkTest(TestCase):
@@ -133,3 +140,75 @@ class PagesHeaderLinkTest(TestCase):
 
         self.assertContains(response, "Déconnexion")
         self.assertContains(response, reverse("auth:logout"))
+
+
+class SitemapTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # WagtailPage creation for tests
+        root = WagtailPage.get_first_root_node()
+        Site.objects.create(
+            hostname="testserver",
+            root_page=root,
+            is_default_site=True,
+            site_name="testserver",
+        )
+        cls.wagtail_page = root.add_child(
+            instance=WagtailPage(
+                title="Test WagtailPage",
+                slug="test-wagtail-page",
+                depth=2,
+                path="0002",
+                last_published_at=timezone.now(),
+            )
+        )
+
+    def test_sitemap_xml(self):
+        """Test sitemap.xml exists"""
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_sitemap_xml_is_not_empty(self):
+        """Test sitemap is not empty and contains urls"""
+        response = self.client.get(reverse("sitemap"))
+
+        self.assertGreater(len(response.content), 0)
+
+    def test_sitemap_is_valid_xml(self):
+        """Test sitemap is valid XML"""
+        response = self.client.get(reverse("sitemap"))
+
+        try:
+            ET.fromstring(response.content)
+        except ET.ParseError:
+            self.fail("Le sitemap n'est pas dans un format XML valide.")
+
+    def test_sitemap_xml_contains_wagtail_page(self):
+        """Test the sitemap contains the wagtail page URL."""
+        response = self.client.get(reverse("sitemap"))
+        wagtail_page_url = self.wagtail_page.full_url
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"<loc>{wagtail_page_url}</loc>")
+
+    def test_wagtail_page_contains_lastmod_tag(self):
+        """Test the sitemap contains the lastmod tag for the wagtail page."""
+        response = self.client.get(reverse("sitemap"))
+        lastmod = self.wagtail_page.last_published_at.strftime("%Y-%m-%d")
+
+        self.assertContains(response, f"<lastmod>{lastmod}</lastmod>")
+
+    def test_sitemap_html(self):
+        """Test that the HTML sitemap page is accessible"""
+        response = self.client.get("/plan-du-site/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_sitemap_html_contains_wagtail_page(self):
+        """Test that the HTML sitemap contains the wagtail page URL and title"""
+        response = self.client.get("/plan-du-site/")
+        wagtail_page_url = self.wagtail_page.get_full_url()
+        wagtail_page_title = self.wagtail_page.title
+
+        self.assertContains(response, f'href="{wagtail_page_url}"')
+        self.assertContains(response, wagtail_page_title)

--- a/lemarche/www/pages/urls.py
+++ b/lemarche/www/pages/urls.py
@@ -8,6 +8,7 @@ from lemarche.www.pages.views import (
     ImpactCalculatorView,
     PageView,
     SiaeGroupListView,
+    SitemapView,
     SocialImpactBuyersCalculatorView,
     StatsView,
     TrackView,
@@ -83,6 +84,7 @@ urlpatterns = [
     path("cgu/", PageView.as_view(), {"url": "/cgu/"}, name="cgu"),
     path("cgu-api/", PageView.as_view(), {"url": "/cgu-api/"}, name="cgu-api"),
     path("confidentialite/", PageView.as_view(), {"url": "/confidentialite/"}, name="confidentialite"),
+    path("plan-du-site/", SitemapView.as_view(), name="plan-du-site"),
     # Error pages
     path("403/", TemplateView.as_view(template_name="403.html"), name="403"),
     path("404/", TemplateView.as_view(template_name="404.html"), name="404"),

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -30,6 +30,8 @@ from lemarche.www.tenders.tasks import notify_admin_tender_created
 from lemarche.www.tenders.utils import create_tender_from_dict, get_or_create_user_from_anonymous_content
 from lemarche.www.tenders.views import TenderCreateMultiStepView
 
+from wagtail.models import Site as WagtailSite
+
 
 class HomeView(TemplateView):
     template_name = "pages/home.html"
@@ -393,3 +395,21 @@ def trigger_error(request):
     if request.POST:
         raise Exception("%s error: %s" % (request.POST.get("status_code"), request.POST.get("error_message")))
     print(1 / 0)  # Should raise a ZeroDivisionError.
+
+
+class SitemapView(View):
+    def get(self, request):
+        # Récupérer la page d'accueil
+        site = WagtailSite.find_for_request(request)
+        homepage = site.root_page  # Page d'accueil de Wagtail
+
+        # Récupérer toutes les pages descendantes publiées
+        all_pages = homepage.get_descendants(inclusive=True).live()
+
+        # Construire une liste des URLs et titres
+        urls_with_titles = [
+            {"url": page.get_full_url(request=request), "title": page.title, "depth": page.depth - homepage.depth}
+            for page in all_pages
+        ]
+
+        return render(request, "pages/plan_du_site.html", {"sitemap_urls": urls_with_titles})


### PR DESCRIPTION
### Quoi ?

Ajout d'un fichier sitemap.xml et d'un lien 'Plan du site' dans le footer.

### Pourquoi ?

Pour améliorer le référencement naturel

### Comment ?

- En utilisant une vue Sitemap de Wagtail pour récupérer les pages du cms
- En créant un fichier sitemaps.py pour définir des Sitemap custom afin de récupérer les FlatPage et les urls de l'app 'pages'

Le fichier sitemap.xml est accessible à la racine. Une vue SitemapView a été créée pour extraire les données de ce dernier et les afficher dans une page 'Plan du Site'.

### Captures d'écran

sitemap.xml
![sitemap_xml](https://github.com/user-attachments/assets/e9a373c4-e5fc-4f14-a027-dfd0b9002464)

plan-du-site
![plan_du_site](https://github.com/user-attachments/assets/0c8c126d-1cce-4b80-a582-70416b0e6397)

lien dans le footer
![footer](https://github.com/user-attachments/assets/a909c77a-f26a-4903-9297-29b11205b38a)

