### PR TITLE
fix(Activités des structures): Adaptation de la commande de reprise de stock pour créer les activités

### DIFF
--- a/lemarche/siaes/management/commands/create_siae_activities.py
+++ b/lemarche/siaes/management/commands/create_siae_activities.py
@@ -1,6 +1,6 @@
+import lemarche.siaes.constants as siae_constants
 from lemarche.perimeters.models import Perimeter
 from lemarche.siaes.models import Siae, SiaeActivity
-from lemarche.siaes.utils import match_location_to_perimeter
 from lemarche.utils.commands import BaseCommand
 from lemarche.utils.data import reset_app_sql_sequences
 
@@ -48,8 +48,7 @@ class Command(BaseCommand):
             self.stdout_info("-" * 80)
             self.stdout_info("Creating SiaeActivities")
             for index, siae in enumerate(siae_qs):
-                siae_location: Perimeter | None = match_location_to_perimeter(siae)
-                self.create_siae_activities(siae, siae_location=siae_location)
+                self.create_siae_activities(siae)
                 if (index % 500) == 0:
                     self.stdout_info(f"{index}...")
 
@@ -66,7 +65,7 @@ class Command(BaseCommand):
         self.stdout_warning(f"No location found for {siae} (post_code empty)")
         return None
 
-    def create_siae_activities(self, siae: Siae, siae_location: Perimeter = None):
+    def create_siae_activities(self, siae: Siae):
         """
         - sector_group / sectors: we look at the existing siae sectors, and create an activity per sector group
         - presta_type: we look at the existing siae presta_types
@@ -79,14 +78,40 @@ class Command(BaseCommand):
         siae_sector_group_ids = list(set(siae.sectors.values_list("group", flat=True)))
         # For each SectorGroup, create a SiaeActivity
         for sector_group_id in siae_sector_group_ids:
-            siae_activity = SiaeActivity.objects.create(
-                siae=siae,
-                sector_group_id=sector_group_id,
-                presta_type=siae.presta_type,
-                location=siae_location,
-                geo_range=siae.geo_range,
-                geo_range_custom_distance=siae.geo_range_custom_distance,
-            )
+            match siae.geo_range:
+                case siae_constants.GEO_RANGE_COUNTRY:
+                    siae_activity = SiaeActivity.objects.create(
+                        siae=siae,
+                        sector_group_id=sector_group_id,
+                        presta_type=siae.presta_type,
+                        geo_range=siae_constants.GEO_RANGE_COUNTRY,
+                    )
+                case siae_constants.GEO_RANGE_CUSTOM:
+                    siae_activity = SiaeActivity.objects.create(
+                        siae=siae,
+                        sector_group_id=sector_group_id,
+                        presta_type=siae.presta_type,
+                        geo_range=siae_constants.GEO_RANGE_CUSTOM,
+                        geo_range_custom_distance=siae.geo_range_custom_distance,
+                    )
+                case siae_constants.GEO_RANGE_REGION:
+                    siae_activity = SiaeActivity.objects.create(
+                        siae=siae,
+                        sector_group_id=sector_group_id,
+                        presta_type=siae.presta_type,
+                        geo_range=siae_constants.GEO_RANGE_ZONES,
+                    )
+                    region = Perimeter.objects.get(kind=Perimeter.KIND_REGION, name=siae.region)
+                    siae_activity.locations.add(region)
+                case siae_constants.GEO_RANGE_DEPARTMENT:
+                    siae_activity = SiaeActivity.objects.create(
+                        siae=siae,
+                        sector_group_id=sector_group_id,
+                        presta_type=siae.presta_type,
+                        geo_range=siae_constants.GEO_RANGE_ZONES,
+                    )
+                    department = Perimeter.objects.get(kind=Perimeter.KIND_DEPARTMENT, insee_code=siae.department)
+                    siae_activity.locations.add(department)
             siae_activity.sectors.set(siae.sectors.filter(group_id=sector_group_id))
 
-        # self.stdout_info(f"Created {len(siae_sector_group_ids)} activities for {siae}")
+        self.stdout_info(f"Created {len(siae_sector_group_ids)} activities for {siae}")

--- a/lemarche/siaes/management/commands/create_siae_activities.py
+++ b/lemarche/siaes/management/commands/create_siae_activities.py
@@ -111,6 +111,9 @@ class Command(BaseCommand):
                     )
                     department = Perimeter.objects.get(kind=Perimeter.KIND_DEPARTMENT, insee_code=siae.department)
                     siae_activity.locations.add(department)
+                case _:
+                    self.stdout_warning(f"Unknown geo_range: {siae.geo_range}")
+                    continue
             siae_activity.sectors.set(siae.sectors.filter(group_id=sector_group_id))
 
         self.stdout_info(f"Created {len(siae_sector_group_ids)} activities for {siae}")

--- a/lemarche/siaes/management/commands/create_siae_activities.py
+++ b/lemarche/siaes/management/commands/create_siae_activities.py
@@ -62,7 +62,6 @@ class Command(BaseCommand):
             ]
             self.stdout_messages_success(msg_success)
 
-        self.stdout_warning(f"No location found for {siae} (post_code empty)")
         return None
 
     def create_siae_activities(self, siae: Siae):

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -1,5 +1,5 @@
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.perimeters.models import Perimeter
@@ -9,7 +9,7 @@ from lemarche.siaes.factories import SiaeFactory
 from lemarche.siaes.models import SiaeActivity
 
 
-class SiaeActivitiesCreateCommandTest(TestCase):
+class SiaeActivitiesCreateCommandTest(TransactionTestCase):
     def setUp(self):
         self.sector1 = SectorFactory()
         self.sector2 = SectorFactory()

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -1,0 +1,102 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from lemarche.perimeters.factories import PerimeterFactory
+from lemarche.perimeters.models import Perimeter
+from lemarche.sectors.factories import SectorFactory
+from lemarche.siaes import constants as siae_constants
+from lemarche.siaes.factories import SiaeFactory
+from lemarche.siaes.models import SiaeActivity
+
+
+class SiaeActivitiesCreateCommandTest(TestCase):
+    def setUp(self):
+        self.sector1 = SectorFactory()
+        self.sector2 = SectorFactory()
+        self.sector3 = SectorFactory()
+
+        region_name = "Collectivités d'outre-mer"
+
+        self.perimeter_department = PerimeterFactory(
+            name="Saint-Martin", kind=Perimeter.KIND_DEPARTMENT, insee_code="978", region_code="97"
+        )
+        self.perimeter_region = PerimeterFactory(name=region_name, kind=Perimeter.KIND_REGION, insee_code="R97")
+
+        self.siae1 = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_AI,
+            presta_type=[siae_constants.PRESTA_PREST, siae_constants.PRESTA_BUILD],
+            geo_range=siae_constants.GEO_RANGE_COUNTRY,
+        )
+        self.siae1.sectors.set([self.sector1, self.sector2])
+
+        self.siae2 = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_EA,
+            presta_type=[siae_constants.PRESTA_DISP],
+            geo_range=siae_constants.GEO_RANGE_CUSTOM,
+        )
+        self.siae2.sectors.set([self.sector3])
+
+        self.siae3 = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_EA,
+            presta_type=[siae_constants.PRESTA_PREST],
+            geo_range=siae_constants.GEO_RANGE_REGION,
+            department="987",
+            region=region_name,
+        )
+        self.siae3.sectors.set([self.sector3])
+
+        self.siae4 = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_EA,
+            presta_type=[siae_constants.PRESTA_DISP],
+            geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
+            department="978",
+            region=region_name,
+        )
+        self.siae4.sectors.set([self.sector2, self.sector3])
+
+    def test_create_activities(self):
+        call_command("create_siae_activities", dry_run=True)
+        self.assertEqual(SiaeActivity.objects.count(), 0)
+
+        call_command("create_siae_activities")
+        self.assertEqual(SiaeActivity.objects.count(), 2 + 1 + 1 + 2)
+        siae1_activities = SiaeActivity.objects.filter(siae=self.siae1)
+        self.assertEqual(siae1_activities.count(), 2)
+        self.assertEqual(siae1_activities.filter(sectors__in=[self.sector1]).count(), 1)
+        self.assertEqual(siae1_activities.filter(sectors__in=[self.sector2]).count(), 1)
+        for siae_activity in siae1_activities:
+            with self.subTest(siae_activity=siae_activity):
+                self.assertEqual(siae_activity.presta_type, [siae_constants.PRESTA_PREST, siae_constants.PRESTA_BUILD])
+                self.assertEqual(siae_activity.geo_range, siae_constants.GEO_RANGE_COUNTRY)
+                self.assertEqual(siae_activity.locations.count(), 0)
+
+        siae2_activities = SiaeActivity.objects.filter(siae=self.siae2)
+        self.assertEqual(siae2_activities.count(), 1)
+        self.assertEqual(siae2_activities.first().presta_type, [siae_constants.PRESTA_DISP])
+        self.assertEqual(siae2_activities.first().geo_range, siae_constants.GEO_RANGE_CUSTOM)
+        self.assertEqual(siae2_activities.first().geo_range_custom_distance, self.siae2.geo_range_custom_distance)
+        self.assertEqual(siae2_activities.filter(sectors__in=[self.sector3]).count(), 1)
+        self.assertEqual(siae2_activities.first().locations.count(), 0)
+
+        siae3_activities = SiaeActivity.objects.filter(siae=self.siae3)
+        self.assertEqual(siae3_activities.count(), 1)
+        self.assertEqual(siae3_activities.filter(sectors__in=[self.sector3]).count(), 1)
+        self.assertEqual(siae3_activities.first().presta_type, [siae_constants.PRESTA_PREST])
+        self.assertEqual(siae3_activities.first().geo_range, siae_constants.GEO_RANGE_ZONES)
+        self.assertEqual(siae3_activities.first().locations.count(), 1)
+        self.assertEqual(siae3_activities.first().locations.first(), self.perimeter_region)
+
+        siae4_activities = SiaeActivity.objects.filter(siae=self.siae4)
+        self.assertEqual(siae4_activities.count(), 2)
+        self.assertEqual(siae4_activities.filter(sectors__in=[self.sector2]).count(), 1)
+        self.assertEqual(siae4_activities.filter(sectors__in=[self.sector3]).count(), 1)
+        for siae_activity in siae4_activities:
+            with self.subTest(siae_activity=siae_activity):
+                self.assertEqual(siae_activity.presta_type, [siae_constants.PRESTA_DISP])
+                self.assertEqual(siae_activity.geo_range, siae_constants.GEO_RANGE_ZONES)
+                self.assertEqual(siae_activity.locations.count(), 1)
+                self.assertEqual(siae_activity.locations.first(), self.perimeter_department)

--- a/lemarche/siaes/tests/test_models.py
+++ b/lemarche/siaes/tests/test_models.py
@@ -563,7 +563,7 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
         )
 
     def test_geo_range_in_perimeter_list(self):
-        self.assertEqual(Siae.objects.address_in_perimeter_list([]).count(), 5)
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([]).count(), 5)
         self.assertEqual(Siae.objects.geo_range_in_perimeter_list([self.guadeloupe_perimeter]).count(), 1)
         self.assertEqual(Siae.objects.geo_range_in_perimeter_list([self.grenoble_perimeter]).count(), 2)
         self.assertEqual(

--- a/lemarche/siaes/tests/test_models.py
+++ b/lemarche/siaes/tests/test_models.py
@@ -519,16 +519,16 @@ class SiaeModelQuerysetTest(TestCase):
 
 class SiaeModelPerimeterQuerysetTest(TestCase):
     @classmethod
-    def setUp(self):
-        self.auvergne_rhone_alpes_perimeter = PerimeterFactory(
+    def setUpTestData(cls):
+        cls.auvergne_rhone_alpes_perimeter = PerimeterFactory(
             name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
         )
-        self.guadeloupe_perimeter = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
-        self.finistere_perimeter = PerimeterFactory(
+        cls.guadeloupe_perimeter = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
+        cls.finistere_perimeter = PerimeterFactory(
             name="Finistère", kind=Perimeter.KIND_DEPARTMENT, insee_code="29", region_code="53"
         )
-        self.grenoble_perimeter = PerimeterFactory(**PERIMETER_GRENOBLE)
-        self.chamrousse_perimeter = PerimeterFactory(
+        cls.grenoble_perimeter = PerimeterFactory(**PERIMETER_GRENOBLE)
+        cls.chamrousse_perimeter = PerimeterFactory(
             name="Chamrousse",
             kind=Perimeter.KIND_CITY,
             insee_code="38567",
@@ -541,16 +541,16 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
         SiaeFactory(city="Pointe-à-Pitre", department="971", region="Guadeloupe", post_code="97110")
         SiaeFactory(city="Brest", department="29", region="Bretagne", post_code="29200")
         SiaeFactory(
-            city=self.grenoble_perimeter.name,
-            department=self.grenoble_perimeter.department_code,
-            region=self.auvergne_rhone_alpes_perimeter.name,
-            post_code=self.grenoble_perimeter.post_codes[0],
+            city=cls.grenoble_perimeter.name,
+            department=cls.grenoble_perimeter.department_code,
+            region=cls.auvergne_rhone_alpes_perimeter.name,
+            post_code=cls.grenoble_perimeter.post_codes[0],
         )
         SiaeFactory(
-            city=self.chamrousse_perimeter.name,
-            department=self.chamrousse_perimeter.department_code,
-            region=self.auvergne_rhone_alpes_perimeter.name,
-            post_code=self.chamrousse_perimeter.post_codes[0],
+            city=cls.chamrousse_perimeter.name,
+            department=cls.chamrousse_perimeter.department_code,
+            region=cls.auvergne_rhone_alpes_perimeter.name,
+            post_code=cls.chamrousse_perimeter.post_codes[0],
             geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
         )
 

--- a/lemarche/siaes/tests/test_models.py
+++ b/lemarche/siaes/tests/test_models.py
@@ -519,16 +519,16 @@ class SiaeModelQuerysetTest(TestCase):
 
 class SiaeModelPerimeterQuerysetTest(TestCase):
     @classmethod
-    def setUpTestData(cls):
-        cls.auvergne_rhone_alpes_perimeter = PerimeterFactory(
+    def setUp(self):
+        self.auvergne_rhone_alpes_perimeter = PerimeterFactory(
             name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
         )
-        cls.guadeloupe_perimeter = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
-        cls.finistere_perimeter = PerimeterFactory(
+        self.guadeloupe_perimeter = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
+        self.finistere_perimeter = PerimeterFactory(
             name="Finistère", kind=Perimeter.KIND_DEPARTMENT, insee_code="29", region_code="53"
         )
-        cls.grenoble_perimeter = PerimeterFactory(**PERIMETER_GRENOBLE)
-        cls.chamrousse_perimeter = PerimeterFactory(
+        self.grenoble_perimeter = PerimeterFactory(**PERIMETER_GRENOBLE)
+        self.chamrousse_perimeter = PerimeterFactory(
             name="Chamrousse",
             kind=Perimeter.KIND_CITY,
             insee_code="38567",
@@ -541,16 +541,16 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
         SiaeFactory(city="Pointe-à-Pitre", department="971", region="Guadeloupe", post_code="97110")
         SiaeFactory(city="Brest", department="29", region="Bretagne", post_code="29200")
         SiaeFactory(
-            city=cls.grenoble_perimeter.name,
-            department=cls.grenoble_perimeter.department_code,
-            region=cls.auvergne_rhone_alpes_perimeter.name,
-            post_code=cls.grenoble_perimeter.post_codes[0],
+            city=self.grenoble_perimeter.name,
+            department=self.grenoble_perimeter.department_code,
+            region=self.auvergne_rhone_alpes_perimeter.name,
+            post_code=self.grenoble_perimeter.post_codes[0],
         )
         SiaeFactory(
-            city=cls.chamrousse_perimeter.name,
-            department=cls.chamrousse_perimeter.department_code,
-            region=cls.auvergne_rhone_alpes_perimeter.name,
-            post_code=cls.chamrousse_perimeter.post_codes[0],
+            city=self.chamrousse_perimeter.name,
+            department=self.chamrousse_perimeter.department_code,
+            region=self.auvergne_rhone_alpes_perimeter.name,
+            post_code=self.chamrousse_perimeter.post_codes[0],
             geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
         )
 
@@ -563,7 +563,7 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
         )
 
     def test_geo_range_in_perimeter_list(self):
-        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([]).count(), 5)
+        self.assertEqual(Siae.objects.address_in_perimeter_list([]).count(), 5)
         self.assertEqual(Siae.objects.geo_range_in_perimeter_list([self.guadeloupe_perimeter]).count(), 1)
         self.assertEqual(Siae.objects.geo_range_in_perimeter_list([self.grenoble_perimeter]).count(), 2)
         self.assertEqual(
@@ -622,17 +622,6 @@ class SiaeUtilsTest(TestCase):
         self.siae_with_siret_2 = SiaeFactory(siret="12312312312346", is_active=True)
         self.siae_with_siret_inactive = SiaeFactory(siret="12312312312347", is_active=False)
         self.assertEqual(siae_utils.calculate_etablissement_count(self.siae_with_siret_1), 2)
-
-    def test_match_location_to_perimeter(self):
-        self.siae_grenoble_from_post_code = SiaeFactory(post_code="38000")
-        self.siae_grenoble_from_insee_code = SiaeFactory(post_code="38185")
-        self.grenoble_perimeter = PerimeterFactory(**PERIMETER_GRENOBLE)
-        self.assertEqual(
-            siae_utils.match_location_to_perimeter(self.siae_grenoble_from_post_code), self.grenoble_perimeter
-        )
-        self.assertEqual(
-            siae_utils.match_location_to_perimeter(self.siae_grenoble_from_insee_code), self.grenoble_perimeter
-        )
 
 
 class SiaeActivitiesTest(TestCase):

--- a/lemarche/siaes/utils.py
+++ b/lemarche/siaes/utils.py
@@ -1,4 +1,3 @@
-from lemarche.perimeters.models import Perimeter
 from lemarche.siaes.models import Siae
 
 
@@ -6,32 +5,3 @@ def calculate_etablissement_count(siae: Siae):
     if siae.siren:
         return Siae.objects.filter(is_active=True, siret__startswith=siae.siren).count()
     return 0
-
-
-def match_location_to_perimeter(siae: Siae):
-    """
-    Find the Siae's location based on the post_code (and city)
-    - first do a post_code search
-    - if multiple perimeters returned, try to match with the city
-    - if still multiple results returned, return None
-    """
-    if siae.post_code:
-        location_results_from_siae_post_code = Perimeter.objects.post_code_search(
-            siae.post_code, include_insee_code=True
-        )
-
-        if not location_results_from_siae_post_code.exists():
-            print(f"No location found for {siae} (with post_code {siae.post_code})")
-            return None
-        elif location_results_from_siae_post_code.count() == 1:
-            return location_results_from_siae_post_code.first()
-        else:
-            # found multiple locations with the post_code, try to match with the city
-            if siae.city:
-                location_results_from_siae_city = Perimeter.objects.name_search(siae.city)
-                if location_results_from_siae_city.count():
-                    if location_results_from_siae_post_code.first() == location_results_from_siae_post_code.first():
-                        return location_results_from_siae_post_code.first()
-                    else:
-                        print(f"Multiple locations found for {siae} (with post_code {siae.post_code})")
-                        return None


### PR DESCRIPTION
### Quoi ?

Adaptation de la commande de reprise de stock pour le matching au niveau des activités.

### Pourquoi ?

Le modèle de données a évolué, notamment avec le changement sur le `geo_range` du modèle `SiaeActivity`.

### Comment ?

Création des activités en fonction du `geo_range` de la SIAE, ajout des secteurs d'activités et ajout des périmètres pour les `geo_range` département et région.

Ajout de tests sur la management command.

### Autre

L'héritage de `TransactionTestCase` plutôt que `TestCase` s'est avéré nécessaire pour éviter les interférences entre les tests.
