### PR TITLE
fix(Brevo): AttributeError in 'api_brevo.create_contact'

### DIFF
--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -81,7 +81,7 @@ def create_contact(user, list_id: int, tender=None):
             api_response = api_instance.create_contact(new_contact).to_dict()
             user.brevo_contact_id = api_response.get("id")
             user.save()
-            logger.info(f"Success Brevo->ContactsApi->create_contact: {api_response.body}")
+            logger.info(f"Success Brevo->ContactsApi->create_contact: {api_response}")
         else:
             logger.info("User already exists in Brevo")
     except ApiException as e:


### PR DESCRIPTION
### Quoi ?

AttributeError dans la méthode `create_contact` de api_brevo.py.

### Comment ?

En retirant .body du dictionnaire `api_response` qui n'a qu'une clé : `id`