### PR TITLE
feat: Inbound email whitelist brevo ips

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -360,6 +360,9 @@ INBOUND_EMAIL_IS_ACTIVATED = env.bool("INBOUND_EMAIL_IS_ACTIVATED", True)
 
 BREVO_TENDERS_MIN_AMOUNT_TO_SEND = env.int("BREVO_TENDERS_MIN_AMOUNT_TO_SEND", 34998)
 
+# ip ranges here (webhook):
+# https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services
+BREVO_IP_WHITELIST_RANGE: str = env.str("BREVO_IP_WHITELIST_RANGE", "127.0.0.0/20")
 
 # Caching
 # https://docs.djangoproject.com/en/4.0/topics/cache/


### PR DESCRIPTION
### Quoi ?
En suivant cette [documentation](https://developers.brevo.com/docs/username-and-password-authentication) l'étape la plus facile pour commencer à sécuriser les webhooks de Brevo est de faire une whitelist de leurs ip.

### Pourquoi ?

L'API actuelle, via `InboundParsingEmailView` est totalement ouverte, il est donc théoriquement possible pour un attaquant d'usurper Brevo pour envoyer de nouvelles conversations, d'autant plus que le code est accessible à tous.

### Comment ?

Comparer les ips entrantes à celles du réseau d'ip de Brevo

### Remarques

Il est maintenant necessaire pour la prod d'avoir `BREVO_IP_WHITELIST_RANGE` defini pour que les ips soient correctement whitelistées. Je ne sais pas ou documenter ca