### PR TITLE
fix(Activités des structures): ajout de la correspondance directe sur la ville, le département ou la région de la structure

### DIFF
--- a/lemarche/siaes/management/commands/create_siae_activities.py
+++ b/lemarche/siaes/management/commands/create_siae_activities.py
@@ -126,8 +126,13 @@ class Command(BaseCommand):
                         continue
 
                 case _:
-                    self.stdout_warning(f"Unknown geo_range: {siae.geo_range}")
-                    continue
+                    # Create a SiaeActivity with no location to continue to match the sectors
+                    siae_activity = SiaeActivity.objects.create(
+                        siae=siae,
+                        sector_group_id=sector_group_id,
+                        presta_type=siae.presta_type,
+                        geo_range=siae_constants.GEO_RANGE_ZONES,
+                    )
             siae_activity.sectors.set(siae.sectors.filter(group_id=sector_group_id))
 
         self.stdout_info(f"Created {len(siae_sector_group_ids)} activities for {siae}")

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -95,11 +95,21 @@ class SiaeActivitiesCreateCommandTest(TransactionTestCase):
         )
         siae4.sectors.set([self.sector2, self.sector3])
 
+        # without geo_range
+        siae5 = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_EA,
+            presta_type=[siae_constants.PRESTA_DISP],
+            department="978",
+            region=self.region_name,
+        )
+        siae5.sectors.set([self.sector3])
+
         call_command("create_siae_activities", dry_run=True)
         self.assertEqual(SiaeActivity.objects.count(), 0)
 
         call_command("create_siae_activities")
-        self.assertEqual(SiaeActivity.objects.count(), 2 + 1 + 1 + 2)
+        self.assertEqual(SiaeActivity.objects.count(), 2 + 1 + 1 + 2 + 1)
         siae1_activities = SiaeActivity.objects.filter(siae=siae1)
         self.assertEqual(siae1_activities.count(), 2)
         self.assertEqual(siae1_activities.filter(sectors__in=[self.sector1]).count(), 1)
@@ -136,3 +146,10 @@ class SiaeActivitiesCreateCommandTest(TransactionTestCase):
                 self.assertEqual(siae_activity.geo_range, siae_constants.GEO_RANGE_ZONES)
                 self.assertEqual(siae_activity.locations.count(), 1)
                 self.assertEqual(siae_activity.locations.first(), self.perimeter_department)
+
+        siae5_activities = SiaeActivity.objects.filter(siae=siae5)
+        self.assertEqual(siae5_activities.count(), 1)
+        self.assertEqual(siae5_activities.filter(sectors__in=[self.sector3]).count(), 1)
+        self.assertEqual(siae5_activities.first().presta_type, [siae_constants.PRESTA_DISP])
+        self.assertEqual(siae5_activities.first().geo_range, siae_constants.GEO_RANGE_ZONES)
+        self.assertEqual(siae5_activities.first().locations.count(), 0)

--- a/lemarche/tenders/tests/test_matching.py
+++ b/lemarche/tenders/tests/test_matching.py
@@ -72,25 +72,41 @@ class TenderMatchingActivitiesTest(TestCase):
         )
         cls.siae_three_activity.sectors.add(cls.other_sector)
 
+        # siae with activity without locations to check if match directly city/department/region
+        cls.siae_four = SiaeFactory(
+            is_active=True,
+            kind=siae_constants.KIND_ESAT,
+            department="75",
+            region="Île-de-France",
+            post_code="75018",
+        )
+        cls.siae_four_activity = SiaeActivityFactory(
+            siae=cls.siae_four,
+            sector_group=cls.sectors[0].group,
+            presta_type=[siae_constants.PRESTA_PREST, siae_constants.PRESTA_BUILD],
+            geo_range=siae_constants.GEO_RANGE_ZONES,
+        )
+        cls.siae_four_activity.sectors.add(cls.sectors[i])
+
     def test_matching_siae_presta_type(self):
         tender = TenderFactory(presta_type=[], sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
         tender = TenderFactory(
             presta_type=[siae_constants.PRESTA_BUILD], sectors=self.sectors, perimeters=self.perimeters
         )
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
         tender = TenderFactory(
             presta_type=[siae_constants.PRESTA_PREST], sectors=self.sectors, perimeters=self.perimeters
         )
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 1)
+        self.assertEqual(len(siae_found_list), 2)
 
     def test_matching_siae_kind(self):
         tender = TenderFactory(siae_kind=[], sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
         tender = TenderFactory(siae_kind=[siae_constants.KIND_AI], sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
         self.assertEqual(len(siae_found_list), 1)
@@ -100,7 +116,7 @@ class TenderMatchingActivitiesTest(TestCase):
             perimeters=self.perimeters,
         )
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
         tender = TenderFactory(siae_kind=[siae_constants.KIND_SEP], sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
         self.assertEqual(len(siae_found_list), 0)
@@ -108,7 +124,7 @@ class TenderMatchingActivitiesTest(TestCase):
     def test_matching_siae_sectors(self):
         tender = TenderFactory(sectors=self.sectors)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
 
     def test_matching_siae_distance_location(self):
         # create SIAE in Tours
@@ -170,7 +186,7 @@ class TenderMatchingActivitiesTest(TestCase):
         tender.distance_location = None
         tender.save()
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2)
+        self.assertEqual(len(siae_found_list), 3)
         self.assertIn(self.siae_one, siae_found_list)
         self.assertIn(self.siae_two, siae_found_list)
 
@@ -199,7 +215,7 @@ class TenderMatchingActivitiesTest(TestCase):
             perimeters=[self.perimeter_paris],  # without effect too
         )
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 3)
+        self.assertEqual(len(siae_found_list), 4)
         self.assertIn(self.siae_one, siae_found_list)
         self.assertIn(self.siae_two, siae_found_list)
         self.assertIn(siae_marseille, siae_found_list)
@@ -217,11 +233,11 @@ class TenderMatchingActivitiesTest(TestCase):
         # tender perimeter custom with include_country_area = False
         tender_1 = TenderFactory(sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender_1)
-        self.assertEqual(len(siae_found_list), 2 + 0)
+        self.assertEqual(len(siae_found_list), 3 + 0)
         # tender perimeter custom with include_country_area = True
         tender_2 = TenderFactory(sectors=self.sectors, perimeters=self.perimeters, include_country_area=True)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender_2)
-        self.assertEqual(len(siae_found_list), 2 + 1)
+        self.assertEqual(len(siae_found_list), 3 + 1)
 
     def test_matching_siae_country(self):
         # add Siae with geo_range_country
@@ -253,7 +269,7 @@ class TenderMatchingActivitiesTest(TestCase):
         # add perimeters
         tender_2.perimeters.set(self.perimeters)
         siae_found_list_2 = Siae.objects.filter_with_tender_through_activities(tender_2)
-        self.assertEqual(len(siae_found_list_2), 2 + 2)
+        self.assertEqual(len(siae_found_list_2), 2 + 3)
         tender_2.is_country_area = True
         tender_2.save()
         siae_found_list_2 = Siae.objects.filter_with_tender_through_activities(tender_2)
@@ -285,7 +301,7 @@ class TenderMatchingActivitiesTest(TestCase):
         # tender perimeter custom
         tender = TenderFactory(sectors=self.sectors, perimeters=self.perimeters)
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2 + 1)
+        self.assertEqual(len(siae_found_list), 3 + 1)
 
     def test_matching_siae_perimeters_france(self):
         # tender france
@@ -357,5 +373,5 @@ class TenderMatchingActivitiesTest(TestCase):
         siae_activity.sectors.add(self.sectors[0])
 
         siae_found_list = Siae.objects.filter_with_tender_through_activities(tender)
-        self.assertEqual(len(siae_found_list), 2 + 0)
+        self.assertEqual(len(siae_found_list), 3 + 0)
         self.assertNotIn(siae, siae_found_list)


### PR DESCRIPTION
### Quoi ?

Ajustement du matching au niveau des périmètres.
Ajustement de la commande pour reprendre les secteurs et les types de prestations même si il n'y a pas de périmètre associé

### Pourquoi ?

Pour permettre aussi la correspondance directement sur la ville/département/région de la structure.

### Comment ?

Dans la commande : ajout de la création d'une activité de type "ZONES", mais sans périmètre
Sur la matching : ajout d'une condition pour tenter la correspondance directement sur la ville, le département ou  la région de la structure.
