### PR TITLE
fix: Autoriser seulement les "GET" sur PerimeterAutocompleteViewSet

### DIFF
--- a/lemarche/api/perimeters/views.py
+++ b/lemarche/api/perimeters/views.py
@@ -22,6 +22,7 @@ class PerimeterAutocompleteViewSet(mixins.ListModelMixin, viewsets.GenericViewSe
     serializer_class = PerimeterSimpleSerializer
     filterset_class = PerimeterAutocompleteFilter
     pagination_class = None
+    http_method_names = ["get"]
 
     def finalize_response(self, request, response, *args, **kwargs):
         """


### PR DESCRIPTION
### Quoi ?

D'après ce [bug sur sentry](https://inclusion.sentry.io/issues/15061076/) les appels http de type `OPTIONS` aboutissent à des erreurs.

### Pourquoi ?

Contrairement aux autres urls de l'API, cette url ne respecte pas un format correct et limite arbitrairement les résultats sans pagination. Les autres verbes http n'ont pas été prévus quand cette modification a été effectuée, menant à des erreurs.

### Comment ?

Seul le verbe `GET` est désormais autorisé. L'autre option était de rendre standard cette partie de l'API, mais il aurait fallu changer aussi le code coté client qui consomme cette url.
