### PR TITLE
fix: Correction de l'affichage des cases à cocher des secteurs d'activités

### DIFF
--- a/lemarche/templates/django/forms/widgets/checkbox_option.html
+++ b/lemarche/templates/django/forms/widgets/checkbox_option.html
@@ -1,8 +1,25 @@
-{% if widget.wrap_label %}
-    <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
-    {% endif %}
-    {% include "django/forms/widgets/input.html" %}
+{% if widget.attrs.dsfr == "dsfr" %}
+    <div class="fr-checkbox-group">
+        {% include "django/forms/widgets/input.html" %}
+        {% if widget.wrap_label %}
+            <label class="fr-label"
+                   {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+                {% if widget.label.label %}
+                    {{ widget.label.label }}
+                    <span class="fr-hint-text">{{ widget.label.help_text }}</span>
+                {% else %}
+                    {{ widget.label }}
+                {% endif %}
+            </label>
+        {% endif %}
+    </div>
+{% else %}
     {% if widget.wrap_label %}
-        {{ widget.label }}
-    </label>
+        <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+        {% endif %}
+        {% include "django/forms/widgets/input.html" %}
+        {% if widget.wrap_label %}
+            {{ widget.label }}
+        </label>
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
### Quoi ?

En voulant corriger l'affichage des cases à cocher dans l'admin, ça a perturbé l'affichage en front

### Captures d'écran

Avant : 

![image](https://github.com/user-attachments/assets/7eb957ce-6d49-4e7a-8b1c-4241ca5282dd)

Après : 

![image](https://github.com/user-attachments/assets/86f18132-32a6-41a2-9a59-de3ea8cc44aa)
