### PR TITLE
feat: Action admin pour l'anonymisation des utilisateurs

### DIFF
--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -211,6 +211,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
     search_fields = ["id", "email", "first_name", "last_name"]
     search_help_text = "Cherche sur les champs : ID, E-mail, Prénom, Nom"
     ordering = ["-created_at"]
+    actions = ["anonymize_users"]
 
     autocomplete_fields = ["company", "partner_network"]
     readonly_fields = (
@@ -402,3 +403,9 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         return "-"
 
     extra_data_display.short_description = User._meta.get_field("extra_data").verbose_name
+
+    @admin.action(description="Anonymiser les utilisateurs sélectionnés")
+    def anonymize_users(self, request, queryset):
+        """Wipe personnal data of all selected users"""
+        queryset.anonymize_update()
+        self.message_user(request, "L'anonymisation s'est déroulée avec succès")

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -3,10 +3,12 @@ from io import StringIO
 from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
+from django.contrib.messages import get_messages
 from django.core.management import call_command
 from django.core.validators import validate_email
 from django.db.models import F
 from django.test import TestCase, override_settings
+from django.urls import reverse
 from django.utils import timezone
 
 from lemarche.companies.factories import CompanyFactory
@@ -310,3 +312,29 @@ class UserAnonymizationTestCase(TestCase):
         call_command("anonymize_old_users", dry_run=True, stdout=self.std_out)
 
         self.assertFalse(TemplateTransactionalSendLog.objects.all())
+
+
+class UserAdminTestCase(TestCase):
+    def setUp(self):
+        UserFactory(is_staff=False, is_anonymized=False)
+        super_user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(super_user)
+
+    def test_anonymize_action(self):
+        """Test the anonymize_users action from the admin"""
+
+        users_ids = User.objects.values_list("id", flat=True)
+        data = {
+            "action": "anonymize_users",
+            "_selected_action": users_ids,
+        }
+        # https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#reversing-admin-urls
+        change_url = reverse("admin:users_user_changelist")
+        response = self.client.post(path=change_url, data=data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, change_url)
+        self.assertTrue(User.objects.filter(is_staff=False).first().is_anonymized)
+
+        messages_strings = [str(message) for message in get_messages(response.wsgi_request)]
+        self.assertIn("L'anonymisation s'est déroulée avec succès", messages_strings)


### PR DESCRIPTION
### Quoi ?

Avoir sur l'interface admin une action personnalisée pour facilement anonymiser les utilisateurs 

### Pourquoi ?

Pour anonymiser manuellement les utilisateurs


