### PR TITLE
feat(Activités des structures): Remplacement de l'onglet "Votre référencement"

### DIFF
--- a/lemarche/templates/dashboard/siae_edit_base.html
+++ b/lemarche/templates/dashboard/siae_edit_base.html
@@ -82,25 +82,14 @@
                                 </a>
                             </li>
                             <li role="presentation">
-                                <a href="{% url 'dashboard_siaes:siae_edit_search' siae.slug %}"
-                                   id="siae-edit-search-tab"
+                                <a href="{% url 'dashboard_siaes:siae_edit_activities' siae.slug %}"
+                                   id="siae-edit-search-2-tab"
                                    class="fr-tabs__tab"
-                                   aria-controls="siae_edit_search_panel"
-                                   aria-selected="{% if 'siae_edit_search' in request.resolver_match.url_name %}true{% else %}false{% endif %}">
+                                   aria-controls="siae_edit_activities_panel"
+                                   aria-selected="{% if 'siae_edit_activities' in request.resolver_match.url_name %}true{% else %}false{% endif %}">
                                     Votre référencement
                                 </a>
                             </li>
-                            {% if user.is_authenticated and user.is_admin %}
-                                <li role="presentation">
-                                    <a href="{% url 'dashboard_siaes:siae_edit_activities' siae.slug %}"
-                                       id="siae-edit-search-2-tab"
-                                       class="fr-tabs__tab"
-                                       aria-controls="siae_edit_activities_panel"
-                                       aria-selected="{% if 'siae_edit_activities' in request.resolver_match.url_name %}true{% else %}false{% endif %}">
-                                        Votre référencement (2)
-                                    </a>
-                                </li>
-                            {% endif %}
                             <li role="presentation">
                                 <a href="{% url 'dashboard_siaes:siae_edit_info' siae.slug %}"
                                    id="siae-edit-info-tab"

--- a/lemarche/www/dashboard_siaes/tests.py
+++ b/lemarche/www/dashboard_siaes/tests.py
@@ -134,7 +134,7 @@ class DashboardSiaeEditViewTest(TestCase):
 
     def test_only_siae_user_can_access_siae_edit_tabs(self):
         SIAE_EDIT_URLS = [
-            "dashboard_siaes:siae_edit_search",
+            "dashboard_siaes:siae_edit_activities",
             "dashboard_siaes:siae_edit_info",
             "dashboard_siaes:siae_edit_offer",
             "dashboard_siaes:siae_edit_links",

--- a/lemarche/www/dashboard_siaes/urls.py
+++ b/lemarche/www/dashboard_siaes/urls.py
@@ -2,15 +2,14 @@ from django.urls import include, path
 from django.views.generic.base import RedirectView
 
 from lemarche.www.dashboard_siaes.views import (
-    SiaeEditActivitiesDeleteView,
     SiaeEditActivitiesCreateView,
+    SiaeEditActivitiesDeleteView,
     SiaeEditActivitiesEditView,
     SiaeEditActivitiesView,
     SiaeEditContactView,
     SiaeEditInfoView,
     SiaeEditLinksView,
     SiaeEditOfferView,
-    SiaeEditSearchView,
     SiaeSearchAdoptConfirmView,
     SiaeSearchBySiretView,
     SiaeUserDeleteView,
@@ -36,7 +35,11 @@ urlpatterns = [
                     name="siae_edit",
                 ),
                 path("contact/", SiaeEditContactView.as_view(), name="siae_edit_contact"),
-                path("recherche/", SiaeEditSearchView.as_view(), name="siae_edit_search"),
+                path(
+                    "recherche/",
+                    RedirectView.as_view(pattern_name="dashboard_siaes:siae_edit_activities", permanent=False),
+                    name="siae_edit_search",
+                ),
                 path("activites/", SiaeEditActivitiesView.as_view(), name="siae_edit_activities"),
                 path("activites/creer", SiaeEditActivitiesCreateView.as_view(), name="siae_edit_activities_create"),
                 path(


### PR DESCRIPTION
### Quoi ?

Remplacement de l'onglet "Votre référencement"

### Pourquoi ?

Pour que les structures puissent modifier leurs activités avec le nouveau système.

### Comment ?

Changement dans le template sans supprimer les anciennes pages pour le moment (au cas où).

### Captures d'écran

Avant

![image](https://github.com/user-attachments/assets/60639545-a1fd-4b16-bfcf-60cdff219b72)

Après

![image](https://github.com/user-attachments/assets/c082568d-b04e-441d-ba6b-6fcf696b7eea)
