### PR TITLE
fix: Affichage du détail du dépôt de besoin

### DIFF
--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -204,3 +204,11 @@ ul.summary-grid-list {
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
     padding: 8px;
 }
+
+.text-center {
+    text-align: center;
+}
+
+.bg-gray {
+    background-color: var(--g300);
+}

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -4,7 +4,8 @@
       {% if SITE_CONFIG.mourning %}data-fr-mourning{% endif %}>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     {% dsfr_favicon %}
     {% dsfr_css %}
     {% compress css %}
@@ -25,7 +26,11 @@
     {% block extra_css %}
     {% endblock extra_css %}
     {% block title %}
-    <title>{% block page_title %}— Le marché de l'inclusion{% endblock page_title %}</title>
+      <title>
+        {% block page_title %}
+          — Le marché de l'inclusion
+        {% endblock page_title %}
+      </title>
     {% endblock title %}
     {% block meta_description %}
       <meta name="description"
@@ -46,12 +51,10 @@
     {% if SITE_CONFIG.notice %}
       {% dsfr_notice title=SITE_CONFIG.notice %}
     {% endif %}
-    
     {% block breadcrumb %}
-        {% comment %} empty because managed for each type of page {% endcomment %}
+      {% comment %} empty because managed for each type of page {% endcomment %}
     {% endblock breadcrumb %}
-    
-    <main id="content" role="main">
+    <main id="content" class="fr-mb-6w" role="main">
       {% block messages %}
         {% dsfr_django_messages wrapper_classes="fr-container fr-my-4v" %}
       {% endblock messages %}
@@ -74,7 +77,8 @@
             src="{% static 'vendor/alphagov-accessible-autocomplete-2.0.3/accessible-autocomplete.min.js' %}"></script>
     <script type="text/javascript"
             src="{% static 'vendor/leaflet-1.7.1/leaflet.js' %}"></script>
-    <script type="text/javascript" src="{% static 'vendor/htmx-1.9.12/htmx.min.js' %}"></script>
+    <script type="text/javascript"
+            src="{% static 'vendor/htmx-1.9.12/htmx.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/utils.js'%}"></script>
     {% if BITOUBI_ENV not in "dev" %}
       {% include "includes/_tracker_tarteaucitron.html" %}

--- a/lemarche/templates/tenders/_closed_badge.html
+++ b/lemarche/templates/tenders/_closed_badge.html
@@ -1,7 +1,8 @@
 <span>
-    {% if tender.deadline_date_is_outdated_annotated %}
-        <p class="fr-badge fr-badge--sm">
-            {{ tender_kind_display|default:tender.get_kind_display }} clôturé{% if tender.kind == "QUOTE" %}e{% endif %}
+    {% if tender.deadline_date_is_outdated_annotated or tender.deadline_date_is_outdated %}
+        <p class="fr-badge fr-badge--sm fr-badge--warning">
+            {{ tender_kind_display|default:tender.get_kind_display }} clôturé
+            {% if tender.kind == "QUOTE" %}e{% endif %}
             le {{ tender.deadline_date|default:"" }}
         </p>
     {% else %}
@@ -12,9 +13,6 @@
                 {{ tender.get_kind_display }}
             {% endif %}
         </p>
-        Disponible <strong>jusqu'au : {{ tender.deadline_date|default:"" }}</strong>
-        {% if is_new_for_siaes %}
-            <p class="fr-badge fr-badge--sm fr-badge--green-emeraude">Nouveau</p>
-        {% endif %}
+        {% if is_new_for_siaes %}<p class="fr-badge fr-badge--sm fr-badge--green-emeraude">Nouveau</p>{% endif %}
     {% endif %}
 </span>

--- a/lemarche/templates/tenders/_closed_badge.html
+++ b/lemarche/templates/tenders/_closed_badge.html
@@ -1,8 +1,8 @@
 <span>
-    {% if tender.deadline_date_is_outdated_annotated or tender.deadline_date_is_outdated %}
+    {% if tender.deadline_date_is_outdated_annotated or tender.deadline_date_outdated %}
         <p class="fr-badge fr-badge--sm fr-badge--warning">
-            {{ tender_kind_display|default:tender.get_kind_display }} clôturé
-            {% if tender.kind == "QUOTE" %}e{% endif %}
+            {{ tender_kind_display|default:tender.get_kind_display }}
+            clôturé{% if tender.kind == "QUOTE" %}e{% endif %}
             le {{ tender.deadline_date|default:"" }}
         </p>
     {% else %}

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -46,8 +46,10 @@
         <!-- tender description -->
         {% if tender.start_working_date %}
             <p class="fr-text--sm">
-                Disponible <strong>jusqu'au {{ tender.deadline_date|default:"" }}</strong>
-                <br>
+                {% if tender.deadline_date_is_outdated_annotated or not tender.deadline_date_outdated %}
+                    Disponible <strong>jusqu'au {{ tender.deadline_date|default:"" }}</strong>
+                    <br>
+                {% endif %}
                 Début d'intervention : {{ tender.start_working_date }}
             </p>
         {% endif %}

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -1,21 +1,7 @@
 {% load static humanize %}
-
-<div class="fr-card">
+<div class="fr-card fr-mb-2w">
     <div class="fr-card__body fr-py-4w">
-        <div class="fr-grid-row">
-            <div class="fr-col-md-12">
-                {% include "tenders/_closed_badge.html" with tender=tender is_new_for_siaes=is_new_for_siaes %}
-            </div>
-        </div>
-        <!-- title & header -->
-        <div class="fr-grid-row">
-            <div class="fr-col-md-12">
-                <h1>
-                    {{ tender.title }}
-                </h1>
-            </div>
-        </div>
-        <div class="fr-grid-row text-bold">
+        <div class="fr-grid-row text-center bg-gray fr-text--xs fr-py-2w">
             {% if tender.contact_company_name_display %}
                 <div class="fr-col-md-4" title="Entreprise">
                     <span class="fr-icon-building-line" aria-hidden="true"></span>
@@ -26,19 +12,31 @@
                 <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
                 {{ tender.location_display|safe }}
             </div>
-            <div class="fr-col-md-4" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
+            <div class="fr-col-md-4"
+                 title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
                 <span class="fr-icon-award-line" aria-hidden="true"></span>
                 {{ tender.sectors_list_string|safe }}
+            </div>
+        </div>
+        <div class="fr-grid-row fr-py-2w">
+            <div class="fr-col-md-12">
+                {% include "tenders/_closed_badge.html" with tender=tender is_new_for_siaes=is_new_for_siaes %}
+            </div>
+        </div>
+        <!-- title & header -->
+        <div class="fr-grid-row">
+            <div class="fr-col-md-12">
+                <h1>{{ tender.title }}</h1>
             </div>
         </div>
         <!-- contact details -->
         {% if not source_form %}
             {% if user.is_authenticated %}
                 {% if user == tender.author %}
-                    <hr class="fr-my-4w">
+                    <hr>
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% elif user_partner_can_display_tender_contact_details %}
-                    <hr class="fr-my-4w">
+                    <hr>
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% elif siae_has_detail_contact_click_date and not tender.deadline_date_outdated %}
                     <!-- for SIAE, contact details are displayed above (see tenders/detail.html) -->
@@ -46,17 +44,17 @@
             {% endif %}
         {% endif %}
         <!-- tender description -->
-        <hr class="fr-my-4w">
-        <h2>
-            Description
-        </h2>
         {% if tender.start_working_date %}
-            <p class="fr-text--sm">Début d'intervention : {{ tender.start_working_date }}</p>
+            <p class="fr-text--sm">
+                Disponible <strong>jusqu'au {{ tender.deadline_date|default:"" }}</strong>
+                <br>
+                Début d'intervention : {{ tender.start_working_date }}
+            </p>
         {% endif %}
-        <p>{{ tender.description|safe|linebreaks }}</p>
+        <p>{{ tender.description|safe }}</p>
         <!-- tender questions -->
         {% if source_form or not source_form and tender.questions_list|length %}
-            <hr class="fr-my-4w">
+            <hr>
             <h2>
                 {% if source_form or user == tender.author %}
                     Questions à poser aux prestataires ciblés
@@ -70,13 +68,13 @@
         {% endif %}
         <!-- tender constraints -->
         {% if tender.constraints %}
-            <hr class="fr-my-4w">
+            <hr>
             <h2>Comment répondre à cette demande ?</h2>
-            <p>{{ tender.constraints|default:"-"|safe|linebreaks }}</p>
+            <p>{{ tender.constraints|safe }}</p>
         {% endif %}
         <!-- tender amount -->
         {% if source_form or user == tender.author or tender.accept_share_amount %}
-            <hr class="fr-my-4w">
+            <hr>
             <h2>
                 {% if source_form or user == tender.author %}
                     Montant du marché

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -994,10 +994,6 @@ class Tender(models.Model):
         return self.status == tender_constants.STATUS_DRAFT
 
     @property
-    def deadline_date_is_outdated(self, limit_date=datetime.today().date()):
-        return self.deadline_date < limit_date
-
-    @property
     def is_pending_validation(self) -> bool:
         return self.status == tender_constants.STATUS_PUBLISHED
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -994,6 +994,10 @@ class Tender(models.Model):
         return self.status == tender_constants.STATUS_DRAFT
 
     @property
+    def deadline_date_is_outdated(self, limit_date=datetime.today().date()):
+        return self.deadline_date < limit_date
+
+    @property
     def is_pending_validation(self) -> bool:
         return self.status == tender_constants.STATUS_PUBLISHED
 


### PR DESCRIPTION
### Quoi ?

Fix de l'affichage des détails de dépôts de besoins.

### Pourquoi ?

Les champs descriptions sont édité depuis l'éditeur de texte ckeditor, donc l'output est déjà en html pas besoin de `linebreaks` dans les template django.

Profite de l'occasion pour réarranger un peu l'affichage.

+fix de la date de clôture du DDB.

### Captures
**Avant**
<img width="831" alt="image" src="https://github.com/user-attachments/assets/02952e11-c8dd-44d0-928d-6efd2b68aef2">

**Après**
<img width="831" alt="image" src="https://github.com/user-attachments/assets/93983787-8d73-4306-a772-a88c607a70f9">
