### PR TITLE
refactor(authentication): Modifier le niveau de log en info pour la méthode d'authentification du jeton d'URL obsolète

### DIFF
--- a/lemarche/api/authentication.py
+++ b/lemarche/api/authentication.py
@@ -27,7 +27,7 @@ class CustomBearerAuthentication(BaseAuthentication):
         elif request.GET.get("token"):  # Otherwise, try the URL parameter
             token = request.GET.get("token")
             warning_issued = True
-            logger.warning("Authentication via URL token detected. This method is deprecated and less secure.")
+            logger.info("Authentication via URL token detected. This method is deprecated and less secure.")
 
         # If no token is provided
         if not token:


### PR DESCRIPTION
### Quoi ?

Passage du message en info plutôt qu'un warning.

### Pourquoi ?

Pour ne pas envoyer des events en passe ..

### Comment ?

Appel à la méthode info.