### PR TITLE
fix(Secteurs d'activités): Mise à jour du calcul du nombre de secteurs pour le déduire des activités associées

### DIFF
--- a/lemarche/siaes/management/commands/update_siae_count_fields.py
+++ b/lemarche/siaes/management/commands/update_siae_count_fields.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         for index, siae in enumerate(siae_queryset):
             # M2M
             siae.user_count = siae.users.count()
-            siae.sector_count = siae.sectors.count()
+            siae.sector_count = siae.activities.values_list("sector_group").distinct().count()
             siae.network_count = siae.networks.count()
             siae.group_count = siae.groups.count()
             # FK

--- a/lemarche/siaes/tests/test_models.py
+++ b/lemarche/siaes/tests/test_models.py
@@ -5,9 +5,9 @@ from lemarche.labels.factories import LabelFactory
 from lemarche.networks.factories import NetworkFactory
 from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.perimeters.models import Perimeter
-from lemarche.sectors.factories import SectorFactory
 from lemarche.siaes import constants as siae_constants, utils as siae_utils
 from lemarche.siaes.factories import (
+    SiaeActivityFactory,
     SiaeClientReferenceFactory,
     SiaeFactory,
     SiaeGroupFactory,
@@ -171,8 +171,7 @@ class SiaeModelTest(TestCase):
         )
         self.assertTrue(score_completion_before < siae_full.completion_rate_calculated)
         score_completion_before = siae_full.completion_rate_calculated
-        sector = SectorFactory()
-        siae_full.sectors.add(sector)
+        SiaeActivityFactory(siae=siae_full)
         SiaeOfferFactory(siae=siae_full)
         SiaeLabelOldFactory(siae=siae_full)
         siae_full.save()  # to update stats
@@ -186,7 +185,7 @@ class SiaeModelTest(TestCase):
             # contact_phone="0000000000",
             description="test",
         )
-        siae_full_2.sectors.add(sector)
+        SiaeActivityFactory(siae=siae_full_2)
         SiaeOfferFactory(siae=siae_full_2)
         SiaeLabelOldFactory(siae=siae_full_2)
         siae_full_2.save()  # to update stats
@@ -265,13 +264,11 @@ class SiaeModelSaveTest(TestCase):
         siae.save()
         self.assertEqual(siae.offer_count, 1)
 
-    def test_update_m2m_sector_count_on_save(self):
+    def test_update_o2m_sector_count_on_save(self):
         siae = SiaeFactory()
-        sector = SectorFactory()
         self.assertEqual(siae.sector_count, 0)
-        siae.sectors.add(sector)
-        self.assertEqual(siae.sectors.count(), 1)
-        # siae.save()  # no need to run save(), m2m_changed signal was triggered above
+        SiaeActivityFactory(siae=siae)
+        self.assertEqual(siae.activities.count(), 1)
         self.assertEqual(siae.sector_count, 1)
 
     def test_update_m2m_network_count_on_save(self):
@@ -328,8 +325,7 @@ class SiaeModelSaveTest(TestCase):
         siae = SiaeFactory(description="")
         user = UserFactory()
         siae.users.add(user)
-        sector = SectorFactory()
-        siae.sectors.add(sector)
+        SiaeActivityFactory(siae=siae)
         self.assertIsNone(siae.content_filled_basic_date)
         siae.description = "test"
         siae.save()

--- a/lemarche/templates/dashboard/siae_edit_base.html
+++ b/lemarche/templates/dashboard/siae_edit_base.html
@@ -37,7 +37,7 @@
                                 <ol class="mb-0">
                                     {% if not siae.sector_count %}
                                         <li>
-                                            <a href="{% url 'dashboard_siaes:siae_edit_search' siae.slug %}">Ajoutez un ou plusieurs secteurs d'activité</a>
+                                            <a href="{% url 'dashboard_siaes:siae_edit_activities' siae.slug %}">Ajoutez un ou plusieurs secteurs d'activité</a>
                                         </li>
                                     {% endif %}
                                     {% if not siae.description and not siae.logo_url %}

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -68,7 +68,7 @@ def generate_siae_row(siae: Siae, siae_field_list):
             col_value = "Oui" if getattr(siae, field_name, None) else "Non"
         # ManyToManyFields
         elif field_name == "sectors":
-            col_value = siae.sectors_full_list_string()
+            col_value = siae.sector_groups_full_list_string()
         # Complex fields
         elif field_name == "contact_phone":
             col_value = siae.contact_phone_display


### PR DESCRIPTION
### Quoi ?

Mise à jour du calcul du nombre de secteurs d'activités pour une structure

### Pourquoi ?

Avec la nouvelle gestion des activités, le calcul n'est plus bon et un message d'information invite à saisir des activités alors qu'il y en a déjà.

À noter que ça impacte également le taux de complétion de la fiche structure.

### Comment ?

Remplacement du Signal pour une mise à jour dynamique à la modification.
Adaptation de la commande de mise à jour pour la mise à plat hebdomadaire des compteurs.
Ajout de tests

### Captures d'écran

![image](https://github.com/user-attachments/assets/05d1a7d9-8925-4425-ad11-1f2c22d4e27d)
