### PR TITLE
Remove is_cocontracting from SiaeEditLinksForm

### DIFF
--- a/lemarche/templates/dashboard/siae_edit_links.html
+++ b/lemarche/templates/dashboard/siae_edit_links.html
@@ -23,20 +23,6 @@
 
     <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
         <div class="fr-col-12 fr-col-lg-8">
-            {% dsfr_form_field form.is_cocontracting %}
-        </div>
-        <div class="fr-col-12 fr-col-lg-4">
-            <div class="fr-callout fr-p-4v">
-                <h3 class="fr-callout__title fr-text--sm"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span> Co-traitance</h3>
-                <p class="fr-callout__text fr-text--sm fr-pl-7v">
-                    Vous êtes prêt à travailler avec une autre structure de l'insertion ou une entreprise du milieu ordinaire.
-                </p>
-            </div>
-        </div>
-    </div>
-
-    <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
-        <div class="fr-col-12 fr-col-lg-8">
             {% dsfr_form_field form.groups %}
             <div class="fr-callout fr-icon-information-line">
                 <h3 class="fr-callout__title fr-text--sm">Le groupement auquel vous appartenez n'apparaît pas dans la liste ?</h3>

--- a/lemarche/www/dashboard_siaes/forms.py
+++ b/lemarche/www/dashboard_siaes/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.forms.models import inlineformset_factory
-from django.utils.html import mark_safe
 from django_select2.forms import ModelSelect2MultipleWidget
 from dsfr.forms import DsfrBaseForm
 
@@ -193,11 +192,6 @@ SiaeImageFormSet = inlineformset_factory(Siae, SiaeImage, form=SiaeImageForm, ex
 
 
 class SiaeEditLinksForm(forms.ModelForm):
-    is_cocontracting = forms.BooleanField(
-        label="Êtes-vous ouvert à la co-traitance ?",
-        required=False,
-        widget=forms.RadioSelect(choices=[(True, "Oui"), (False, "Non")]),
-    )
     networks = forms.ModelMultipleChoiceField(
         queryset=Network.objects.all().order_by("name"),
         required=False,
@@ -220,7 +214,6 @@ class SiaeEditLinksForm(forms.ModelForm):
     class Meta:
         model = Siae
         fields = [
-            "is_cocontracting",
             "networks",
             "groups",
         ]
@@ -229,13 +222,6 @@ class SiaeEditLinksForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["networks"].label = "Votre structure est-elle adhérente à un réseau ou une fédération ?"
-        self.fields["is_cocontracting"].label = mark_safe(
-            (
-                "Êtes-vous ouvert à la co-traitance ou au groupement momentané d'entreprises "
-                '(<a href="https://www.economie.gouv.fr/dae/groupement-momentane-dentreprises" target="_blank"'
-                ' rel="noopener">GME</a>) ?'
-            )
-        )
         self.fields["groups"].label = "Appartenez-vous à un groupement ou ensemblier ?"
 
 


### PR DESCRIPTION
### Quoi ?

Supprimer l'option "ouvert à la co-traitance"

### Pourquoi ?
La fonctionnalité était très peu utilisée

### Comment ?

En supprimant le code lié, mais en gardant le champs de la base, pour des raisons statistiques