### PR TITLE
feat: Ajout d'attributs de contact pour les acheteurs inscrits

### DIFF
--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -1,5 +1,8 @@
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
+
+from unittest.mock import patch
 
 from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.sectors.factories import SectorFactory
@@ -44,10 +47,28 @@ class TenderCreateApiTest(TestCase):
     def setUpTestData(cls):
         cls.url = reverse("api:tenders-list") + "?token=admin"
         cls.user = UserFactory()
+        cls.user_buyer = UserFactory(kind=User.KIND_BUYER, company_name="Entreprise Buyer")
         cls.user_with_token = UserFactory(email="admin@example.com", api_key="admin")
         cls.perimeter = PerimeterFactory()
         cls.sector_1 = SectorFactory()
         cls.sector_2 = SectorFactory()
+
+    @patch("lemarche.api.tenders.views.get_or_create_user_from_anonymous_content")
+    def setup_mock_user_and_tender_creation(self, mock_get_user, user=None, title="Test Tally", extra_data=None):
+        """Helper method to setup mock user and create a tender."""
+        user = user if user else self.user
+        mock_get_user.return_value = user
+
+        # Tender data
+        tender_data = TENDER_JSON.copy()
+        tender_data["title"] = title
+        tender_data["extra_data"] = extra_data or {}
+
+        # Tender creation
+        response = self.client.post(self.url, data=tender_data, content_type="application/json")
+        tender = Tender.objects.get(title=title)
+
+        return response, tender, user
 
     def test_anonymous_user_cannot_create_tender(self):
         url = reverse("api:tenders-list")
@@ -67,7 +88,7 @@ class TenderCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertIn("slug", response.data.keys())
         tender = Tender.objects.get(title="Test author 1")
-        self.assertEqual(User.objects.count(), 2 + 1)  # created a new user
+        self.assertEqual(User.objects.count(), 3 + 1)  # created a new user
         self.assertEqual(tender.author.email, USER_CONTACT_EMAIL)
         self.assertEqual(tender.status, tender_constants.STATUS_PUBLISHED)
         self.assertEqual(tender.source, tender_constants.SOURCE_API)
@@ -81,7 +102,7 @@ class TenderCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertIn("slug", response.data.keys())
         tender = Tender.objects.get(title="Test author 2")
-        self.assertEqual(User.objects.count(), 3)  # did not create a new user
+        self.assertEqual(User.objects.count(), 4)  # did not create a new user
         self.assertEqual(tender.author, self.user_with_token)
         self.assertEqual(tender.status, tender_constants.STATUS_PUBLISHED)
         self.assertEqual(tender.source, tender_constants.SOURCE_API)
@@ -135,14 +156,45 @@ class TenderCreateApiTest(TestCase):
         response = self.client.post(self.url, data=tender_data)
         self.assertEqual(response.status_code, 400)
 
-    def test_create_tender_with_tally_source(self):
-        tender_data = TENDER_JSON.copy()
-        tender_data["title"] = "Test tally"
-        tender_data["extra_data"] = {"source": "TALLY"}
-        response = self.client.post(self.url, data=tender_data, content_type="application/json")
+    @patch("lemarche.api.tenders.views.add_to_contact_list")
+    def test_create_tender_with_tally_source(self, mock_add_to_contact_list):
+        extra_data = {"source": "TALLY"}
+        response, tender, user = self.setup_mock_user_and_tender_creation(title="Test tally", extra_data=extra_data)
+
+        mock_add_to_contact_list.assert_called_once()
+        args, kwargs = mock_add_to_contact_list.call_args
+
         self.assertEqual(response.status_code, 201)
-        tender = Tender.objects.get(title="Test tally")
         self.assertEqual(tender.source, tender_constants.SOURCE_TALLY)
+        # Check other arguments like user, type, and source
+        self.assertEqual(kwargs["user"], user)
+        self.assertEqual(kwargs["type"], "signup")
+        self.assertEqual(kwargs["source"], user_constants.SOURCE_TALLY_FORM)
+        # Verify that `tender` is an instance of Tender
+        self.assertIsInstance(
+            kwargs.get("tender"), Tender, "Expected an instance of Tender for the 'tender' argument."
+        )
+
+    @patch("lemarche.utils.apis.api_brevo.sib_api_v3_sdk.CreateContact")
+    def test_create_contact_call_has_user_buyer_attributes(self, mock_create_contact):
+        """Test CreateContact call contains user buyer attributes"""
+        extra_data = {"source": "TALLY"}
+        _, tender, user = self.setup_mock_user_and_tender_creation(
+            title="Test tally", user=self.user_buyer, extra_data=extra_data
+        )
+        sectors = tender.sectors.all()
+
+        mock_create_contact.assert_called_once()
+        args, kwargs = mock_create_contact.call_args
+        attributes = kwargs["attributes"]
+
+        self.assertEqual(kwargs["email"], user.email)
+        self.assertIn(settings.BREVO_CL_SIGNUP_BUYER_ID, kwargs["list_ids"])
+        self.assertEqual(attributes["MONTANT_BESOIN_ACHETEUR"], tender.amount)
+        self.assertEqual(attributes["TYPE_BESOIN_ACHETEUR"], tender.kind)
+
+        if sectors.exists():
+            attributes["TYPE_VERTICALE_ACHETEUR"] = sectors.first().name
 
     def test_create_tender_with_different_contact_data(self):
         tender_data = TENDER_JSON.copy()

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -1,8 +1,8 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
-
-from unittest.mock import patch
 
 from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.sectors.factories import SectorFactory
@@ -190,7 +190,7 @@ class TenderCreateApiTest(TestCase):
 
         self.assertEqual(kwargs["email"], user.email)
         self.assertIn(settings.BREVO_CL_SIGNUP_BUYER_ID, kwargs["list_ids"])
-        self.assertEqual(attributes["MONTANT_BESOIN_ACHETEUR"], tender.amount)
+        self.assertEqual(attributes["MONTANT_BESOIN_ACHETEUR"], tender.amount_int)
         self.assertEqual(attributes["TYPE_BESOIN_ACHETEUR"], tender.kind)
 
         if sectors.exists():

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -8,6 +8,7 @@ from lemarche.api.utils import BasicChoiceSerializer, check_user_token
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
 from lemarche.users import constants as user_constants
+from lemarche.utils.emails import add_to_contact_list
 from lemarche.www.tenders.utils import get_or_create_user_from_anonymous_content
 
 
@@ -73,13 +74,14 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         serializer.validated_data.pop("contact_kind", None)
         serializer.validated_data.pop("contact_buyer_kind_detail", None)
         # create Tender
-        serializer.save(
+        tender = serializer.save(
             author=user,
             status=tender_constants.STATUS_PUBLISHED,
             published_at=timezone.now(),
             source=tender_source,
             import_raw_object=self.request.data,
         )
+        add_to_contact_list(user=user, type="signup", source=user_source, tender=tender)
 
 
 class TenderKindViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -54,7 +54,7 @@ def whitelist_recipient_list(recipient_list):
     return [email for email in recipient_list if (email and email.endswith("beta.gouv.fr"))]
 
 
-def add_to_contact_list(user, type: str, source: str = user_constants.SOURCE_SIGNUP_FORM):
+def add_to_contact_list(user, type: str, tender=None, source: str = user_constants.SOURCE_SIGNUP_FORM):
     """Add user to contactlist
 
     Args:
@@ -65,7 +65,7 @@ def add_to_contact_list(user, type: str, source: str = user_constants.SOURCE_SIG
     if type == "signup":
         contact_list_id = api_mailjet.get_mailjet_cl_on_signup(user, source)
         if user.kind == user.KIND_BUYER:
-            api_brevo.create_contact(user=user, list_id=settings.BREVO_CL_SIGNUP_BUYER_ID)
+            api_brevo.create_contact(user=user, list_id=settings.BREVO_CL_SIGNUP_BUYER_ID, tender=tender)
         elif user.kind == user.KIND_SIAE:
             api_brevo.create_contact(user=user, list_id=settings.BREVO_CL_SIGNUP_SIAE_ID)
     elif type == "buyer_search":

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -18,6 +18,7 @@ from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender, TenderStepsData
 from lemarche.users import constants as user_constants
 from lemarche.users.models import User
+from lemarche.utils.emails import add_to_contact_list
 from lemarche.utils.tracker import track
 from lemarche.www.pages.forms import (
     CompanyReferenceCalculatorForm,
@@ -342,6 +343,7 @@ def csrf_failure(request, reason=""):  # noqa C901
         # create tender
         if is_adding:
             tender: Tender = create_tender_from_dict(tender_dict)
+            add_to_contact_list(user=user, type="signup", source=user_constants.SOURCE_TENDER_FORM, tender=tender)
         elif is_update:
             slug = request.path.split("/")[-1]
             tender: Tender = Tender.objects.get(slug=slug)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -293,7 +293,7 @@ class TenderCreateViewTest(TestCase):
 
         self.assertEqual(kwargs["email"], user.email)
         self.assertIn(settings.BREVO_CL_SIGNUP_BUYER_ID, kwargs["list_ids"])
-        self.assertEqual(attributes["MONTANT_BESOIN_ACHETEUR"], tender.amount)
+        self.assertEqual(attributes["MONTANT_BESOIN_ACHETEUR"], tender.amount_int)
         self.assertEqual(attributes["TYPE_BESOIN_ACHETEUR"], tender.kind)
         self.assertIsNone(
             attributes["TYPE_VERTICALE_ACHETEUR"], "Expected TYPE_VERTICALE_ACHETEUR to be None for non-TALLY sources"

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -4,7 +4,6 @@ from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender, TenderQuestion
 from lemarche.users import constants as user_constants
 from lemarche.users.models import User
-from lemarche.utils.emails import add_to_contact_list
 from lemarche.www.auth.tasks import send_new_user_password_reset_link
 
 
@@ -79,7 +78,6 @@ def get_or_create_user_from_anonymous_content(
     )
     if created and settings.BITOUBI_ENV == "prod":
         send_new_user_password_reset_link(user)
-        add_to_contact_list(user=user, type="signup", source=source)
     return user
 
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -18,6 +18,7 @@ from lemarche.users import constants as user_constants
 from lemarche.users.models import User
 from lemarche.utils import constants, settings_context_processors
 from lemarche.utils.data import get_choice
+from lemarche.utils.emails import add_to_contact_list
 from lemarche.utils.mixins import (
     SesameSiaeMemberRequiredMixin,
     SesameTenderAuthorRequiredMixin,
@@ -229,7 +230,6 @@ class TenderCreateMultiStepView(SessionWizardView):
         tender_dict = cleaned_data | {"author": user, "source": tender_constants.SOURCE_FORM}
         is_draft: bool = self.request.POST.get("is_draft", False)
         self.save_instance_tender(tender_dict=tender_dict, form_dict=form_dict, is_draft=is_draft)
-
         # remove steps data
         uuid = self.request.session.get("tender_steps_data_uuid", None)
         if uuid:
@@ -254,6 +254,8 @@ class TenderCreateMultiStepView(SessionWizardView):
                 message=self.get_success_message(cleaned_data, self.instance, is_draft=is_draft),
                 extra_tags="modal_message_bizdev",
             )
+        tender = self.instance
+        add_to_contact_list(user=user, type="signup", source=user_constants.SOURCE_TENDER_FORM, tender=tender)
         return redirect(self.get_success_url())
 
     def get_success_url(self):


### PR DESCRIPTION
### Quoi ?

Ajout de trois attributs lors de la création de contact dans la liste #10 (Acheteurs inscrits) de Brevo : 
- MONTANT_BESOIN_ACHETEUR
- TYPE_BESOIN_ACHETEUR
- TYPE_VERTICALE_ACHETEUR

### Pourquoi ?

Pour segmenter les envois d'email et ne pas multiplier les listes sur Brevo.

### Comment ?

En ajoutant un argument `tender_id` dans la méthode `add_to_contact_list` définie dans emails.py. Cette dernière est appelée dans les trois méthodes de création de Tender (`done`, `perform_create` et `csrf_failure`) afin de récupérer l'id du tender qui permettra d'associer les informations du tender à l'utilisateur de type "acheteur".

### Captures d'écran (optionnel)

![contact_attributs](https://github.com/user-attachments/assets/5c9167eb-c648-4d74-be48-d38cce265788)

### Autre (optionnel)

#### Tests :
- Il manque un test sur la méthode csrf_failure car il était compliqué de récupérer l'erreur csrf dans le test pour la traiter et permettre la création du tender.
- J'ai ajouté un User de type BUYER dans setUpTestData donc j'ai légèrement modifié `test_user_with_valid_api_key_can_create_tender` pour que les assertEqual du nombre de User passent.
