### PR TITLE
fix: Amélioration de la commande 'create_content_pages'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ shell_on_postgres_container:
 populate_db:
 	pg_restore -d marche --if-exists --clean --no-owner --no-privileges lemarche/perimeters/management/commands/data/perimeters_20220104.sql
 	ls -d lemarche/fixtures/django/* | xargs django-admin loaddata
-	djan-admin create_content_pages
+	django-admin create_content_pages
 
 populate_db_container:
 	docker compose exec -ti app bash -c "ls -d lemarche/fixtures/django/* | xargs django-admin loaddata"

--- a/lemarche/cms/management/commands/create_content_pages.py
+++ b/lemarche/cms/management/commands/create_content_pages.py
@@ -1,17 +1,23 @@
 import json
 
 from django.core.management.base import BaseCommand
-from wagtail.models import Site
+from wagtail.models import Page
 
 from content_manager.models import ContentPage
 
 
 class Command(BaseCommand):
     help = """
-    Creates a series of content pages.
+    Créé une série de pages de type ContentPage.
     """
 
     def handle(self, *args, **kwargs):
+        try:
+            home_page = Page.objects.get(title="Accueil")
+        except Page.DoesNotExist:
+            self.stdout.write(self.style.ERROR("La page 'Accueil' n'existe pas."))
+            return
+
         try:
             with open("lemarche/fixtures/cms_content_pages.json") as f:
                 pages_data = json.load(f)
@@ -28,8 +34,6 @@ class Command(BaseCommand):
             )
             return
 
-        home_page = Site.objects.filter(is_default_site=True).first().root_page
-
         for page_data in pages_data:
             slug = page_data["slug"]
             title = page_data["title"]
@@ -41,15 +45,14 @@ class Command(BaseCommand):
         """
         Creates a page for the site.
         """
-
         # Don't replace or duplicate an already existing page
         already_exists = ContentPage.objects.filter(slug=slug).first()
         if already_exists:
-            self.stdout.write(f"The {slug} page seem to already exist with id {already_exists.id}")
+            self.stdout.write(f"La page /{slug}/ semble déjà exister avec l'id {already_exists.id}")
             return already_exists
 
         new_page = parent_page.add_child(instance=ContentPage(title=title, body=body, slug=slug, show_in_menus=True))
 
-        self.stdout.write(self.style.SUCCESS(f"Page {slug} created with id {new_page.id}"))
+        self.stdout.write(self.style.SUCCESS(f"Page /{slug}/ créée avec l'id {new_page.id}"))
 
         return new_page

--- a/lemarche/cms/tests/test_commands.py
+++ b/lemarche/cms/tests/test_commands.py
@@ -2,37 +2,67 @@ import json
 
 from django.core.management import call_command
 from django.test import Client, TestCase
-from wagtail.models import Site
+from wagtail.models import Page, Site
 
 from content_manager.models import ContentPage
 
 
-class CreateContentPagesCommandTests(TestCase):
+class CreateContentPagesCommandTest(TestCase):
+    def setUp(self):
+        self.root_page = Page.get_root_nodes().first()
+        self.home_page = Page(title="Accueil")
+        self.root_page.add_child(instance=self.home_page)
+        self.home_page.save_revision().publish()
+
+        # We change root_page of default site
+        Site.objects.filter(hostname="localhost", is_default_site=True).update(root_page=self.home_page)
+
+    def test_parent_page_setup(self):
+        """Test the parent page for the home page is correctly set up"""
+        self.assertIsNotNone(self.root_page, "La page racine n'a pas été trouvée.")
+        self.assertIsNotNone(self.home_page, "La page parente 'Accueil' n'a pas été trouvée.")
+        self.assertTrue(self.home_page.live, "La page parente 'Accueil' n'est pas publiée.")
+        self.assertIn(
+            self.home_page, self.root_page.get_children(), "La page 'Accueil' n'est pas un enfant direct de la racine."
+        )
+
+        response = self.client.get(self.home_page.get_url())
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"La page d'accueil n'est pas accessible (status: {response.status_code}).",
+        )
+
     def test_create_content_pages_with_json(self):
-        client = Client()
+        """Test the content pages are correctly created from the JSON file"""
         with open("lemarche/fixtures/cms_content_pages.json") as f:
             pages_data = json.load(f)
 
         call_command("create_content_pages")
 
-        # Check that the pages were created
         for page_data in pages_data:
             slug = page_data["slug"]
-            self.assertTrue(
-                ContentPage.objects.filter(slug=slug).exists(), msg=f"La page avec le slug '{slug}' n'a pas été créée."
+
+            try:
+                page = ContentPage.objects.get(slug=slug)
+            except ContentPage.DoesNotExist:
+                self.fail(f"La page avec le slug '{slug}' n'a pas été trouvée.")
+
+            self.assertEqual(
+                page.get_parent(), self.home_page, f"La page '{slug}' n'est pas reliée à la page 'Accueil'."
             )
 
-            response = client.get(f"/{slug}/")
+            client = Client()
+            response = client.get(page.get_url())
             self.assertEqual(
                 response.status_code,
                 200,
-                msg=f"La page avec le slug '{slug}' n'est pas accessible (status: {response.status_code}).",
+                f"La page avec le slug '{slug}' n'est pas accessible (status: {response.status_code}).",
             )
 
     def test_prevent_duplicate_page_creation(self):
-        """Ensure the command does not create duplicate pages"""
-        home_page = Site.objects.get(is_default_site=True).root_page
-        home_page.add_child(instance=ContentPage(slug="mentions-legales", title="Mentions légales"))
+        """Test the command does not create duplicate pages"""
+        self.home_page.add_child(instance=ContentPage(slug="mentions-legales", title="Mentions légales"))
 
         call_command("create_content_pages")
 


### PR DESCRIPTION
### Quoi ?

- Amélioration de la commande `create_content_pages`
- Amélioration des tests de cette commande
- Correction d'une faute de frappe dans Makefile

### Pourquoi ?

Pour que les pages créées soient des enfants directs de la page "Accueil" au lieu de la page "Welcome to your new Wagtail site !"

### Comment ?

En modifiant le queryset qui ciblait la page Accueil pour s'assurer que le bon site est sélectionné.

### Autre

Je pense qu'il y a une confusion dans les sites de Wagtail en local. Par défaut, Wagtail créé un site avec : 
- une root_page "Welcome to your new Wagtail site !"
- un hostname "localhost"
- le champ `is_default_site` à True

Or, dans la fixture '20_cms.json' (capture d'écran ci-dessous), vous pouvez voir  qu'un second site est créé avec : 
- une root_page d'un id 25 (qui correspond à la page "Accueil")
- un hostname "localhost"
- le champ `is_default_site` à True

Ce qui est bizarre puisque le champ `hostname` est censé être unique et que deux sites ne peuvent être les sites par défaut.

### Captures d'écran

fichier '20_cms.json'
![fixture_cms](https://github.com/user-attachments/assets/e8e88f4a-14a3-49a9-8de6-09d1f56ccea3)