### PR TITLE
feat(Besoin): Ajout d'un template de mail transactionnel quand le besoin est suivi par un partenaire commercial

### DIFF
--- a/lemarche/tenders/migrations/0094_add_templatetransactional_tender_author_commercial_partners.py
+++ b/lemarche/tenders/migrations/0094_add_templatetransactional_tender_author_commercial_partners.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def create_template(apps, schema_editor):
+    TemplateTransactional = apps.get_model("conversations", "TemplateTransactional")
+    TemplateTransactional.objects.create(
+        name="Dépôt de besoin : auteur : notification quand son besoin a été validé et pris en charge par les partenaires commerciaux",
+        code="TENDERS_AUTHOR_CONFIRMATION_VALIDATED_COMMERCIAL_PARTNERS",
+        description="Envoyé à l'auteur du besoin lorsque son besoin a été validé et qu'il n'est pas envoyé aux structures mais proposé aux partenaires commerciaux",
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenders", "0093_alter_tender_send_to_commercial_partners_only"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_template),
+    ]

--- a/lemarche/tenders/migrations/0094_add_templatetransactional_tender_author_commercial_partners.py
+++ b/lemarche/tenders/migrations/0094_add_templatetransactional_tender_author_commercial_partners.py
@@ -10,11 +10,16 @@ def create_template(apps, schema_editor):
     )
 
 
+def delete_template(apps, schema_editor):
+    TemplateTransactional = apps.get_model("conversations", "TemplateTransactional")
+    TemplateTransactional.objects.get(code="TENDERS_AUTHOR_CONFIRMATION_VALIDATED_COMMERCIAL_PARTNERS").delete()
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("tenders", "0093_alter_tender_send_to_commercial_partners_only"),
     ]
 
     operations = [
-        migrations.RunPython(create_template),
+        migrations.RunPython(create_template, reverse_code=delete_template),
     ]

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -225,7 +225,7 @@ class SiaeEditActivitiesCreateView(SiaeMemberRequiredMixin, CreateView):
         return reverse_lazy("dashboard_siaes:siae_edit_activities", args=[self.kwargs.get("slug")])
 
     def get_success_message(self, cleaned_data):
-        return mark_safe(f"Votre activité <strong>{cleaned_data['sector_group']}</strong> a été crée avec succès.")
+        return mark_safe(f"Votre activité <strong>{cleaned_data['sector_group']}</strong> a été créée avec succès.")
 
 
 class SiaeEditActivitiesEditView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -372,7 +372,13 @@ def send_confirmation_published_email_to_author(tender: Tender):
     """
     Send email to the author when the tender is published to the siaes
     """
-    email_template = TemplateTransactional.objects.get(code="TENDERS_AUTHOR_CONFIRMATION_VALIDATED")
+
+    template_code = (
+        "TENDERS_AUTHOR_CONFIRMATION_VALIDATED_COMMERCIAL_PARTNERS"
+        if tender.send_to_commercial_partners_only
+        else "TENDERS_AUTHOR_CONFIRMATION_VALIDATED"
+    )
+    email_template = TemplateTransactional.objects.get(code=template_code)
     recipient_list = whitelist_recipient_list([tender.author.email])
     if len(recipient_list):
         recipient_email = recipient_list[0]


### PR DESCRIPTION
### Quoi ?

Ajout d'un template de mail spécifique à destination des auteurs de besoin qui ont été pris en charge par un partenaire commercial. 

+ correction d'une petite faute d'orthographe

### Pourquoi ?

Pour éviter aux acheteurs de recevoir un mail indiquant 0 fournisseur trouvé et de recevoir un appel dans la foulée indiquant le contraire.

### Comment ?

À la validation du besoin, le template n'est pas le même si le besoin a été marqué pour être envoyé aux partenaires commerciaux.

### Autre

Le `TemplateTransactional` est créé par la migration, mais l'id devra être ajouté en production et passé en actif.