### PR TITLE
feat(Admin): Ajout de 'contact_phone' dans la recherche

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -314,8 +314,8 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "start_working_date",
     )
     # filter on "perimeters"? (loads ALL the perimeters... Use django-admin-autocomplete-filter instead?)
-    search_fields = ["id", "title", "slug", "author__id", "author__email"]
-    search_help_text = "Cherche sur les champs : ID, Titre, Slug, Auteur (ID, E-mail)"
+    search_fields = ["id", "title", "slug", "author__id", "author__email", "contact_phone"]
+    search_help_text = "Cherche sur les champs : ID, Titre, Slug, Auteur (ID, E-mail), Contact Phone"
     ordering = ["-created_at"]
 
     form = TenderForm


### PR DESCRIPTION
### Quoi ?

Ajout du champ `contact_phone` dans la recherche de l'admin.

### Pourquoi ?

Pour que les admins puissent trouver un besoin à partir de son numéro de téléphone.

### Comment ?

En ajoutant le champ `contact_phone` dans les search_fields.

### Captures d'écran (optionnel)
tenders.admin.py
![admin_search](https://github.com/user-attachments/assets/7e5499a6-7b14-464c-9957-1beb39ba29c2)