### PR TITLE
fix(Liste des dépôts de besoin): Correction d'une erreur javascript pour éviter un bug sur la liste

### DIFF
--- a/lemarche/static/js/utils.js
+++ b/lemarche/static/js/utils.js
@@ -20,8 +20,6 @@ window.addEventListener('DOMContentLoaded', function () {
         location.href = "mailto:?" + rot13(this.dataset['nextUrl']);
     });
 
-    initModalMessages();
-
     initSuperBadges();
 
     // some elements have their url in data-url attribute


### PR DESCRIPTION
### Quoi ?

Corriger le clic sur les dépôts de besoins pour les acheteurs

### Pourquoi ?

Parce qu'une erreur js empêche le javascript de géré le clic

### Comment ?

En supprimant l'appel à une fonctionne qui n'existe plus.

### Capture d'écran

![image](https://github.com/user-attachments/assets/e0d5b151-4074-45e8-ae2d-776e6e074dc8)
