### PR TITLE
fix: Flacky test causé par un mot de passe aléatoire non valide

### DIFF
--- a/lemarche/api/datacube/tests.py
+++ b/lemarche/api/datacube/tests.py
@@ -46,12 +46,12 @@ class DatacubeApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"count": 0, "next": None, "previous": None, "results": []})
 
-        user = UserFactory(kind=User.KIND_BUYER)
+        user = UserFactory(kind=User.KIND_BUYER, email="lagarde@example.com")
         CompanyFactory(name="Lagarde et Fils", users=[user])
         TenderFactory(title="Sébastien Le Lopez", amount="0-42K", author=user, presta_type=["FANFAN", "LA", "TULIPE"])
 
         # no associated company
-        TenderFactory(title="Marc Henry", amount_exact=697)
+        TenderFactory(title="Marc Henry", amount_exact=697, author__email="henry@example.com")
 
         response = self.client.get(url, headers={"Authorization": "Token bar"})
         self.assertEqual(response.status_code, 200)
@@ -65,7 +65,7 @@ class DatacubeApiTest(TestCase):
                     {
                         "amount": "0-42K",
                         "amount_exact": None,
-                        "author_email": "email1@example.com",
+                        "author_email": "lagarde@example.com",
                         "company_name": "Lagarde et Fils",
                         "company_slug": "lagarde-et-fils",
                         "created_at": "2024-06-21T14:23:34+02:00",
@@ -80,7 +80,7 @@ class DatacubeApiTest(TestCase):
                     {
                         "amount": None,
                         "amount_exact": 697,
-                        "author_email": "email2@example.com",
+                        "author_email": "henry@example.com",
                         "created_at": "2024-06-21T14:23:34+02:00",
                         "kind": "QUOTE",
                         "presta_type": [],

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -44,8 +44,8 @@ class SiaeFactory(DjangoModelFactory):
     address = factory.Faker("street_address", locale="fr_FR")
     city = factory.Faker("city", locale="fr_FR")
     post_code = factory.Faker("postalcode")
-    department = factory.fuzzy.FuzzyChoice([key for (key, value) in Siae.DEPARTMENT_CHOICES])
-    region = factory.fuzzy.FuzzyChoice([key for (key, value) in Siae.REGION_CHOICES])
+    department = "35"
+    region = "Bretagne"
     contact_email = factory.Sequence("siae_contact_email{0}@beta.gouv.fr".format)
     contact_first_name = factory.Faker("name", locale="fr_FR")
     contact_last_name = factory.Faker("name", locale="fr_FR")

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -1,8 +1,8 @@
-import factory
 import logging
 import os
 from unittest.mock import patch
 
+import factory
 from django.core.management import call_command
 from django.db.models import signals
 from django.test import TransactionTestCase
@@ -328,6 +328,7 @@ class SiaeActivitiesCreateCommandTest(TransactionTestCase):
             kind=siae_constants.KIND_EA,
             presta_type=[siae_constants.PRESTA_DISP],
             geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
+            department="35",
         )
         siae.sectors.set([self.sector2, self.sector3])
 
@@ -346,6 +347,7 @@ class SiaeActivitiesCreateCommandTest(TransactionTestCase):
             kind=siae_constants.KIND_EA,
             presta_type=[siae_constants.PRESTA_DISP],
             geo_range=siae_constants.GEO_RANGE_REGION,
+            region="Bretagne",
         )
         siae.sectors.set([self.sector2, self.sector3])
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -785,8 +785,8 @@ class Tender(models.Model):
     def sectors_full_list_string(self) -> str:
         return self.sectors_list_string(display_max=None)
 
-    def perimeters_list(self):
-        return self.perimeters.values_list("name", flat=True)
+    def perimeters_list(self) -> list:
+        return list(self.perimeters.order_by("name").values_list("name", flat=True))
 
     @cached_property
     def perimeters_list_string(self) -> str:

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -84,8 +84,10 @@ class TenderModelPropertyTest(TestCase):
             title="Besoin 3", perimeters=[self.grenoble_perimeter, self.chamrousse_perimeter]
         )
         self.assertEqual(len(tender_with_perimeters.perimeters_list()), 2)
-        self.assertEqual(tender_with_perimeters.perimeters_list()[0], self.grenoble_perimeter.name)
-        self.assertEqual(tender_with_perimeters.perimeters_list_string, "Grenoble, Chamrousse")
+        self.assertEqual(
+            tender_with_perimeters.perimeters_list(), [self.chamrousse_perimeter.name, self.grenoble_perimeter.name]
+        )
+        self.assertEqual(tender_with_perimeters.perimeters_list_string, "Chamrousse, Grenoble")
 
     def test_location_display_property(self):
         tender_country_area = TenderFactory(title="Besoin 1", is_country_area=True)

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -18,11 +18,9 @@ SIAE = {
     "first_name": "Prenom",
     "last_name": "Nom",
     "phone": "+33123456789",  # not required
-    # "company_name": "",  # not asked here
     "email": "siae@example.com",
     "password1": EXAMPLE_PASSWORD,
     "password2": EXAMPLE_PASSWORD,
-    # "id_accept_rgpd"  # required
 }
 
 BUYER = {
@@ -30,16 +28,11 @@ BUYER = {
     "first_name": "Prenom",
     "last_name": "Nom",
     "phone": "0123456789",
-    # "buyer_kind_detail": "PRIVATE_BIG_CORP",
     "company_name": "Ma boite",
     "position": "Role important",
     "email": "buyer@example.com",
     "password1": EXAMPLE_PASSWORD,
     "password2": EXAMPLE_PASSWORD,
-    # "nb_of_handicap_provider_last_year": "3",
-    # "nb_of_inclusive_provider_last_year": "4",
-    # "id_accept_rgpd"  # required
-    # "id_accept_survey"  # not required
 }
 
 PARTNER = {
@@ -47,13 +40,10 @@ PARTNER = {
     "first_name": "Prenom",
     "last_name": "Nom",
     "phone": "01 23 45 67 89",  # not required
-    # "partner_kind": "RESEAU_IAE",
     "company_name": "Ma boite",
     "email": "partner@example.com",
     "password1": EXAMPLE_PASSWORD,
     "password2": EXAMPLE_PASSWORD,
-    # "id_accept_rgpd"  # required
-    # "id_accept_survey"  # not required
 }
 
 PARTNER_2 = {
@@ -61,25 +51,19 @@ PARTNER_2 = {
     "first_name": "Prenom",
     "last_name": "Nom",
     "phone": "+33123456789",  # not required
-    # "partner_kind": "RESEAU_IAE",
     "company_name": "Ma boite",
     "email": "partner2@example.com",
     "password1": EXAMPLE_PASSWORD,
     "password2": EXAMPLE_PASSWORD,
-    # "id_accept_rgpd"  # required
-    # "id_accept_survey"  # not required
 }
 
 INDIVIDUAL = {
     "id_kind": 3,
     "first_name": "Prenom",
     "last_name": "Nom",
-    # "phone": "012345678",  # not required
     "email": "individual@example.com",
     "password1": EXAMPLE_PASSWORD,
     "password2": EXAMPLE_PASSWORD,
-    # "id_accept_rgpd"  # required
-    # "id_accept_survey"  # not required
 }
 
 
@@ -244,7 +228,6 @@ class SignupFormTest(StaticLiveServerTestCase):
         # should not submit form (position field is required)
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
-    # TODO: problem with this test
     def test_partner_submits_signup_form_success(self):
         self._complete_form(user_profile=PARTNER, with_submit=False)
         partner_kind_option_element = self.driver.find_element(

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -1,5 +1,3 @@
-import secrets
-import string
 import time
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -13,7 +11,7 @@ from lemarche.users.factories import DEFAULT_PASSWORD, UserFactory
 from lemarche.users.models import User
 
 
-EXAMPLE_PASSWORD = "".join(secrets.choice(string.ascii_letters + string.digits + string.punctuation) for i in range(9))
+EXAMPLE_PASSWORD = "c*[gkp`0="
 
 SIAE = {
     "id_kind": 0,  # required
@@ -247,16 +245,16 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
     # TODO: problem with this test
-    # def test_partner_submits_signup_form_success(self):
-    #     self._complete_form(user_profile=PARTNER, with_submit=False)
-    #     partner_kind_option_element = self.driver.find_element(
-    #         By.XPATH, "//select[@id='id_partner_kind']/option[text()='Réseaux IAE']"
-    #     )
-    #     scroll_to_and_click_element(self.driver, partner_kind_option_element, sleep_time=10)
-    #     submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
-    #     scroll_to_and_click_element(self.driver, submit_element)
+    def test_partner_submits_signup_form_success(self):
+        self._complete_form(user_profile=PARTNER, with_submit=False)
+        partner_kind_option_element = self.driver.find_element(
+            By.XPATH, "//select[@id='id_partner_kind']/option[text()='Réseaux IAE']"
+        )
+        scroll_to_and_click_element(self.driver, partner_kind_option_element, sleep_time=10)
+        submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
+        scroll_to_and_click_element(self.driver, submit_element)
 
-    #     self._assert_signup_success(redirect_url=reverse("wagtail_serve", args=("",)))
+        self._assert_signup_success(redirect_url=reverse("wagtail_serve", args=("",)))
 
     def test_partner_submits_signup_form_error(self):
         user_profile = PARTNER.copy()

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -1,5 +1,3 @@
-import time
-
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
 from selenium import webdriver
@@ -11,17 +9,15 @@ from lemarche.users.factories import DEFAULT_PASSWORD, UserFactory
 from lemarche.users.models import User
 
 
-def scroll_to_and_click_element(driver, element, click=True, sleep_time=1):
+def scroll_to_and_click_element(driver, element, click=True):
     """
     Helper to avoid some errors with selenium
     - selenium.common.exceptions.ElementNotInteractableException
     - selenium.common.exceptions.ElementClickInterceptedException
     """
-    # element.click()
     # click instead with javascript
     driver.execute_script("arguments[0].scrollIntoView();", element)
     # small pause
-    time.sleep(sleep_time)
     if click:
         try:
             element.click()
@@ -232,7 +228,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         partner_kind_option_element = self.driver.find_element(
             By.XPATH, "//select[@id='id_partner_kind']/option[text()='Réseaux IAE']"
         )
-        scroll_to_and_click_element(self.driver, partner_kind_option_element, sleep_time=10)
+        scroll_to_and_click_element(self.driver, partner_kind_option_element)
         submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
         scroll_to_and_click_element(self.driver, submit_element)
 

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -11,62 +11,6 @@ from lemarche.users.factories import DEFAULT_PASSWORD, UserFactory
 from lemarche.users.models import User
 
 
-EXAMPLE_PASSWORD = "c*[gkp`0="
-
-SIAE = {
-    "id_kind": 0,  # required
-    "first_name": "Prenom",
-    "last_name": "Nom",
-    "phone": "+33123456789",  # not required
-    "email": "siae@example.com",
-    "password1": EXAMPLE_PASSWORD,
-    "password2": EXAMPLE_PASSWORD,
-}
-
-BUYER = {
-    "id_kind": 1,  # required
-    "first_name": "Prenom",
-    "last_name": "Nom",
-    "phone": "0123456789",
-    "company_name": "Ma boite",
-    "position": "Role important",
-    "email": "buyer@example.com",
-    "password1": EXAMPLE_PASSWORD,
-    "password2": EXAMPLE_PASSWORD,
-}
-
-PARTNER = {
-    "id_kind": 2,  # required
-    "first_name": "Prenom",
-    "last_name": "Nom",
-    "phone": "01 23 45 67 89",  # not required
-    "company_name": "Ma boite",
-    "email": "partner@example.com",
-    "password1": EXAMPLE_PASSWORD,
-    "password2": EXAMPLE_PASSWORD,
-}
-
-PARTNER_2 = {
-    "id_kind": 2,  # required
-    "first_name": "Prenom",
-    "last_name": "Nom",
-    "phone": "+33123456789",  # not required
-    "company_name": "Ma boite",
-    "email": "partner2@example.com",
-    "password1": EXAMPLE_PASSWORD,
-    "password2": EXAMPLE_PASSWORD,
-}
-
-INDIVIDUAL = {
-    "id_kind": 3,
-    "first_name": "Prenom",
-    "last_name": "Nom",
-    "email": "individual@example.com",
-    "password1": EXAMPLE_PASSWORD,
-    "password2": EXAMPLE_PASSWORD,
-}
-
-
 def scroll_to_and_click_element(driver, element, click=True, sleep_time=1):
     """
     Helper to avoid some errors with selenium
@@ -95,13 +39,69 @@ class SignupFormTest(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # selenium browser  # TODO: make it test-wide
+        # selenium browser
         options = Options()
         options.add_argument("-headless")
         cls.driver = webdriver.Firefox(options=options)
         cls.driver.implicitly_wait(1)
         # other init
         cls.user_count = User.objects.count()
+
+    def setUp(self):
+        EXAMPLE_PASSWORD = "c*[gkp`0="
+
+        self.SIAE = {
+            "id_kind": 0,  # required
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "phone": "+33123456789",  # not required
+            "email": "siae@example.com",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
+
+        self.BUYER = {
+            "id_kind": 1,  # required
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "phone": "0123456789",
+            "company_name": "Ma boite",
+            "position": "Role important",
+            "email": "buyer@example.com",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
+
+        self.PARTNER = {
+            "id_kind": 2,  # required
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "phone": "01 23 45 67 89",  # not required
+            "company_name": "Ma boite",
+            "email": "partner@example.com",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
+
+        self.PARTNER_2 = {
+            "id_kind": 2,  # required
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "phone": "+33123456789",  # not required
+            "company_name": "Ma boite",
+            "email": "partner2@example.com",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
+
+        self.INDIVIDUAL = {
+            "id_kind": 3,
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "email": "individual@example.com",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
 
     def _complete_form(self, user_profile: dict, signup_url=reverse("auth:signup"), with_submit=True):
         """the function allows you to go to the "signup" page and complete the user profile.
@@ -154,7 +154,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         return messages
 
     def test_siae_submits_signup_form_success(self):
-        self._complete_form(user_profile=SIAE.copy(), with_submit=True)
+        self._complete_form(user_profile=self.SIAE, with_submit=True)
 
         # should redirect SIAE to dashboard
         messages = self._assert_signup_success(redirect_url=reverse("dashboard:home"))
@@ -162,7 +162,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertTrue("Vous pouvez maintenant ajouter votre structure" in messages.text)
 
     def test_siae_submits_signup_form_error(self):
-        user_profile = SIAE.copy()
+        user_profile = self.SIAE
         del user_profile["last_name"]
 
         self._complete_form(user_profile=user_profile, with_submit=True)
@@ -171,9 +171,9 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
     def test_siae_submits_signup_form_email_already_exists(self):
-        UserFactory(email=SIAE["email"], kind=User.KIND_SIAE)
+        UserFactory(email=self.SIAE["email"], kind=User.KIND_SIAE)
 
-        user_profile = SIAE.copy()
+        user_profile = self.SIAE
         self._complete_form(user_profile=user_profile, with_submit=True)
 
         # should not submit form (email field already used)
@@ -183,7 +183,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertTrue("Cette adresse e-mail est déjà utilisée." in alerts.text)
 
     def test_buyer_submits_signup_form_success(self):
-        self._complete_form(user_profile=BUYER, with_submit=False)
+        self._complete_form(user_profile=self.BUYER, with_submit=False)
 
         buyer_kind_detail_select_element = self.driver.find_element(By.CSS_SELECTOR, "select#id_buyer_kind_detail")
         element_select_option(self.driver, buyer_kind_detail_select_element, "Grand groupe (+5000 salariés)")
@@ -195,7 +195,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self._assert_signup_success(redirect_url=reverse("siae:search_results"))
 
     def test_buyer_submits_signup_form_success_extra_data(self):
-        self._complete_form(user_profile=BUYER, with_submit=False)
+        self._complete_form(user_profile=self.BUYER, with_submit=False)
 
         buyer_kind_detail_select_element = self.driver.find_element(By.CSS_SELECTOR, "select#id_buyer_kind_detail")
         element_select_option(self.driver, buyer_kind_detail_select_element, "Grand groupe (+5000 salariés)")
@@ -213,14 +213,14 @@ class SignupFormTest(StaticLiveServerTestCase):
         submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
         scroll_to_and_click_element(self.driver, submit_element)
         # should get created User
-        user = User.objects.get(email=BUYER.get("email"))
+        user = User.objects.get(email=self.BUYER["email"])
 
         # assert extra_data are inserted
         self.assertEqual(user.extra_data.get("nb_of_handicap_provider_last_year"), nb_of_handicap)
         self.assertEqual(user.extra_data.get("nb_of_inclusive_provider_last_year"), nb_of_inclusive)
 
     def test_buyer_submits_signup_form_error(self):
-        user_profile = BUYER.copy()
+        user_profile = self.BUYER
         del user_profile["position"]
 
         self._complete_form(user_profile=user_profile, with_submit=True)
@@ -229,7 +229,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
     def test_partner_submits_signup_form_success(self):
-        self._complete_form(user_profile=PARTNER, with_submit=False)
+        self._complete_form(user_profile=self.PARTNER, with_submit=False)
         partner_kind_option_element = self.driver.find_element(
             By.XPATH, "//select[@id='id_partner_kind']/option[text()='Réseaux IAE']"
         )
@@ -240,7 +240,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self._assert_signup_success(redirect_url=reverse("wagtail_serve", args=("",)))
 
     def test_partner_submits_signup_form_error(self):
-        user_profile = PARTNER.copy()
+        user_profile = self.PARTNER
         del user_profile["company_name"]
 
         self._complete_form(user_profile=user_profile, with_submit=True)
@@ -256,7 +256,7 @@ class SignupFormTest(StaticLiveServerTestCase):
     #     self._assert_signup_success(redirect_url=reverse("wagtail_serve", args=("",)))
 
     def test_individual_submits_signup_form_error(self):
-        user_profile = INDIVIDUAL.copy()
+        user_profile = self.INDIVIDUAL
         del user_profile["last_name"]
 
         self._complete_form(user_profile=user_profile, with_submit=True)
@@ -267,7 +267,7 @@ class SignupFormTest(StaticLiveServerTestCase):
     def test_user_submits_signup_form_with_next_param_success_and_redirect(self):
         next_url = f"{reverse('siae:search_results')}?kind=ESAT"
         self._complete_form(
-            user_profile=SIAE.copy(),
+            user_profile=self.SIAE,
             signup_url=f"{reverse('auth:signup')}?next={next_url}",
             with_submit=False,
         )

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -119,7 +119,6 @@ class SignupFormTest(StaticLiveServerTestCase):
         except:  # noqa # selenium.common.exceptions.NoSuchElementException:
             pass
 
-        user_profile = user_profile.copy()
         user_kind = user_profile.pop("id_kind")
         self.driver.find_element(By.CSS_SELECTOR, f"label[for='id_kind_{user_kind}']").click()
         for key in user_profile:

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -40,8 +40,6 @@ class SignupFormTest(StaticLiveServerTestCase):
         options.add_argument("-headless")
         cls.driver = webdriver.Firefox(options=options)
         cls.driver.implicitly_wait(1)
-        # other init
-        cls.user_count = User.objects.count()
 
     def setUp(self):
         EXAMPLE_PASSWORD = "c*[gkp`0="
@@ -136,7 +134,7 @@ class SignupFormTest(StaticLiveServerTestCase):
             list: list of success messages
         """
         # should create User
-        self.assertEqual(User.objects.count(), self.user_count + 1)
+        self.assertEqual(User.objects.count(), 1)
         # user should be automatically logged in
         header = self.driver.find_element(By.CSS_SELECTOR, "header#header")
         self.assertTrue("Tableau de bord" in header.text)


### PR DESCRIPTION
### Quoi ?

Les tests échouaient parfois de manière inexpliquée sur la CI, comme ici: https://github.com/gip-inclusion/le-marche/actions/runs/12300147620/job/34327607329

Un autre test échoué est https://github.com/gip-inclusion/le-marche/actions/runs/12548544358/job/34987960701, cette fois à cause des factory avec du Fuzzing. La région était générée aléatoirement, matchant aléatoirement le périmètre créé dans le setup. Par ailleurs, la factory générait des données un peu absurde car le département Morbihan pouvait se trouver dans la région Occitanie sans problèmes.

Des tests interdépendants ont été trouvés en changeant l'ordre d’exécution avec `--shuffle` ou `--reverse`. Par exemple,
`pythonb test --reverse lemarche.tenders.tests.test_commands.TestSendAuthorListOfSuperSiaesEmails` échoue avec l'option reverse.

### Pourquoi ?

Un mot de passe aléatoire était généré dans les tests, mais dans certains cas il ne respectait pas les caractéristiques requises par le validateur.

Le fait de dépendre des données contenues dans les migrations peut être problématique pour certains tests, notamment les `TransactionTestCase` et ceux qui en héritent car la base est purgée à la fin du test.

Pareil, avec des factory ou des objets nommés après des séquences d'id, les séquences ne sont pas toujours prédictibles et il ne faut pas compter dessus. (`test_list_tenders_content`)

### Comment ?

Ce mot de passe à été remplacé par un mot de passe fixe respectant le validateur. Si le validateur doit être testé ce n'est pas au niveau des tests fonctionnels.

### Remarques

Un test qui avait été commenté comme cassé était en fait fonctionnel, il a été de-commenté

Voici le script utilisé pour tester la validité du mot de passe aléatoire:
```python
class A(StaticLiveServerTestCase):
    def test_bidon(self):
        from django.contrib.auth import password_validation
        import secrets
        import string
        # c*[gkp`0=
        for i in range(0, 30):
            password = "".join(secrets.choice(string.ascii_letters + string.digits + string.punctuation) for i in range(9))
            print("MOT DE PASSE: ", password)
            password_validation.validate_password(password)
```

- Les dictionnaires définis en constantes ont été déplacés dans le setup plutot que de faire des `.copy()` partout
- Test accélérés en enlevant le `time.sleep()`

Les test avec du Fuzzing sont utiles, mais pas pas forcément à leur place dans une CI destinée à valider les changements de code. Par ailleurs ici ils ne sont pas déterministes, donc impossible à reproduire. S'il y avait une seed réutilisable on pourrait détecter facilement les erreurs.

Une manière de détecter des tests interdépendants est l'option `--shuffle`, avec une seed qui permet d'avoir des résultats reproductibles.

Pour faire apparaitre l'erreur d'un test que l'on sait flacky:
```python
import os
from django.core.management import execute_from_command_line

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local_test")

for i in range(0, 50):
    execute_from_command_line(
        ['manage.py',
         'test',
         'lemarche.tenders.tests.test_models.TenderModelPropertyTest.test_perimeters_list_property',
         '--keepdb']
    )

```