### PR TITLE
fix(Import des emplois): exclusion du type OPCS de l'import

### DIFF
--- a/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
+++ b/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
@@ -213,12 +213,14 @@ class Command(BaseCommand):
         c1_list_filtered = []
 
         for c1_siae in c1_list:
-            if c1_siae["kind"] not in ("RESERVED",):  # do nothing if kind is filtered as reserved
+            if c1_siae["kind"] not in ["RESERVED", "OPCS"]:  # do nothing if kind is filtered as reserved
                 if c1_siae["kind"] in siae_constants.KIND_INSERTION_LIST + siae_constants.KIND_HANDICAP_LIST:
                     c1_list_filtered.append(c1_siae)
                 else:
                     logger.error(
-                        f"Kind not supported: {c1_siae['kind']}/{c1_siae['id']}/{c1_siae['name']}/{c1_siae['siret']}"
+                        "Kind not supported: %s",
+                        c1_siae["kind"],
+                        extra=dict(c1_id=c1_siae["id"], c1_name=c1_siae["name"], c1_siret=c1_siae["siret"]),
                     )
         return c1_list_filtered
 


### PR DESCRIPTION
### Quoi ?

Les OPCS n'ont pas besoin d'être importer

### Pourquoi ?

Auparavant importé avec un type non reconnu, elles ne sont pas utilisées pour le moment.

### Comment ?

Ajout du kind dans les kinds exclus

### Autre

Ajustement du log d'erreur pour avoir une erreur générique avec les détails dans l'erreur.
