### PR TITLE
fix(Admin): Correction de la mise en page des cases à cochées

### DIFF
--- a/lemarche/templates/django/forms/widgets/checkbox_option.html
+++ b/lemarche/templates/django/forms/widgets/checkbox_option.html
@@ -1,0 +1,8 @@
+{% if widget.wrap_label %}
+    <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+    {% endif %}
+    {% include "django/forms/widgets/input.html" %}
+    {% if widget.wrap_label %}
+        {{ widget.label }}
+    </label>
+{% endif %}


### PR DESCRIPTION
### Quoi ?

Correction de la mise en page des cases à cochées

### Pourquoi ?

Le module Django DSFR surcharge les widgets et modifie la structure, même dans l'admin.

### Comment ?

En surchargeant.. avec le widget d'origine !

### Captures d'écran

Avant : 

![image](https://github.com/user-attachments/assets/376221c4-11df-4bef-afe6-a677d1800363)

Après : 

![image](https://github.com/user-attachments/assets/d53d1ac6-d4ad-46c8-834b-99c2622a15a2)