### PR TITLE
fix: Changement de conditions de synchronisation des DDB vers le crm brevo

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -358,8 +358,6 @@ INBOUND_PARSING_DOMAIN_EMAIL = env.str("INBOUND_PARSING_DOMAIN_EMAIL", "reply.st
 
 INBOUND_EMAIL_IS_ACTIVATED = env.bool("INBOUND_EMAIL_IS_ACTIVATED", True)
 
-BREVO_TENDERS_MIN_AMOUNT_TO_SEND = env.int("BREVO_TENDERS_MIN_AMOUNT_TO_SEND", 34998)
-
 # ip ranges here (webhook):
 # https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services
 BREVO_IP_WHITELIST_RANGE: str = env.str("BREVO_IP_WHITELIST_RANGE", "127.0.0.0/20")

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -255,6 +255,23 @@ class TenderForm(forms.ModelForm):
         model = Tender
         fields = "__all__"
 
+    is_followed_by_us = forms.BooleanField(
+        widget=forms.CheckboxInput(),
+        required=False,
+        label=Tender._meta.get_field("is_followed_by_us").verbose_name,
+    )
+    proj_resulted_in_reserved_tender = forms.BooleanField(
+        widget=forms.CheckboxInput(),
+        required=False,
+        label=Tender._meta.get_field("proj_resulted_in_reserved_tender").verbose_name,
+    )
+
+    is_reserved_tender = forms.BooleanField(
+        widget=forms.CheckboxInput(),
+        required=False,
+        label=Tender._meta.get_field("is_reserved_tender").verbose_name,
+    )
+
     def clean(self):
         """
         Add validation on form rules:
@@ -500,8 +517,8 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                     "admins",
                     "is_followed_by_us",
                     "proj_resulted_in_reserved_tender",
-                    "proj_link_to_tender",
                     "is_reserved_tender",
+                    "proj_link_to_tender",
                 )
             },
         ),

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -1,6 +1,5 @@
 from ckeditor.widgets import CKEditorWidget
 from django import forms
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.core.exceptions import ValidationError
@@ -789,7 +788,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
             return HttpResponseRedirect("./#structures")  # redirect to structures sections
         if request.POST.get("_validate_send_to_siaes"):
             obj.set_validated()
-            if obj.amount_int > settings.BREVO_TENDERS_MIN_AMOUNT_TO_SEND:
+            if obj.is_followed_by_us:
                 try:
                     api_brevo.create_deal(tender=obj, owner_email=request.user.email)
                     # we link deal(tender) with author contact

--- a/lemarche/tenders/tests/test_admin.py
+++ b/lemarche/tenders/tests/test_admin.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from lemarche.tenders.admin import TenderAdmin
+from lemarche.tenders.factories import TenderFactory
+from lemarche.tenders.models import Tender
+from lemarche.users.factories import UserFactory
+
+
+# Create a dummy response function for the middleware
+def get_response(request):
+    return HttpResponse("OK")
+
+
+class TenderAdminTestCase(TestCase):
+    def setUp(self):
+        # Initialize required objects for testing
+        self.factory = RequestFactory()
+        self.admin_site = AdminSite()
+        self.user_admin = UserFactory(is_superuser=True)  # Admin user
+        self.admin = TenderAdmin(Tender, self.admin_site)
+
+    @patch("lemarche.tenders.admin.api_brevo.create_deal")  # Mock the create_deal API call
+    @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
+    def test_validate_send_to_siaes_not_synch_brevo(self, mock_link_deal, mock_create_deal):
+        tender = TenderFactory(is_followed_by_us=False)  # Tender object
+        # Simulate a POST request without triggering the validation action
+        request = self.factory.post("/", data={"_validate_send_to_siaes": "1"})
+        request.user = self.user_admin
+
+        # Initialize and apply SessionMiddleware
+        middleware = SessionMiddleware(get_response)
+        middleware.process_request(request)
+        request.session.save()  # Save the session to avoid any issues
+
+        # Attach a message storage system to the request
+        setattr(request, "_messages", FallbackStorage(request))
+
+        # Call the response_change method without the validation action enabled
+        response = self.admin.response_change(request, tender)
+
+        # Check that the create_deal and link_deal functions were not called
+        mock_create_deal.assert_not_called()
+        mock_link_deal.assert_not_called()
+
+        # Verify the response
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(".", response.url)
+
+        # Verify the flash messages
+        messages = list(request._messages._queued_messages)
+        self.assertEqual(len(messages), 1)  # Expecting only one message
+        self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
+
+    @patch("lemarche.tenders.admin.api_brevo.create_deal")  # Mock the create_deal API call
+    @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
+    def test_validate_send_to_siaes_with_sync_brevo(self, mock_link_deal, mock_create_deal):
+        tender = TenderFactory(is_followed_by_us=True)  # Tender object
+        # Simulate a POST request to trigger "_validate_send_to_siaes"
+        request = self.factory.post("/", data={"_validate_send_to_siaes": "1"})
+        request.user = self.user_admin
+
+        # Initialize and apply SessionMiddleware
+        middleware = SessionMiddleware(get_response)
+        middleware.process_request(request)
+        request.session.save()  # Save the session to avoid any issues
+
+        # Attach a message storage to the request
+        setattr(request, "_messages", FallbackStorage(request))
+
+        # Call the response_change method
+        response = self.admin.response_change(request, tender)
+
+        # Verify that the tender is marked as validated
+        tender.refresh_from_db()
+        self.assertTrue(tender.is_validated)
+
+        # Check if the create_deal and link_deal API methods were called
+        mock_create_deal.assert_called_once_with(tender=tender, owner_email=self.user_admin.email)
+        mock_link_deal.assert_called_once_with(tender=tender)
+
+        # Ensure the response redirects correctly
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(".", response.url)
+
+        # Verify flash messages
+        messages = list(request._messages._queued_messages)
+        self.assertEqual(len(messages), 2)  # Expecting two messages
+        self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été synchronisé avec Brevo")
+        self.assertEqual(str(messages[1]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")

--- a/lemarche/tenders/tests/test_admin.py
+++ b/lemarche/tenders/tests/test_admin.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
@@ -25,16 +26,13 @@ class TenderAdminTestCase(TestCase):
         self.user_admin = UserFactory(is_superuser=True)  # Admin user
         self.admin = TenderAdmin(Tender, self.admin_site)
 
-    def setUpRequest(self, tender, is_followed_by_us):
-        tender.is_followed_by_us = is_followed_by_us
-        tender.save()
+    def setUpRequest(self):
         request = self.factory.post("/", data={"_validate_send_to_siaes": "1"})
         request.user = self.user_admin
 
         # Initialize and apply SessionMiddleware
         middleware = SessionMiddleware(get_response)
         middleware.process_request(request)
-        request.session.save()  # Save the session to avoid any issues
 
         # Attach a message storage system to the request
         setattr(request, "_messages", FallbackStorage(request))
@@ -45,7 +43,7 @@ class TenderAdminTestCase(TestCase):
     @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
     def test_validate_send_to_siaes_not_synch_brevo(self, mock_link_deal, mock_create_deal):
         tender = TenderFactory(is_followed_by_us=False)  # Tender object
-        request = self.setUpRequest(tender, is_followed_by_us=False)
+        request = self.setUpRequest()
 
         # Call the response_change method without the validation action enabled
         response = self.admin.response_change(request, tender)
@@ -59,7 +57,7 @@ class TenderAdminTestCase(TestCase):
         self.assertIn(".", response.url)
 
         # Verify the flash messages
-        messages = request._messages._queued_messages
+        messages = list(get_messages(request))
         self.assertEqual(len(messages), 1)  # Expecting only one message
         self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
 
@@ -67,7 +65,7 @@ class TenderAdminTestCase(TestCase):
     @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
     def test_validate_send_to_siaes_with_sync_brevo(self, mock_link_deal, mock_create_deal):
         tender = TenderFactory(is_followed_by_us=True)  # Tender object
-        request = self.setUpRequest(tender, is_followed_by_us=True)
+        request = self.setUpRequest()
 
         # Call the response_change method
         response = self.admin.response_change(request, tender)
@@ -85,7 +83,7 @@ class TenderAdminTestCase(TestCase):
         self.assertIn(".", response.url)
 
         # Verify flash messages
-        messages = request._messages._queued_messages
+        messages = list(get_messages(request))
         self.assertEqual(len(messages), 2)  # Expecting two messages
         self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été synchronisé avec Brevo")
         self.assertEqual(str(messages[1]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")

--- a/lemarche/tenders/tests/test_admin.py
+++ b/lemarche/tenders/tests/test_admin.py
@@ -25,11 +25,9 @@ class TenderAdminTestCase(TestCase):
         self.user_admin = UserFactory(is_superuser=True)  # Admin user
         self.admin = TenderAdmin(Tender, self.admin_site)
 
-    @patch("lemarche.tenders.admin.api_brevo.create_deal")  # Mock the create_deal API call
-    @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
-    def test_validate_send_to_siaes_not_synch_brevo(self, mock_link_deal, mock_create_deal):
-        tender = TenderFactory(is_followed_by_us=False)  # Tender object
-        # Simulate a POST request without triggering the validation action
+    def setUpRequest(self, tender, is_followed_by_us):
+        tender.is_followed_by_us = is_followed_by_us
+        tender.save()
         request = self.factory.post("/", data={"_validate_send_to_siaes": "1"})
         request.user = self.user_admin
 
@@ -40,6 +38,14 @@ class TenderAdminTestCase(TestCase):
 
         # Attach a message storage system to the request
         setattr(request, "_messages", FallbackStorage(request))
+
+        return request
+
+    @patch("lemarche.tenders.admin.api_brevo.create_deal")  # Mock the create_deal API call
+    @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
+    def test_validate_send_to_siaes_not_synch_brevo(self, mock_link_deal, mock_create_deal):
+        tender = TenderFactory(is_followed_by_us=False)  # Tender object
+        request = self.setUpRequest(tender, is_followed_by_us=False)
 
         # Call the response_change method without the validation action enabled
         response = self.admin.response_change(request, tender)
@@ -53,7 +59,7 @@ class TenderAdminTestCase(TestCase):
         self.assertIn(".", response.url)
 
         # Verify the flash messages
-        messages = list(request._messages._queued_messages)
+        messages = request._messages._queued_messages
         self.assertEqual(len(messages), 1)  # Expecting only one message
         self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")
 
@@ -61,17 +67,7 @@ class TenderAdminTestCase(TestCase):
     @patch("lemarche.tenders.admin.api_brevo.link_deal_with_contact_list")  # Mock the link_deal API call
     def test_validate_send_to_siaes_with_sync_brevo(self, mock_link_deal, mock_create_deal):
         tender = TenderFactory(is_followed_by_us=True)  # Tender object
-        # Simulate a POST request to trigger "_validate_send_to_siaes"
-        request = self.factory.post("/", data={"_validate_send_to_siaes": "1"})
-        request.user = self.user_admin
-
-        # Initialize and apply SessionMiddleware
-        middleware = SessionMiddleware(get_response)
-        middleware.process_request(request)
-        request.session.save()  # Save the session to avoid any issues
-
-        # Attach a message storage to the request
-        setattr(request, "_messages", FallbackStorage(request))
+        request = self.setUpRequest(tender, is_followed_by_us=True)
 
         # Call the response_change method
         response = self.admin.response_change(request, tender)
@@ -89,7 +85,7 @@ class TenderAdminTestCase(TestCase):
         self.assertIn(".", response.url)
 
         # Verify flash messages
-        messages = list(request._messages._queued_messages)
+        messages = request._messages._queued_messages
         self.assertEqual(len(messages), 2)  # Expecting two messages
         self.assertEqual(str(messages[0]), "Ce dépôt de besoin a été synchronisé avec Brevo")
         self.assertEqual(str(messages[1]), "Ce dépôt de besoin a été validé. Il sera envoyé en temps voulu :)")

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -5,7 +5,7 @@ from random import randint
 from django.apps import apps
 from django.contrib.gis.geos import Point
 from django.forms.models import model_to_dict
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, TransactionTestCase
 from django.utils import timezone
 
 from lemarche.networks.factories import NetworkFactory
@@ -1081,9 +1081,9 @@ class TenderAdminTest(TestCase):
         self.assertTrue(tender_response.send_to_commercial_partners_only)
 
 
-class TenderUtilsTest(TestCase):
+class TenderUtilsTest(TransactionTestCase):
     @classmethod
-    def setUpTestData(cls):
+    def setUpClass(cls):
         cls.user_siae = UserFactory(kind=User.KIND_SIAE)
         cls.user_buyer = UserFactory(kind=User.KIND_BUYER)
         cls.siae_with_tender_1 = SiaeFactory(users=[cls.user_siae])
@@ -1105,6 +1105,7 @@ class TenderUtilsTest(TestCase):
         self.assertNotEqual(self.tender_with_siae.status, new_tender.status)
         self.assertEqual(self.tender_with_siae.sectors.count(), new_tender.sectors.count())
         self.assertNotEqual(self.tender_with_siae.siaes.count(), new_tender.siaes.count())
+        self.assertNotEqual(self.tender_with_siae.slug, new_tender.slug)
 
 
 class TenderUtilsFindAmountRangesTests(TestCase):


### PR DESCRIPTION
### Quoi ?

Changement de conditions de synchronisation des DDB vers le crm brevo. Au lieu de synchroniser par rapport au montant, on synchronise juste si l'attribut `is_followed_by_us=True`

### Pourquoi ?

Certains cas sont compliqué à jugé sur le prix dans un premier temps.
