### PR TITLE
chore(Activités des structures): Passage du formulaire "Votre référencement" en lecture seule

### DIFF
--- a/lemarche/templates/dashboard/siae_edit_search.html
+++ b/lemarche/templates/dashboard/siae_edit_search.html
@@ -1,76 +1,69 @@
 {% extends "dashboard/siae_edit_base.html" %}
 {% load static dsfr_tags %}
-
 {% block content_siae_form %}
-<form method="post" action="">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-        <section class="fr-my-4v fr-input-group fr-input-group--error">
-            {{ form.non_field_errors }}
-        </section>
-    {% endif %}
-    <div class="fr-grid-row fr-mb-4v">
-        <div class="fr-col-12">
-            <h3>Réferencez efficacement votre structure dans les résultats de recherche</h3>
-        </div>
-    </div>
-
-    <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
-        <div class="fr-col-12 fr-col-lg-8">
-            {% dsfr_form_field form.presta_type %}
-        </div>
-        <div class="fr-col-12 fr-col-lg-4">
-            <div class="fr-callout fr-p-4v">
-                <h3 class="fr-callout__title fr-text--sm"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Type de prestation</h3>
-                <p class="fr-callout__text fr-text--sm fr-pl-7v">
-                    Vous pourrez ensuite détailler vos prestations dans l'onglet <strong>offre commerciale</strong>.
-                </p>
+    <form method="post" action="">
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+            <section class="fr-my-4v fr-input-group fr-input-group--error">
+                {{ form.non_field_errors }}
+            </section>
+        {% endif %}
+        <div class="fr-grid-row fr-mb-4v">
+            <div class="fr-col-12">
+                <h3>Réferencez efficacement votre structure dans les résultats de recherche</h3>
+                <div class="fr-alert fr-alert--warning">
+                    <p>
+                        Les informations ne sont actuellement plus éditables, car la refonte de cette fonctionnalité est en cours de déploiement.
+                    </p>
+                </div>
             </div>
         </div>
-    </div>
-
-    <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
-        <div class="fr-col-12 fr-col-lg-8">
-            {% dsfr_form_field form.geo_range %}
-            {{ form.geo_range_custom_distance }}
-        </div>
-        <div class="fr-col-12 fr-col-lg-4">
-            <div class="fr-callout fr-p-4v">
-                <h3 class="fr-callout__title fr-text--sm"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Périmètre d'intervention</h3>
-                <p class="fr-callout__text fr-text--sm fr-pl-7v">
-                    Le périmètre d'intervention est un critère essentiel dans le choix des acheteurs.
-                    Il est nécessaire de bien le renseigner.
-                </p>
+        <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
+            <div class="fr-col-12 fr-col-lg-8">{% dsfr_form_field form.presta_type %}</div>
+            <div class="fr-col-12 fr-col-lg-4">
+                <div class="fr-callout fr-p-4v">
+                    <h3 class="fr-callout__title fr-text--sm">
+                        <span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Type de prestation
+                    </h3>
+                    <p class="fr-callout__text fr-text--sm fr-pl-7v">
+                        Vous pourrez ensuite détailler vos prestations dans l'onglet <strong>offre commerciale</strong>.
+                    </p>
+                </div>
             </div>
         </div>
-    </div>
-
-    <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
-        <div class="fr-col-12 fr-col-lg-8">
-            {% dsfr_form_field form.sectors %}
-        </div>
-        <div class="fr-col-12 fr-col-lg-4">
-            <div class="fr-callout fr-p-4v">
-                <h3 class="fr-callout__title fr-text--sm"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Secteurs d'activité</h3>
-                <p class="fr-callout__text fr-text--sm fr-pl-7v">
-                    Améliorez votre référencement en indiquant tous les secteurs d'activités sur lesquels votre struture est positionnée.
-                </p>
+        <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
+            <div class="fr-col-12 fr-col-lg-8">
+                {% dsfr_form_field form.geo_range %}
+                {{ form.geo_range_custom_distance }}
+            </div>
+            <div class="fr-col-12 fr-col-lg-4">
+                <div class="fr-callout fr-p-4v">
+                    <h3 class="fr-callout__title fr-text--sm">
+                        <span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Périmètre d'intervention
+                    </h3>
+                    <p class="fr-callout__text fr-text--sm fr-pl-7v">
+                        Le périmètre d'intervention est un critère essentiel dans le choix des acheteurs.
+                        Il est nécessaire de bien le renseigner.
+                    </p>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="fr-grid-row">
-        <div class="fr-col-12 fr-col-lg-8">
-            <ul class="fr-btns-group--right fr-btns-group fr-btns-group--inline">
-                <li>
-                    {% dsfr_button label="Enregistrer mes modifications" extra_classes="fr-mt-4v" %}
-                </li>
-            </ul>
+        <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
+            <div class="fr-col-12 fr-col-lg-8">{% dsfr_form_field form.sectors %}</div>
+            <div class="fr-col-12 fr-col-lg-4">
+                <div class="fr-callout fr-p-4v">
+                    <h3 class="fr-callout__title fr-text--sm">
+                        <span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Secteurs d'activité
+                    </h3>
+                    <p class="fr-callout__text fr-text--sm fr-pl-7v">
+                        Améliorez votre référencement en indiquant tous les secteurs d'activités sur lesquels votre struture est positionnée.
+                    </p>
+                </div>
+            </div>
         </div>
-        <div class="fr-col-12 fr-col-lg-4"></div>
-    </div>
-</form>
+    </form>
 {% endblock content_siae_form %}
-
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'js/siae_geo_range_field.js' %}"></script>
+    <script type="text/javascript"
+            src="{% static 'js/siae_geo_range_field.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/www/dashboard_siaes/forms.py
+++ b/lemarche/www/dashboard_siaes/forms.py
@@ -73,12 +73,14 @@ class SiaeEditSearchForm(forms.ModelForm):
         choices=siae_constants.PRESTA_CHOICES,
         required=True,
         widget=forms.CheckboxSelectMultiple,
+        disabled=True,
     )
     geo_range = forms.ChoiceField(
         label=Siae._meta.get_field("geo_range").verbose_name,
         choices=siae_constants.GEO_RANGE_CHOICES,
         required=True,
         widget=forms.RadioSelect,
+        disabled=True,
     )
     sectors = GroupedModelMultipleChoiceField(
         label=Sector._meta.verbose_name_plural,
@@ -86,6 +88,7 @@ class SiaeEditSearchForm(forms.ModelForm):
         choices_groupby="group",
         required=True,
         widget=forms.CheckboxSelectMultiple,
+        disabled=True,
     )
 
     class Meta:

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.gis.geos import Point
+from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.urls import reverse
 
@@ -59,8 +60,9 @@ class SiaeSearchNumQueriesTest(TestCase):
     def test_search_num_queries(self):
         url = reverse("siae:search_results")
 
-        # fix cache issue in parallel testing context, "SELECT 'django_site'" query appears additionally otherwise
-        self.client.get(url)
+        # fix cache issue in parallel testing context because only first call fetches database
+        # See https://docs.djangoproject.com/en/5.1/ref/contrib/sites/#caching-the-current-site-object
+        Site.objects.get_current()
 
         with self.assertNumQueries(12):
             response = self.client.get(url)


### PR DESCRIPTION
### Quoi ?

Pour déployer la refonte des activités, il faut lancer la commande de reprise de stock et il ne faut pas de modification pendant ce temps et ce jusqu'à ce que le nouvel onglet soit publié.

Cette PR permettra donc de mettre en lecture seule cet onglet.

### Pourquoi ?

Pour qu'il n'y ait pas de modification le temps de lancer la commande de reprise de stock.

### Comment ?

Ajout d'un message de warning, champs en disable et suppression du bouton submit.

### Captures d'écran

![image](https://github.com/user-attachments/assets/fb7bb1f9-22f0-48d7-9663-759ecb75ec67)

### Autres

J'en ai profité pour fixer le test sur les nombres de requêtes de la home qui passait à 13 quand on lançait les tests en parallèle. Grâce à une discussion avec @rsebille, il s'avère que la mise en cache et la séquence peuvent différer en parallèle. Un simple appel à la page en amont permet donc de corriger le problème. 