### PR TITLE
fix: Correction au niveau des logos d'entête

### DIFF
--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -1,13 +1,11 @@
 {% load i18n static theme_inclusion %}
-
 {% if not user.is_authenticated %}
-    {% if page.slug == "accueil-structure" %}
-        {% include "includes/_header_for_buyers.html" %}
-    {% else %}
-        {% include "includes/_header_for_siaes.html" %}
-    {% endif %}
+  {% if page.slug == "accueil-structure" %}
+    {% include "includes/_header_for_buyers.html" %}
+  {% else %}
+    {% include "includes/_header_for_siaes.html" %}
+  {% endif %}
 {% endif %}
-
 <header role="banner" class="fr-header" id="header">
   <div class="fr-header__body">
     <div class="fr-container">
@@ -17,27 +15,21 @@
             <div class="fr-header__logo">
               {% block brand %}
                 {% translate "Home page" as home_page %}
-                <a href="/" title="{{ home_page }} — {{ SITE_CONFIG.site_title }}">
+                <a href="/"
+                   title="{{ home_page }} — {{ settings.content_manager.CmsDsfrConfig.header_brand }}">
                   <p class="fr-logo">
-                    {{ SITE_CONFIG.header_brand_html|default_if_none:"république<br />française" | safe }}
+                    {{ settings.content_manager.CmsDsfrConfig.header_brand_html|default_if_none:"république<br />française" | safe }}
                   </p>
                 </a>
               {% endblock brand %}
             </div>
-            {% comment "" %}
-            {% block operator_logo %}
-              {% if SITE_CONFIG.operator_logo_file and SITE_CONFIG.operator_logo_alt %}
-                <div class="fr-header__operator">
-                  <img class="fr-responsive-img"
-                       src="{{ SITE_CONFIG.operator_logo_file.url }}"
-                       alt="{{ SITE_CONFIG.operator_logo_alt }}"
-                       {% if SITE_CONFIG.operator_logo_width >= 1 %}style="max-width:{{ SITE_CONFIG.operator_logo_width }}rem;"{% endif %} />
-                </div>
-              {% endif %}
-              {% endblock operator_logo %}
-              {% endcomment %}
-              <div class="fr-header__operator">
-                <a href="{{ HOME_PAGE_PATH }}"><img class="fr-responsive-img" style="max-width:8rem;" src="{% static_theme_images 'logo-marche-inclusion.svg' %}" alt="Le marché de l'inclusion"></a>
+            <div class="fr-header__operator">
+              <a href="{{ HOME_PAGE_PATH }}">
+                <img class="fr-responsive-img"
+                     style="max-width:16rem"
+                     src="{% static_theme_images 'logo-marche-inclusion.svg' %}"
+                     alt="Le marché de l'inclusion">
+              </a>
             </div>
             {% block burger_menu %}
               {% translate "Menu" as menu_label %}
@@ -46,37 +38,18 @@
                         data-fr-opened="false"
                         aria-controls="fr-menu-mobile"
                         id="fr-btn-menu-mobile"
-                        title="{{ menu_label }}">
-                  {{ menu_label }}
-                </button>
+                        title="{{ menu_label }}">{{ menu_label }}</button>
               </div>
             {% endblock burger_menu %}
-          </div>
-          <div class="fr-header__service">
-            {% block service_title %}
-              <a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
-                <p class="fr-header__service-title">
-                  {{ SITE_CONFIG.site_title }}
-                  {% if SITE_CONFIG.beta_tag %}
-                    <span class="fr-badge fr-badge--sm fr-badge--green-emeraude">BETA</span>
-                  {% endif %}
-                </p>
-              </a>
-            {% endblock service_title %}
-            <p class="fr-header__service-tagline">
-              {% block service_tagline %}
-                {{ SITE_CONFIG.site_tagline }}
-              {% endblock service_tagline %}
-            </p>
           </div>
         </div>
         <div class="fr-header__tools">
           <div class="fr-header__tools-links">
-              {% block header_tools %}
-                {% with tender_siae_unread_count=user.tender_siae_unread_count %}
-                  {% include "layouts/_header_nav_primary_items.html" %}
-                {% endwith %}
-              {% endblock header_tools %}
+            {% block header_tools %}
+              {% with tender_siae_unread_count=user.tender_siae_unread_count %}
+                {% include "layouts/_header_nav_primary_items.html" %}
+              {% endwith %}
+            {% endblock header_tools %}
           </div>
           {% block header_search %}
           {% endblock header_search %}
@@ -89,17 +62,14 @@
          id="fr-menu-mobile"
          aria-labelledby="fr-btn-menu-mobile">
       <div class="fr-container">
-        <button class="fr-btn--close fr-btn" aria-controls="fr-menu-mobile">
-          {% translate "Close" %}
-        </button>
-        <div class="fr-header__menu-links">
-        </div>
+        <button class="fr-btn--close fr-btn" aria-controls="fr-menu-mobile">{% translate "Close" %}</button>
+        <div class="fr-header__menu-links"></div>
         {% translate "Main menu" as main_menu_label %}
         <nav role="navigation"
              class="fr-nav"
              id="fr-navigation"
              aria-label="{{ main_menu_label }}">
-             {% include 'layouts/_header_nav_secondary_items.html' %}
+          {% include 'layouts/_header_nav_secondary_items.html' %}
         </nav>
       </div>
     </div>

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -1,7 +1,7 @@
 {% load static compress dsfr_tags %}
 <!DOCTYPE html>
 <html lang="{% block lang %}fr{% endblock lang %}"
-      {% if SITE_CONFIG.mourning %}data-fr-mourning{% endif %}>
+      {% if settings.content_manager.CmsDsfrConfig.mourning %}data-fr-mourning{% endif %}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport"
@@ -48,8 +48,8 @@
     {% block header %}
       {% include "layouts/_header.html" %}
     {% endblock header %}
-    {% if SITE_CONFIG.notice %}
-      {% dsfr_notice title=SITE_CONFIG.notice %}
+    {% if settings.content_manager.CmsDsfrConfig.notice %}
+      {% dsfr_notice title=settings.content_manager.CmsDsfrConfig.notice %}
     {% endif %}
     {% block breadcrumb %}
       {% comment %} empty because managed for each type of page {% endcomment %}


### PR DESCRIPTION
### Quoi ?

Correction de l'intégration des logos et texte de l'entête

### Pourquoi ?

La mention "République Français" n'apparaissait plus.

### Comment ?

En remplaçant la variable obsolète "SITE_CONFIG" pour prendre les infos renseignées dans la partie Site configuration de Wagtail

### Captures d'écran

Avant:

![image](https://github.com/user-attachments/assets/744aebb6-cefd-48bf-ab1c-97ddf13975ae)

Après:

![image](https://github.com/user-attachments/assets/a5f4db9b-61f4-4a77-984e-c999ec501a89)

