### PR TITLE
fix: Erreurs de serialisation des inbound email

### DIFF
--- a/lemarche/api/emails/serializers.py
+++ b/lemarche/api/emails/serializers.py
@@ -7,21 +7,23 @@ class UserInboundParsingSerializer(serializers.DictField):
 
 
 class EmailItemSerializer(serializers.Serializer):
-    """Email ItemSerializer for data comes from Brevo"""
+    """Email ItemSerializer for data comes from Brevo
+    https://developers.brevo.com/docs/inbound-parse-webhooks#parsed-email-payload
+    """
 
     Uuid = serializers.ListField(child=serializers.UUIDField())
     MessageId = serializers.CharField()
-    InReplyTo = serializers.CharField(required=False, allow_null=True)
+    InReplyTo = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     From = UserInboundParsingSerializer()
     To = serializers.ListField(child=UserInboundParsingSerializer())
     Cc = serializers.ListField(child=UserInboundParsingSerializer(), required=False)
-    ReplyTo = serializers.CharField(required=False, allow_null=True)
+    ReplyTo = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     SentAtDate = serializers.CharField()
     Subject = serializers.CharField(required=False, allow_null=True)
-    RawHtmlBody = serializers.CharField(required=False, allow_null=True)
-    RawTextBody = serializers.CharField(required=False, allow_null=True)
+    RawHtmlBody = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    RawTextBody = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     ExtractedMarkdownMessage = serializers.CharField(required=False, allow_null=True)
-    ExtractedMarkdownSignature = serializers.CharField(required=False, allow_null=True)
+    ExtractedMarkdownSignature = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     SpamScore = serializers.FloatField()
     Attachments = serializers.ListField(child=serializers.DictField(), required=False)
     Headers = serializers.DictField()

--- a/lemarche/api/emails/serializers.py
+++ b/lemarche/api/emails/serializers.py
@@ -24,9 +24,9 @@ class EmailItemSerializer(serializers.Serializer):
     RawTextBody = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     ExtractedMarkdownMessage = serializers.CharField(required=False, allow_null=True)
     ExtractedMarkdownSignature = serializers.CharField(required=False, allow_null=True, allow_blank=True)
-    SpamScore = serializers.FloatField()
+    SpamScore = serializers.FloatField(required=False)
     Attachments = serializers.ListField(child=serializers.DictField(), required=False)
-    Headers = serializers.DictField()
+    Headers = serializers.DictField(required=False)
 
 
 class EmailsSerializer(serializers.Serializer):


### PR DESCRIPTION
### Quoi ?

Des erreurs sentry https://inclusion.sentry.io/issues/15209997/ , https://inclusion.sentry.io/issues/15209972/ https://inclusion.sentry.io/issues/15596789/ https://inclusion.sentry.io/issues/13943251/ https://inclusion.sentry.io/issues/13943251/
révèlent que certains payload envoyé à `InboundParsingEmailView` ne correspondent pas au `EmailItemSerializer` car certains champs manquent.

### Pourquoi ?

Malgré leur [documentation](https://developers.brevo.com/docs/inbound-parse-webhooks#parsed-email-payload) , certains champs du payload manquent alors qu'ils sont indiqués comme présent dans la doc, par exemple `SpamScore` et `Headers`  sont parfois absents alors qu'indiqué comme présents dans la doc. 

### Comment ?

Régler le serializer pour accepter que certains champs manquent 

### Remarques
Dans certains issues https://inclusion.sentry.io/issues/15596789/ https://inclusion.sentry.io/issues/13943251/  https://inclusion.sentry.io/issues/13943251/ de sentry, le payload est indiqué comme vide, alors que le message d'erreurs 
```
{'items': {0: {'RawHtmlBody': [ErrorDetail(string='Ce champ ne peut être vide.', code='blank')]}}}
```
laisse bien penser qu'un payload avec des champs manquants a été recu.