### PR TITLE
feat(Activités des structures): Adaptation de l'affichage des secteurs d'activités des structures

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1008,8 +1008,12 @@ class Siae(models.Model):
             return "Intérim"
         if self.kind == siae_constants.KIND_AI:
             return "Mise à disposition du personnel"
-        if self.presta_type:
-            return choice_array_to_values(siae_constants.PRESTA_CHOICES, self.presta_type)
+        if self.activities.exists():
+            presta_types = set()
+            for activity in self.activities.all():
+                if activity.presta_type:
+                    presta_types.update(activity.presta_type)
+            return choice_array_to_values(siae_constants.PRESTA_CHOICES, list(presta_types))
         return ""
 
     @property

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -151,6 +151,7 @@ ul.summary-grid-list {
 }
 
 .cmsfr-background-dark {
+
     & h1,
     h2,
     h3,
@@ -198,6 +199,7 @@ ul.summary-grid-list {
     width: 100%;
     border: 0;
 }
+
 .autocomplete__menu {
     /* Style DSFR pour le menu */
     border: 1px solid #000091;
@@ -211,4 +213,13 @@ ul.summary-grid-list {
 
 .bg-gray {
     background-color: var(--g300);
+}
+
+span.fr-tag--green-emeraude,
+p.fr-tag--green-emeraude {
+    --idle: transparent;
+    --hover: var(--background-action-low-green-emeraude-hover);
+    --active: var(--background-action-low-green-emeraude-active);
+    background-color: var(--background-action-low-green-emeraude);
+    color: var(--text-action-high-green-emeraude)
 }

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -1,6 +1,5 @@
-{% load static siae_sectors_display %}
+{% load static %}
 {% load theme_inclusion %}
-
 <div class="fr-card fr-card--horizontal fr-card--horizontal-tier {% if siae.super_badge %}super-badge-card{% endif %}">
     <div class="fr-card__body">
         <div class="fr-card__content">
@@ -8,9 +7,15 @@
             <div class="fr-card__desc">
                 <div class="fr-col-auto">
                     {% if siae.logo_url %}
-                        <img src="{{ siae.logo_url }}" width="100" alt="Logo de la structure {{ siae.name }}" loading="lazy" />
+                        <img src="{{ siae.logo_url }}"
+                             width="100"
+                             alt="Logo de la structure {{ siae.name }}"
+                             loading="lazy" />
                     {% else %}
-                        <img src="{% static 'img/default-listing.png' %}" width="100" alt="{{ siae.name }}" loading="lazy" />
+                        <img src="{% static 'img/default-listing.png' %}"
+                             width="100"
+                             alt="{{ siae.name }}"
+                             loading="lazy" />
                     {% endif %}
                 </div>
                 <div class="fr-col">
@@ -19,46 +24,45 @@
                             <h1>
                                 {{ siae.name_display }}
                                 {% if user.is_authenticated and user.is_admin and not siae.user_count %}
-                                    <span class="badge badge-base rounded-pill text-warning fs-sm">
-                                        pas encore inscrite
-                                    </span>
+                                    <span class="fr-badge fr-badge--sm fr-badge--warning">pas encore inscrite</span>
                                 {% endif %}
                             </h1>
                             {% include "includes/_super_badge.html" with siae=siae %}
-                            <p class="fr-text--sm"><i>(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</i></p>
+                            <p class="fr-text--sm">
+                                <i>(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</i>
+                            </p>
                             {% if user.is_authenticated %}
                                 <!-- buttons needed for modal to be triggered -->
-                                <button data-fr-opened="false" aria-controls="favorite_item_add_modal" class="fr-hidden"></button>
-                                <button data-fr-opened="false" aria-controls="favorite_item_remove_modal" class="fr-hidden"></button>
+                                <button data-fr-opened="false"
+                                        aria-controls="favorite_item_add_modal"
+                                        class="fr-hidden"></button>
+                                <button data-fr-opened="false"
+                                        aria-controls="favorite_item_remove_modal"
+                                        class="fr-hidden"></button>
                                 {% if siae.in_user_favorite_list_count_annotated %}
-                                    <button 
-                                        id="favorite-remove-modal-btn"
-                                        class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-fill"
-                                        x-data="favoriteItem"
-                                        x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
-                                        @click="remove"
-                                        title="Dans votre liste d'achat">
-                                        Supprimer de votre liste d'achat
-                                    </button>
+                                    <button id="favorite-remove-modal-btn"
+                                            class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-fill"
+                                            x-data="favoriteItem"
+                                            x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
+                                            @click="remove"
+                                            title="Dans votre liste d'achat">Supprimer de votre liste d'achat</button>
                                 {% else %}
-                                    <button
-                                        id="favorite-add-modal-btn"
-                                        class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
-                                        x-data="favoriteItem"
-                                        x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
-                                        @click="add"
-                                        title="Ajouter à votre liste d'achat">
+                                    <button id="favorite-add-modal-btn"
+                                            class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
+                                            x-data="favoriteItem"
+                                            x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
+                                            @click="add"
+                                            title="Ajouter à votre liste d'achat">
                                         Ajouter à votre liste d'achat
                                     </button>
                                 {% endif %}
                             {% else %}
-                                <button
-                                    id="favorite-modal-btn"
-                                    class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
-                                    data-fr-opened="false"
-                                    aria-controls="login_or_signup_modal"
-                                    data-next-params="{% url 'siae:detail' siae.slug %}"
-                                    title="Ajouter à votre liste d'achat">
+                                <button id="favorite-modal-btn"
+                                        class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
+                                        data-fr-opened="false"
+                                        aria-controls="login_or_signup_modal"
+                                        data-next-params="{% url 'siae:detail' siae.slug %}"
+                                        title="Ajouter à votre liste d'achat">
                                     Se connecter pour Ajouter à votre liste d'achat
                                 </button>
                             {% endif %}
@@ -67,12 +71,12 @@
                     <div class="fr-grid-row">
                         <div class="fr-col-md-6">
                             <ul class="list-unstyled">
-                                <li class="mb-2">
+                                <li>
                                     <i class="fr-icon-building-line"></i>
                                     <span>{{ siae.get_kind_display }}</span>
                                 </li>
                                 {% if siae.legal_form %}
-                                    <li class="mb-2">
+                                    <li>
                                         <i class="fr-icon-building-fill"></i>
                                         <span>{{ siae.get_legal_form_display }}</span>
                                     </li>
@@ -82,17 +86,12 @@
                         <div class="fr-col-md-6">
                             <div class="badge-group">
                                 {% if siae.is_qpv %}
-                                    <span class="badge badge-pill badge-emploi-lightest" title="Quartier prioritaire de la politique de la ville">QPV</span>
+                                    <span class="fr-badge"
+                                          title="Quartier prioritaire de la politique de la ville">QPV</span>
                                 {% endif %}
-                                {% if siae.is_zrr %}
-                                    <span class="badge badge-pill badge-emploi-lightest" title="Zone de revitalisation rurale">ZRR</span>
-                                {% endif %}
-                                {% for group in siae.groups.all %}
-                                    <span class="badge badge-pill badge-emploi-light">{{ group.name }}</span>
-                                {% endfor %}
-                                {% if siae.is_cocontracting %}
-                                    <span class="badge badge-pill badge-success-light">Ouvert à la co-traitance</span>
-                                {% endif %}
+                                {% if siae.is_zrr %}<span class="fr-badge" title="Zone de revitalisation rurale">ZRR</span>{% endif %}
+                                {% for group in siae.groups.all %}<span class="fr-badge">{{ group.name }}</span>{% endfor %}
+                                {% if siae.is_cocontracting %}<span class="fr-badge">Ouvert à la co-traitance</span>{% endif %}
                             </div>
                         </div>
                     </div>
@@ -103,15 +102,15 @@
             <div class="fr-card__end">
                 <hr />
                 <!-- First row : Description -->
-                <div class="fr-grid-row">
-                    <div class="fr-col-sm-12 img-left">
-                        <div class="il-l">
+                <div class="fr-grid-row fr-mb-4v">
+                    <div class="fr-col-sm-12">
+                        <div>
                             <img src="{% static_theme_images 'ico-bicro-marche-descript-act.svg' %}"
-                                    alt=""
-                                    height="32" />
+                                 alt=""
+                                 height="32" />
                         </div>
-                        <div class="il-r">
-                            <h3 class="h2 mb-1 mt-1">Présentation du prestataire</h3>
+                        <div>
+                            <h2>Présentation du prestataire</h2>
                             <div>
                                 {% if siae.description %}
                                     {{ siae.description|linebreaks }}
@@ -124,40 +123,38 @@
                 </div>
                 <!-- Second & third row : Secteurs, Références -->
                 <hr />
-                <div class="fr-grid-row">
-                    <div class="fr-col-sm-6 img-left">
-                        <div class="il-l">
-                            <img src="{% static_theme_images 'ico-bicro-marche-secteur.svg' %}" alt="" height="32" />
+                <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
+                    <div class="fr-col-sm-6">
+                        <div>
+                            <img src="{% static_theme_images 'ico-bicro-marche-secteur.svg' %}"
+                                 alt=""
+                                 height="32" />
                         </div>
-                        <div class="il-r">
-                            <h3 class="h2 mb-1 mt-1">Secteurs d'activité</h3>
-                            {% if user.is_authenticated and user.is_admin %}
-                                {% for activity in siae.activities.all %}
-                                    {% include "siaes/_siae_activity_content.html" with activity=activity with_collapse=True %}
-                                {% endfor %}
-                            {% else %}
-                                {% if not siae.sector_count %}
-                                    <p>Non renseigné</p>
-                                {% else %}
-                                    <ul>
-                                        {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
-                                    </ul>
-                                {% endif %}
-                            {% endif %}
+                        <div>
+                            <h2>Secteurs d'activité</h2>
+                            {% for activity in siae.activities.all %}
+                                <div class="fr-accordions-group">{% include "siaes/_siae_activity_content.html" with activity=activity %}</div>
+                            {% empty %}
+                                <p>Non renseigné</p>
+                            {% endfor %}
                         </div>
                     </div>
                     {% if siae.client_reference_count %}
-                        <div class="fr-col-sm-6 img-left">
-                            <div class="il-l">
-                                <img src="{% static_theme_images 'ico-bicro-marche-ref-clients.svg' %}" alt="" height="32" />
+                        <div class="fr-col-sm-6">
+                            <div>
+                                <img src="{% static_theme_images 'ico-bicro-marche-ref-clients.svg' %}"
+                                     alt=""
+                                     height="32" />
                             </div>
-                            <div class="il-r">
-                                <h3 class="h2 mb-1 mt-1">Références clients</h3>
+                            <div>
+                                <h2>Références clients</h2>
                                 {% if siae.client_reference_count <= 6 %}
                                     <div class="fr-grid-row">
                                         {% for image in siae.client_references.all %}
                                             <div class="fr-col-12 fr-col-sm-4">
-                                                <img class="fr-responsive-img" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                                <img class="fr-responsive-img"
+                                                     src="{{ image.logo_url }}"
+                                                     alt="{{ image.name }}" />
                                             </div>
                                         {% endfor %}
                                     </div>
@@ -165,7 +162,9 @@
                                     <div class="fr-grid-row">
                                         {% for image in siae.client_references.all|slice:":6" %}
                                             <div class="fr-col-12 fr-col-sm-4">
-                                                <img class="fr-responsive-img" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                                <img class="fr-responsive-img"
+                                                     src="{{ image.logo_url }}"
+                                                     alt="{{ image.name }}" />
                                             </div>
                                         {% endfor %}
                                     </div>
@@ -173,12 +172,20 @@
                                         <div class="fr-grid-row">
                                             {% for image in siae.client_references.all|slice:"6:" %}
                                                 <div class="fr-col-12 fr-col-sm-4">
-                                                    <img class="fr-responsive-img" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                                    <img class="fr-responsive-img"
+                                                         src="{{ image.logo_url }}"
+                                                         alt="{{ image.name }}" />
                                                 </div>
                                             {% endfor %}
                                         </div>
                                     </div>
-                                    <a class="mt-3 is-collapse-caret-clients has-collapse-caret collapsed" data-toggle="collapse" href="#collapseMoreRefClients" role="button" aria-expanded="false" aria-controls="collapseMoreRefClients" title="Plus de références clients">de références clients</a>
+                                    <a class="is-collapse-caret-clients has-collapse-caret collapsed"
+                                       data-toggle="collapse"
+                                       href="#collapseMoreRefClients"
+                                       role="button"
+                                       aria-expanded="false"
+                                       aria-controls="collapseMoreRefClients"
+                                       title="Plus de références clients">de références clients</a>
                                 {% endif %}
                             </div>
                         </div>
@@ -188,21 +195,23 @@
                 {% if siae.offer_count %}
                     <hr />
                     <div class="fr-grid-row">
-                        <div class="fr-col-sm-12 img-left">
-                            <div class="il-l">
+                        <div class="fr-col-sm-12">
+                            <div>
                                 <img src="{% static_theme_images 'ico-bicro-marche-detail.svg' %}"
-                                        alt=""
-                                        height="32" />
+                                     alt=""
+                                     height="32" />
                             </div>
-                            <div class="il-r">
-                                <h3 class="h2 mb-1 mt-1">Détails des prestations effectuées <small>(matériels, lieux, savoir-faire)</small></h3>
+                            <div>
+                                <h2>
+                                    Détails des prestations effectuées <small>(matériels, lieux, savoir-faire)</small>
+                                </h2>
                                 <div class="fr-grid-row">
                                     {% for offer in siae.offers.all %}
                                         <article class="prests-post fr-col-12 {% if siae.offer_count > 1 %}col-lg-6{% endif %} mt-2">
-                                            <h4>
+                                            <h3>
                                                 <img src="{% static 'img/prof_dot.png' %}" alt="" />
                                                 <span>{{ offer.name }}</span>
-                                            </h4>
+                                            </h3>
                                             <div>{{ offer.description|linebreaks }}</div>
                                         </article>
                                     {% endfor %}
@@ -216,21 +225,21 @@
                     <hr />
                     <div class="fr-grid-row">
                         {% if siae.network_count %}
-                            <div class="fr-col-12 fr-col-md-6 img-left">
-                                <div class="il-l">
+                            <div class="fr-col-12 fr-col-md-6">
+                                <div>
                                     <img src="{% static_theme_images 'ico-bicro-marche-reseaux.svg' %}"
-                                            alt=""
-                                            height="32" />
+                                         alt=""
+                                         height="32" />
                                 </div>
-                                <div class="il-r">
-                                    <h3 class="h2 mb-1 mt-1">Réseaux</h3>
+                                <div>
+                                    <h2>Réseaux</h2>
                                     <ul>
                                         {% for network in siae.networks.all %}
                                             <li>
                                                 <a href="{{ network.website }}"
-                                                    class="network_link"
-                                                    rel="noopener"
-                                                    target="_blank">
+                                                   class="network_link"
+                                                   rel="noopener"
+                                                   target="_blank">
                                                     <span>{{ network.name }}</span>
                                                     {% if network.brand %}<span>({{ network.brand }})</span>{% endif %}
                                                 </a>
@@ -241,18 +250,16 @@
                             </div>
                         {% endif %}
                         {% if siae.label_count %}
-                            <div class="fr-col-12 fr-col-md-6 img-left">
-                                <div class="il-l">
+                            <div class="fr-col-12 fr-col-md-6">
+                                <div>
                                     <img src="{% static_theme_images 'ico-bicro-marche-labels.svg' %}"
-                                            alt=""
-                                            height="32" />
+                                         alt=""
+                                         height="32" />
                                 </div>
-                                <div class="il-r">
-                                    <h3 class="h2 mb-1 mt-1">Labels & certifications</h3>
+                                <div>
+                                    <h2>Labels & certifications</h2>
                                     <ul>
-                                        {% for label in siae.labels_old.all %}
-                                            <li>{{ label.name }}</li>
-                                        {% endfor %}
+                                        {% for label in siae.labels_old.all %}<li>{{ label.name }}</li>{% endfor %}
                                     </ul>
                                 </div>
                             </div>
@@ -263,14 +270,14 @@
                 {% if siae.images.count %}
                     <hr />
                     <div class="fr-grid-row">
-                        <div class="fr-col-12 img-left">
-                            <div class="il-l">
+                        <div class="fr-col-12">
+                            <div>
                                 <img src="{% static_theme_images 'ico-bicro-marche-realisation.svg' %}"
-                                        alt=""
-                                        height="32" />
+                                     alt=""
+                                     height="32" />
                             </div>
-                            <div class="il-r">
-                                <h3 class="h2 mb-1 mt-1">Nos réalisations</h3>
+                            <div>
+                                <h2>Nos réalisations</h2>
                             </div>
                         </div>
                     </div>
@@ -279,30 +286,30 @@
                             <div class="fr-col-12 fr-col-sm-4">
                                 <!-- 3 per row -->
                                 <img src="{{ image.image_url }}"
-                                        class="fr-responsive-img"
-                                        title="{{ image.name|default:'' }}"
-                                        loading="lazy" />
+                                     class="fr-responsive-img"
+                                     title="{{ image.name|default:'' }}"
+                                     loading="lazy" />
                             </div>
                         {% endfor %}
                     </div>
                 {% endif %}
                 {% if not siae.user_count and not user.is_authenticated %}
                     <div id="user_update_cta"
-                            class="fr-grid-row justify-content-center mb-5 mb-lg-3 mt-lg-5">
-                        <div class="fr-col-12 fr-col-lg-10">
-                            <div class="card c-card c-card--mini h-100 p-3 p-lg-5 pr-lg-7">
-                                <div class="card-body text-center">
-                                    <h3 class="h2 m-0">C'est votre structure et vous souhaitez modifier ses informations ?</h3>
-                                </div>
-                                <div class="card-footer text-center">
-                                    <a href="{% url 'auth:signup' %}"
-                                        class="btn btn-primary btn-ico stretched-link">
-                                        <span>Inscrivez-vous dès maintenant</span>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                                            <path fill="currentColor" fill-rule="nonzero" stroke="currentColor" d="M1.964 8.95h11.03L9.51 12.737a.451.451 0 00.037.646.474.474 0 00.66-.037L14.386 8.8l.035-.043.033-.05.013-.05V8.539c0-.012.033-.02.033-.044v-.151l-.014-.05-.019-.03-.034-.045-4.193-4.566a.474.474 0 00-.66-.037.452.452 0 00-.036.646l3.45 3.777H1.963a.46.46 0 00-.464.455.46.46 0 00.464.455z">
-                                            </path>
-                                        </svg>
-                                    </a>
+                         class="fr-grid-row fr-mb-5v fr-mb-lg-3v fr-mt-lg-5v">
+                        <div class="fr-col-12">
+                            <div class="fr-card fr-card--shadow">
+                                <div class="fr-card__body">
+                                    <div class="fr-card__content">
+                                        <h3 class="fr-card__title">C'est votre structure et vous souhaitez modifier ses informations ?</h3>
+                                        <div class="fr-card__desc">
+                                            <a href="{% url 'auth:signup' %}"
+                                               id="track_siae_detail_partners_esat_ea"
+                                               class="fr-btn btn-sm btn-outline-primary btn-ico">
+                                                <span>Inscrivez-vous dès maintenant</span>
+                                                <i class="ri-arrow-right-up-line ri-lg"></i>
+                                            </a>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -20,6 +20,14 @@
                     <h3 class="fr-card__title">
                         <a href="{% url 'siae:detail' siae.slug %}">{{ siae.name_display }}</a>
                     </h3>
+                    <p class="fr-text--xs fr-mt-4v">
+                        <span class="fr-badge fr-badge--blue-cumulus fr-mr-2v"
+                              aria-describedby="tooltip-{{ siae.pk }}">{{ siae.kind }}</span> {{ siae.presta_type_display }}
+                        <span class="fr-tooltip fr-placement"
+                              id="tooltip-{{ siae.pk }}"
+                              role="tooltip"
+                              aria-hidden="true">{{ siae.get_kind_display }}</span>
+                    </p>
                 </div>
                 <div class="fr-col-12 fr-col-lg-4">
                     <ul class="fr-tags-group lemarche--align-right">
@@ -68,40 +76,21 @@
                         </li>
                     </ul>
                 </div>
-                <div class="fr-col-12">
-                    <span class="fr-tag">{{ siae.get_kind_display }}</span>
-                </div>
-                <div class="fr-col-12 fr-col-lg-6">
-                    <p>
-                        <span class="fr-icon-briefcase-line" aria-hidden="true"></span> {{ siae.presta_type_display }}
-                    </p>
-                </div>
-                <div class="fr-col-12 fr-col-lg-6">
-                    <p class="fr-m-0">
-                        <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
-                        {{ siae.city }}
-                    </p>
-                </div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col-12">
-                    <ul class="fr-tags-group">
-                        {% for activity in siae.activities.all %}
-                            {% if forloop.counter <= 4 %}
-                                <li>
-                                    <p class="fr-tag">{{ activity.sector_group }}</p>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                        {% if siae.activities.count > 4 %}
-                            <li>
-                                <p class="fr-tag">+ {{ siae.activities.count|add:"-4" }}</p>
-                            </li>
-                        {% endif %}
-                    </ul>
+                    {% siae_sector_groups_display siae display_max=3 current_sector_groups=current_sector_groups %}
                     {% if user.is_authenticated and user.is_admin and not siae.user_count %}
                         <p class="fr-card__detail fr-icon-warning-fill fr-mt-3w">pas encore inscrite</p>
                     {% endif %}
+                </div>
+            </div>
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-lg-6">
+                    <p class="fr-m-0 fr-mt-4v">
+                        <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
+                        {{ siae.city }}
+                    </p>
                 </div>
             </div>
         </div>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -6,14 +6,14 @@
                 <div class="fr-col-1">
                     {% if siae.logo_url %}
                         <img src="{{ siae.logo_url }}"
-                                class="fr-responsive-img"
-                                alt="Logo de la structure {{ siae.name }}"
-                                loading="lazy" />
+                             class="fr-responsive-img"
+                             alt="Logo de la structure {{ siae.name }}"
+                             loading="lazy" />
                     {% else %}
                         <img src="{% static 'img/default-listing.png' %}"
-                                class="fr-responsive-img"
-                                alt="{{ siae.name }}"
-                                loading="lazy" />
+                             class="fr-responsive-img"
+                             alt="{{ siae.name }}"
+                             loading="lazy" />
                     {% endif %}
                 </div>
                 <div class="fr-col-10 fr-col-lg-7">
@@ -27,7 +27,7 @@
                         {% if siae.is_qpv %}
                             <li>
                                 <span class="fr-tag"
-                                        title="Quartier prioritaire de la politique de la ville">QPV</span>
+                                      title="Quartier prioritaire de la politique de la ville">QPV</span>
                             </li>
                         {% endif %}
                         {% if siae.is_zrr %}
@@ -39,34 +39,29 @@
                         <li>
                             {% if user.is_authenticated %}
                                 {% if from_profile or siae.in_user_favorite_list_count_annotated %}
-                                    <button 
-                                        id="favorite-remove-modal-btn"
-                                        class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-star-fill"
-                                        x-data="favoriteItem"
-                                        x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
-                                        @click="remove"
-                                        title="Dans votre liste d'achat">
-                                        Supprimer de votre liste d'achat
-                                    </button>
+                                    <button id="favorite-remove-modal-btn"
+                                            class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-star-fill"
+                                            x-data="favoriteItem"
+                                            x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
+                                            @click="remove"
+                                            title="Dans votre liste d'achat">Supprimer de votre liste d'achat</button>
                                 {% else %}
-                                    <button
-                                        id="favorite-add-modal-btn"
-                                        class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-star-line"
-                                        x-data="favoriteItem"
-                                        x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
-                                        @click="add"
-                                        title="Ajouter à votre liste d'achat">
+                                    <button id="favorite-add-modal-btn"
+                                            class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-star-line"
+                                            x-data="favoriteItem"
+                                            x-init="initOptions('{{ siae.slug }}', '{{ siae.name_display|escapejs }}')"
+                                            @click="add"
+                                            title="Ajouter à votre liste d'achat">
                                         Ajouter à votre liste d'achat
                                     </button>
                                 {% endif %}
                             {% else %}
-                                <button
-                                    id="favorite-modal-btn"
-                                    class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
-                                    data-fr-opened="false"
-                                    aria-controls="login_or_signup_modal"
-                                    data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}"
-                                    title="Ajouter à votre liste d'achat">
+                                <button id="favorite-modal-btn"
+                                        class="fr-btn fr-btn--tertiary-no-outline fr-icon-star-line"
+                                        data-fr-opened="false"
+                                        aria-controls="login_or_signup_modal"
+                                        data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}"
+                                        title="Ajouter à votre liste d'achat">
                                     Se connecter pour Ajouter à votre liste d'achat
                                 </button>
                             {% endif %}
@@ -82,17 +77,28 @@
                     </p>
                 </div>
                 <div class="fr-col-12 fr-col-lg-6">
-                    <p>{% siae_sectors_display siae display_max=3 current_search_query=current_search_query %}</p>
+                    <p class="fr-m-0">
+                        <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
+                        {{ siae.city }}
+                    </p>
                 </div>
             </div>
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col-12">
-                    <p class="fr-m-0">
-                        <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
-                        {{ siae.city }}
-                        <span class="fr-icon-road-map-line fr-ml-2w" aria-hidden="true"></span>
-                        {{ siae.geo_range_pretty_display }}
-                    </p>
+                    <ul class="fr-tags-group">
+                        {% for activity in siae.activities.all %}
+                            {% if forloop.counter <= 4 %}
+                                <li>
+                                    <p class="fr-tag">{{ activity.sector_group }}</p>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                        {% if siae.activities.count > 4 %}
+                            <li>
+                                <p class="fr-tag">+ {{ siae.activities.count|add:"-4" }}</p>
+                            </li>
+                        {% endif %}
+                    </ul>
                     {% if user.is_authenticated and user.is_admin and not siae.user_count %}
                         <p class="fr-card__detail fr-icon-warning-fill fr-mt-3w">pas encore inscrite</p>
                     {% endif %}

--- a/lemarche/templates/siaes/_siae_activity_card.html
+++ b/lemarche/templates/siaes/_siae_activity_card.html
@@ -10,7 +10,7 @@
                     </ul>
                     <p>
                         <span class="fr-icon-briefcase-line" aria-hidden="true"></span>
-                        <span class="fr-sr-only ">Type(s) de prestation :</span>
+                        <span class="fr-sr-only">Type(s) de prestation :</span>
                         <span>{{ activity.presta_type_display }}</span>
                     </p>
                     <p>

--- a/lemarche/templates/siaes/_siae_activity_content.html
+++ b/lemarche/templates/siaes/_siae_activity_content.html
@@ -1,28 +1,23 @@
 {% load siae_sectors_display %}
-
-<p class="h4 lh-sm">
-    {% if with_collapse %}
-        <a href="#collapseSiaeActiviyContent{{ activity.id }}" class="text-decoration-none has-collapse-caret collapsed" data-toggle="collapse">
-            {{ activity.sector_group }}
-        </a>
-    {% else %}
-        {{ activity.sector_group }}
-    {% endif %}
-</p>
-
-<div id="collapseSiaeActiviyContent{{ activity.id }}" class="{% if with_collapse %}pb-3 collapse{% endif %}">
-    <ul style="padding-left:1.5rem">
-        {% siae_sectors_display activity display_max=6 output_format='li' %}
-    </ul>
-
-    <p class="mb-0">
-        <i class="ri-briefcase-4-line mr-1"></i>
-        <span class="sr-only">Type(s) de prestation :</span>
-        <span>{{ activity.presta_type_display }}</span>
-    </p>
-    <p class="mb-0">
-        <i class="ri-map-2-line"></i>
-        <span class="sr-only">Intervient sur : {{ siae.geo_range_pretty_title }}</span>
-        <span>{{ siae.geo_range_pretty_display }}</span>
-    </p>
-</div>
+<section class="fr-accordion">
+    <h3 class="fr-accordion__title">
+        <button class="fr-accordion__btn"
+                aria-expanded="false"
+                aria-controls="accordion-activity-{{ activity.id }}">{{ activity.sector_group }}</button>
+    </h3>
+    <div class="fr-collapse" id="accordion-activity-{{ activity.id }}">
+        <ul>
+            {% siae_sectors_display activity display_max=6 output_format='li' %}
+        </ul>
+        <p class="fr-mt-4w">
+            <span class="fr-icon-briefcase-line" aria-hidden="true"></span>
+            <span class="fr-sr-only">Type(s) de prestation :</span>
+            <span>{{ activity.presta_type_display }}</span>
+        </p>
+        <p>
+            <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
+            <span class="fr-sr-only">Intervient sur :</span>
+            <span>{{ activity.geo_range_pretty_display }}</span>
+        </p>
+    </div>
+</section>

--- a/lemarche/templates/utils/templatetags/siae_sectors_display.html
+++ b/lemarche/templates/utils/templatetags/siae_sectors_display.html
@@ -1,0 +1,12 @@
+<ul class="fr-tags-group">
+    {% for sector_group in current_search_sector_groups %}
+        <li>
+            <span class="fr-tag fr-tag--green-emeraude fr-tag--sm">{{ sector_group }}</span>
+        </li>
+    {% endfor %}
+    {% for sector_group in sector_groups %}
+        <li>
+            <span class="fr-tag fr-tag--sm">{{ sector_group }}</span>
+        </li>
+    {% endfor %}
+</ul>

--- a/lemarche/utils/templatetags/siae_sectors_display.py
+++ b/lemarche/utils/templatetags/siae_sectors_display.py
@@ -39,3 +39,44 @@ def siae_sectors_display(object, display_max=5, current_search_query="", output_
         return mark_safe("".join([f"<li>{elem_name}</li>" for elem_name in values]))
     else:  # "string"
         return ", ".join(values)
+
+
+@register.inclusion_tag("utils/templatetags/siae_sectors_display.html")
+def siae_sector_groups_display(object, display_max=5, current_sector_groups=[]):
+    """
+    Pretty rendering of M2M field SectorGroup for Siae.
+    """
+
+    # to avoid duplicates and display current search values first
+    seen_slugs = set()
+
+    current_values = []
+    # Add sector groups from current_sector_groups if they are in object's activities
+    for sector_group in current_sector_groups:
+        if any(activity.sector_group.slug == sector_group.slug for activity in object.activities.all()):
+            if sector_group.slug not in seen_slugs:
+                current_values.append(sector_group.name)
+                seen_slugs.add(sector_group.slug)
+
+    values = []
+
+    # Add remaining sector groups from object's activities
+    for activity in object.activities.all():
+        if activity.sector_group.slug not in seen_slugs:
+            values.append(activity.sector_group.name)
+            seen_slugs.add(activity.sector_group.slug)
+
+    # alphabetical order here to avoid N+1 queries
+    values = sorted(values)
+
+    # filter number of displayed values
+    groups_count = len(seen_slugs)
+    if groups_count > display_max:
+        display_max_values = display_max - len(current_values)
+        if display_max_values > 0:
+            values = values[:display_max_values]
+        else:
+            values = []
+        values.append(f"+{groups_count-display_max}")
+
+    return {"current_search_sector_groups": sorted(current_values), "sector_groups": values}

--- a/lemarche/utils/tests_templatetags.py
+++ b/lemarche/utils/tests_templatetags.py
@@ -1,55 +1,72 @@
+from django.template import Context, Template
 from django.test import TestCase
 
-from lemarche.sectors.factories import SectorFactory
-from lemarche.siaes.factories import SiaeFactory
+from lemarche.sectors.factories import SectorFactory, SectorGroupFactory
+from lemarche.siaes.factories import SiaeActivityFactory, SiaeFactory
 from lemarche.utils.templatetags.siae_sectors_display import siae_sectors_display
 
 
 class SiaeSectorDisplayTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.siae_with_one_sector = SiaeFactory()
-        cls.siae_with_two_sectors = SiaeFactory()
-        cls.siae_with_many_sectors = SiaeFactory()
+        siae_with_one_sector = SiaeFactory()
+        siae_with_two_sectors = SiaeFactory()
+        siae_with_many_sectors = SiaeFactory()
         cls.siae_etti = SiaeFactory(kind="ETTI")
         sector_1 = SectorFactory(name="Entretien")
         sector_2 = SectorFactory(name="Agro")
         sector_3 = SectorFactory(name="Hygiène")
         sector_4 = SectorFactory(name="Bâtiment")
         sector_5 = SectorFactory(name="Informatique")
-        cls.siae_with_one_sector.sectors.add(sector_1)
-        cls.siae_with_two_sectors.sectors.add(sector_1, sector_2)
-        cls.siae_with_many_sectors.sectors.add(sector_1, sector_2, sector_3, sector_4, sector_5)
+
+        cls.siae_activity_with_one_sector = SiaeActivityFactory(siae=siae_with_one_sector)
+        cls.siae_activity_with_one_sector.sectors.add(sector_1)
+        cls.siae_activity_with_two_sectors = SiaeActivityFactory(siae=siae_with_two_sectors)
+        cls.siae_activity_with_two_sectors.sectors.add(sector_1, sector_2)
+        cls.siae_activity_with_many_sectors = SiaeActivityFactory(siae=siae_with_many_sectors)
+        cls.siae_activity_with_many_sectors.sectors.add(sector_1, sector_2, sector_3, sector_4, sector_5)
+
         cls.siae_etti.sectors.add(sector_1, sector_2, sector_3, sector_4, sector_5)
 
     def test_should_return_list_of_siae_sector_strings(self):
-        self.assertEqual(siae_sectors_display(self.siae_with_one_sector), "Entretien")
-        self.assertEqual(siae_sectors_display(self.siae_with_two_sectors), "Agro, Entretien")  # default ordering: name
+        self.assertEqual(siae_sectors_display(self.siae_activity_with_one_sector), "Entretien")
         self.assertEqual(
-            siae_sectors_display(self.siae_with_many_sectors), "Agro, Bâtiment, Entretien, Hygiène, Informatique"
+            siae_sectors_display(self.siae_activity_with_two_sectors), "Agro, Entretien"
+        )  # default ordering: name
+        self.assertEqual(
+            siae_sectors_display(self.siae_activity_with_many_sectors),
+            "Agro, Bâtiment, Entretien, Hygiène, Informatique",
         )
 
     def test_should_filter_list_of_siae_sectors(self):
         self.assertEqual(
-            siae_sectors_display(self.siae_with_many_sectors, display_max=3), "Agro, Bâtiment, Entretien, …"
+            siae_sectors_display(self.siae_activity_with_many_sectors, display_max=3), "Agro, Bâtiment, Entretien, …"
         )
 
     def test_should_return_list_in_the_specified_format(self):
-        self.assertEqual(siae_sectors_display(self.siae_with_two_sectors, output_format="list"), ["Agro", "Entretien"])
         self.assertEqual(
-            siae_sectors_display(self.siae_with_two_sectors, output_format="li"), "<li>Agro</li><li>Entretien</li>"
+            siae_sectors_display(self.siae_activity_with_two_sectors, output_format="list"), ["Agro", "Entretien"]
+        )
+        self.assertEqual(
+            siae_sectors_display(self.siae_activity_with_two_sectors, output_format="li"),
+            "<li>Agro</li><li>Entretien</li>",
         )
 
     def test_should_have_different_behavior_for_etti(self):
         self.assertEqual(siae_sectors_display(self.siae_etti), "Multisectoriel")
 
     def test_should_filter_list_on_current_search_query(self):
-        self.assertEqual(siae_sectors_display(self.siae_with_one_sector, current_search_query="sectors=agro"), "")
         self.assertEqual(
-            siae_sectors_display(self.siae_with_two_sectors, current_search_query="sectors=entretien"), "Entretien"
+            siae_sectors_display(self.siae_activity_with_one_sector, current_search_query="sectors=agro"), ""
         )
         self.assertEqual(
-            siae_sectors_display(self.siae_with_many_sectors, current_search_query="sectors=entretien&sectors=agro"),
+            siae_sectors_display(self.siae_activity_with_two_sectors, current_search_query="sectors=entretien"),
+            "Entretien",
+        )
+        self.assertEqual(
+            siae_sectors_display(
+                self.siae_activity_with_many_sectors, current_search_query="sectors=entretien&sectors=agro"
+            ),
             "Agro, Entretien",
         )
         # priority is on current_search (over ETTI)
@@ -57,3 +74,103 @@ class SiaeSectorDisplayTest(TestCase):
             siae_sectors_display(self.siae_etti, current_search_query="sectors=entretien&sectors=agro"),
             "Agro, Entretien",
         )
+
+
+class SiaeSectorGroupsDisplayTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.siae_with_one_sector = SiaeFactory()
+        cls.siae_with_three_sectors = SiaeFactory()
+        cls.siae_with_many_sectors = SiaeFactory()
+
+        cls.sector_group_1 = SectorGroupFactory(name="Entretien du linge")
+        cls.sector_group_2 = SectorGroupFactory(name="Espaces verts")
+        cls.sector_group_3 = SectorGroupFactory(name="Bâtiment")
+        cls.sector_group_4 = SectorGroupFactory(name="Agro-Alimentaire")
+
+        sector_1 = SectorFactory(name="Blanchisserie", group=cls.sector_group_1)
+        sector_2 = SectorFactory(name="Génie écologique", group=cls.sector_group_2)
+        sector_3 = SectorFactory(name="Menuiserie", group=cls.sector_group_3)
+        sector_4 = SectorFactory(name="Agriculture", group=cls.sector_group_4)
+        sector_5 = SectorFactory(name="Plomberie", group=cls.sector_group_3)
+
+        siae_with_one_sector_activity = SiaeActivityFactory(
+            siae=cls.siae_with_one_sector, sector_group=cls.sector_group_1
+        )
+        siae_with_one_sector_activity.sectors.add(sector_1)
+
+        siae_with_three_sectors_activity_1 = SiaeActivityFactory(
+            siae=cls.siae_with_three_sectors, sector_group=cls.sector_group_1
+        )
+        siae_with_three_sectors_activity_1.sectors.add(sector_1)
+        siae_with_three_sectors_activity_2 = SiaeActivityFactory(
+            siae=cls.siae_with_three_sectors, sector_group=cls.sector_group_2
+        )
+        siae_with_three_sectors_activity_2.sectors.add(sector_2)
+        siae_with_three_sectors_activity_3 = SiaeActivityFactory(
+            siae=cls.siae_with_three_sectors, sector_group=cls.sector_group_3
+        )
+        siae_with_three_sectors_activity_3.sectors.add(sector_3, sector_5)
+
+        siae_with_many_sectors_activity_1 = SiaeActivityFactory(
+            siae=cls.siae_with_many_sectors, sector_group=cls.sector_group_1
+        )
+        siae_with_many_sectors_activity_1.sectors.add(sector_1)
+        siae_with_many_sectors_activity_2 = SiaeActivityFactory(
+            siae=cls.siae_with_many_sectors, sector_group=cls.sector_group_2
+        )
+        siae_with_many_sectors_activity_2.sectors.add(sector_2)
+        siae_with_many_sectors_activity_3 = SiaeActivityFactory(
+            siae=cls.siae_with_many_sectors, sector_group=cls.sector_group_3
+        )
+        siae_with_many_sectors_activity_3.sectors.add(sector_3)
+        siae_with_many_sectors_activity_4 = SiaeActivityFactory(
+            siae=cls.siae_with_many_sectors, sector_group=cls.sector_group_4
+        )
+        siae_with_many_sectors_activity_4.sectors.add(sector_4)
+        siae_with_many_sectors_activity_5 = SiaeActivityFactory(
+            siae=cls.siae_with_many_sectors, sector_group=cls.sector_group_3
+        )
+        siae_with_many_sectors_activity_5.sectors.add(sector_5)
+
+    # Test siae_sector_groups_display if return only one sector group
+    def test_should_return_html_with_siae_sector_groups(self):
+        template = Template(
+            "{% load siae_sectors_display %}"
+            "{% siae_sector_groups_display siae display_max=3 current_sector_groups=current_sector_groups %}"
+        )
+
+        # Render the template with a context (if needed)
+        rendered = template.render(Context({"siae": self.siae_with_one_sector, "current_sector_groups": []}))
+
+        self.assertInHTML("Entretien du linge", rendered)
+        self.assertNotIn("+", rendered)
+
+        rendered = template.render(Context({"siae": self.siae_with_three_sectors, "current_sector_groups": []}))
+        self.assertInHTML("Bâtiment", rendered)
+        self.assertInHTML("Entretien du linge", rendered)
+        self.assertInHTML("Espaces verts", rendered)
+        self.assertNotIn("+", rendered)
+
+        rendered = template.render(Context({"siae": self.siae_with_many_sectors, "current_sector_groups": []}))
+
+        self.assertInHTML("Agro-Alimentaire", rendered)
+        self.assertInHTML("Bâtiment", rendered)
+        self.assertInHTML("Entretien du linge", rendered)
+        self.assertInHTML("+1", rendered)
+
+        self.assertNotIn("Espaces verts", rendered)
+
+        rendered = template.render(
+            Context(
+                {
+                    "siae": self.siae_with_many_sectors,
+                    "current_sector_groups": [self.sector_group_3],
+                }
+            )
+        )
+        self.assertInHTML('<span class="fr-tag fr-tag--green-emeraude fr-tag--sm">Bâtiment</span>', rendered)
+        self.assertInHTML("Agro-Alimentaire", rendered)
+        self.assertInHTML("Entretien du linge", rendered)
+        self.assertInHTML("+1", rendered)
+        self.assertNotIn("Espaces verts", rendered)

--- a/lemarche/www/dashboard_favorites/tests.py
+++ b/lemarche/www/dashboard_favorites/tests.py
@@ -34,5 +34,8 @@ class DashboardFavoriteListViewTest(TestCase):
         # favorite list user
         self.client.force_login(self.user_favorite_list)
         url = reverse("dashboard_favorites:list_detail", args=[self.favorite_list_1.slug])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+
+        # check number of queries
+        with self.assertNumQueries(6):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)

--- a/lemarche/www/dashboard_favorites/views.py
+++ b/lemarche/www/dashboard_favorites/views.py
@@ -64,7 +64,7 @@ class DashboardFavoriteListCreateView(LoginRequiredMixin, SuccessMessageMixin, C
 
 class DashboardFavoriteListDetailView(FavoriteListOwnerRequiredMixin, DetailView):
     template_name = "favorites/dashboard_favorite_list_detail.html"
-    queryset = FavoriteList.objects.prefetch_related("siaes").all()
+    queryset = FavoriteList.objects.prefetch_related("siaes", "siaes__activities__sector_group").all()
     context_object_name = "favorite_list"
 
     def get_context_data(self, **kwargs):

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -230,6 +230,8 @@ class SiaeFilterForm(forms.Form):
         if not hasattr(self, "cleaned_data"):
             self.full_clean()
 
+        qs = qs.prefetch_related("activities__sector_group")
+
         kinds = self.cleaned_data.get("kind", None)
         if kinds:
             qs = qs.filter(kind__in=kinds)

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -64,7 +64,7 @@ class SiaeSearchNumQueriesTest(TestCase):
         # See https://docs.djangoproject.com/en/5.1/ref/contrib/sites/#caching-the-current-site-object
         Site.objects.get_current()
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.get(url)
             siaes = list(response.context["siaes"])
             self.assertEqual(len(siaes), 20)

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -120,6 +120,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
                 current_sectors = siae_search_form.cleaned_data.get("sectors")
                 if current_sectors:
                     context["current_sectors"] = list(current_sectors.values("id", "slug", "name"))
+                    context["current_sector_groups"] = list(set(sector.group for sector in current_sectors))
 
         # store the current search query in the session
         current_search_query = self.request.GET.urlencode()


### PR DESCRIPTION
### Quoi ?

Affichage des secteurs d'activité et types de prestation des activités sur les cartes des structures sur la recherche, sur la liste de favoris et sur la fiche structure

### Pourquoi ?

Pour tenir compte du système des activités des structures.

### Comment ?

Avec un template tag pour gérer l'affichage des secteurs d'activités. Dans la recherche, les secteurs sélectionnés doivent s'afficher en premier avec un style différent.

Et avec des accordéons sur la fiche structure.

### Captures d'écran

Avant

![screenshot-staging lemarche inclusion beta gouv fr-2024 11 13-18_25_23](https://github.com/user-attachments/assets/a49cd0d0-109f-409f-b684-ee9c00020a40)

Après

![screenshot-marche localhost_8880-2024 11 13-18_24_32](https://github.com/user-attachments/assets/9ecd93bb-61d7-407f-ada4-ff53a67046dd)

Avant

![screenshot-lemarche inclusion beta gouv fr-2024 11 13-18_28_51](https://github.com/user-attachments/assets/c66e2e13-dd60-4689-87b0-314aae86a90a)

Après

![screenshot-marche localhost_8880-2024 11 13-18_29_29](https://github.com/user-attachments/assets/89b26f28-6c88-41e3-9056-61af6a294787)
