### PR TITLE
fix: Réparation du montant lors de la synchro avec Brevo

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -789,21 +789,20 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         if request.POST.get("_validate_send_to_siaes"):
             obj.set_validated()
             if obj.amount_int > settings.BREVO_TENDERS_MIN_AMOUNT_TO_SEND:
-                api_brevo.create_deal(tender=obj, owner_email=request.user.email)
-                # we link deal(tender) with author contact
-                api_brevo.link_deal_with_contact_list(tender=obj)
-                self.message_user(request, "Ce dépôt de besoin a été synchronisé avec Brevo")
+                try:
+                    api_brevo.create_deal(tender=obj, owner_email=request.user.email)
+                    # we link deal(tender) with author contact
+                    api_brevo.link_deal_with_contact_list(tender=obj)
+                    self.message_user(request, "Ce dépôt de besoin a été synchronisé avec Brevo")
+                except Exception as e:
+                    self.message_user(request, f"Erreur dans la synchronisation du DDB avec Brevo {str(e)}")
             self.message_user(request, "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
             return HttpResponseRedirect(".")
         if request.POST.get("_validate_send_to_commercial_partners"):
             obj.send_to_commercial_partners_only = True
             obj.set_validated()
-            if obj.amount_int > settings.BREVO_TENDERS_MIN_AMOUNT_TO_SEND:
-                api_brevo.create_deal(tender=obj, owner_email=request.user.email)
-                # we link deal(tender) with author contact
-                api_brevo.link_deal_with_contact_list(tender=obj)
-                self.message_user(request, "Ce dépôt de besoin a été synchronisé avec Brevo")
-            self.message_user(request, "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
+            # we don't need to send it in the crm, parteners manage them
+            self.message_user(request, "Ce dépôt de besoin a été validé. Il sera envoyé aux partenaires :)")
             return HttpResponseRedirect(".")
         elif request.POST.get("_restart_tender"):
             restart_send_tender_task(tender=obj)

--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from huey.contrib.djhuey import task
 from sib_api_v3_sdk.rest import ApiException
 
-from lemarche.tenders.constants import AMOUNT_RANGE_CHOICE_EXACT
 from lemarche.utils.constants import EMAIL_SUBJECT_PREFIX
 from lemarche.utils.data import sanitize_to_send_by_email
 from lemarche.utils.urls import get_object_admin_url, get_object_share_url
@@ -170,7 +169,7 @@ def create_deal(tender, owner_email: str):
             "deal_owner": owner_email,
             "close_date": tender.deadline_date.strftime("%Y-%m-%d"),
             # custom attributes
-            "amount": AMOUNT_RANGE_CHOICE_EXACT.get(tender.amount, 0),
+            "amount": tender.amount_int,
             "tender_admin_url": tender.get_admin_url(),
         },
     )
@@ -184,6 +183,7 @@ def create_deal(tender, owner_email: str):
         tender.save()
     except ApiException as e:
         logger.error("Exception when calling Brevo->DealApi->create_deal: %s\n" % e)
+        raise ApiException(e)
 
 
 def link_deal_with_contact_list(tender, contact_list: list = None):


### PR DESCRIPTION
### Quoi ?

- Réparation du montant qui n'était pas complété lors de la synchronisation avec Brevo
- Plus de synchronisation avec Brevo quand on envoi aux partenaires
- Envoi de l'erreur à l'utilisateur sur les prochaines erreurs de synchronisation

