### PR TITLE
feat: Authentification obligatoire sur l'API

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -548,6 +548,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "lemarche.api.authentication.CustomBearerAuthentication",
     ],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
 }
 
 

--- a/lemarche/api/authentication.py
+++ b/lemarche/api/authentication.py
@@ -25,7 +25,7 @@ class CustomBearerAuthentication(BaseAuthentication):
 
         # If no token is provided
         if not token:
-            return None
+            raise AuthenticationFailed("No token provided")
 
         # Check the minimum length of the token
         if len(token) < 64:

--- a/lemarche/api/authentication.py
+++ b/lemarche/api/authentication.py
@@ -13,21 +13,15 @@ class CustomBearerAuthentication(BaseAuthentication):
     """
     Authentication via:
     1. Authorization header: Bearer <token> (recommended).
-    2. URL parameter ?token=<token> (deprecated, temporary support).
     """
 
     def authenticate(self, request):
         token = None
-        warning_issued = False
 
         # Priority to the Authorization header
         auth_header = request.headers.get("Authorization")
         if auth_header and auth_header.startswith("Bearer "):
             token = auth_header.split("Bearer ")[1]
-        elif request.GET.get("token"):  # Otherwise, try the URL parameter
-            token = request.GET.get("token")
-            warning_issued = True
-            logger.info("Authentication via URL token detected. This method is deprecated and less secure.")
 
         # If no token is provided
         if not token:
@@ -46,10 +40,6 @@ class CustomBearerAuthentication(BaseAuthentication):
         except User.DoesNotExist:
             raise AuthenticationFailed("Invalid or expired token")
 
-        # Add a warning in the response for URL tokens
-        if warning_issued:
-            request._deprecated_auth_warning = True  # Marker for middleware or view
-
         # Return the user and the token
         return (user, token)
 
@@ -58,35 +48,3 @@ class CustomBearerAuthentication(BaseAuthentication):
         Returns the expected header for 401 responses.
         """
         return 'Bearer realm="api"'
-
-
-class DeprecationWarningMiddleware:
-    """
-    Middleware to inform users that authentication via URL `?token=` is deprecated.
-
-    This middleware checks if the request contains a deprecated authentication token
-    and adds a warning header to the response if it does.
-
-    Attributes:
-        get_response (callable): The next middleware or view in the chain.
-
-    Methods:
-        __call__(request):
-            Processes the request and adds a deprecation warning header to the response
-            if the request contains a deprecated authentication token.
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-
-        # Add a warning if the marker is set in the request
-        if hasattr(request, "_deprecated_auth_warning") and request._deprecated_auth_warning:
-            response.headers["Deprecation-Warning"] = (
-                "URL token authentication is deprecated and will be removed on 2025/01. "
-                "Please use Authorization header with Bearer tokens."
-            )
-
-        return response

--- a/lemarche/api/authentication.py
+++ b/lemarche/api/authentication.py
@@ -25,7 +25,7 @@ class CustomBearerAuthentication(BaseAuthentication):
 
         # If no token is provided
         if not token:
-            raise AuthenticationFailed("No token provided")
+            return None
 
         # Check the minimum length of the token
         if len(token) < 64:

--- a/lemarche/api/emails/views.py
+++ b/lemarche/api/emails/views.py
@@ -47,7 +47,7 @@ class BrevoWhitelistPermission(BasePermission):
 
 
 class InboundParsingEmailView(APIView):
-    permission_classes = [BrevoWhitelistPermission] + APIView.permission_classes
+    permission_classes = [BrevoWhitelistPermission]  # override the default class that requires Authentication
 
     @extend_schema(exclude=True)
     def post(self, request):

--- a/lemarche/api/networks/tests.py
+++ b/lemarche/api/networks/tests.py
@@ -10,11 +10,12 @@ class NetworkApiTest(TestCase):
     def setUpTestData(cls):
         NetworkFactory(name="Reseau 1")
         NetworkFactory(name="Reseau 2")
-        UserFactory(api_key="admin")
+        cls.token = "a" * 64
+        UserFactory(api_key=cls.token)
 
     def test_should_return_network_list(self):
-        url = reverse("api:networks-list")  # anonymous user
-        response = self.client.get(url)
+        url = reverse("api:networks-list")
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 2)
         self.assertEqual(len(response.data["results"]), 2)
         self.assertTrue("slug" in response.data["results"][0])

--- a/lemarche/api/perimeters/tests.py
+++ b/lemarche/api/perimeters/tests.py
@@ -26,22 +26,23 @@ class PerimeterListFilterApiTest(TestCase):
         )
         cls.token = "a" * 64
         UserFactory(api_key=cls.token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.token}"})
 
     def test_should_return_perimeter_list(self):
         url = reverse("api:perimeters-list")
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 3)
         self.assertEqual(len(response.data["results"]), 3)
 
     def test_should_filter_perimeter_list_by_kind(self):
         # single
         url = reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
         url = reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}&kind={Perimeter.KIND_DEPARTMENT}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 

--- a/lemarche/api/perimeters/tests.py
+++ b/lemarche/api/perimeters/tests.py
@@ -24,25 +24,24 @@ class PerimeterListFilterApiTest(TestCase):
         cls.perimeter_region = PerimeterFactory(
             name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
         )
-        UserFactory(api_key="admin")
+        cls.token = "a" * 64
+        UserFactory(api_key=cls.token)
 
     def test_should_return_perimeter_list(self):
-        url = reverse("api:perimeters-list")  # anonymous user
-        response = self.client.get(url)
+        url = reverse("api:perimeters-list")
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 3)
         self.assertEqual(len(response.data["results"]), 3)
 
     def test_should_filter_perimeter_list_by_kind(self):
         # single
-        url = reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}"  # anonymous user
-        response = self.client.get(url)
+        url = reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
-        url = (
-            reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}&kind={Perimeter.KIND_DEPARTMENT}"
-        )  # anonymous user  # noqa
-        response = self.client.get(url)
+        url = reverse("api:perimeters-list") + f"?kind={Perimeter.KIND_CITY}&kind={Perimeter.KIND_DEPARTMENT}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
@@ -127,8 +126,10 @@ class PerimetersAutocompleteFilterApiTest(TestCase):
 
 class PerimeterChoicesApiTest(TestCase):
     def test_should_return_perimeter_kinds_list(self):
-        url = reverse("api:perimeter-kinds-list")  # anonymous user
-        response = self.client.get(url)
+        token = "a" * 64
+        UserFactory(api_key=token)
+        url = reverse("api:perimeter-kinds-list")
+        response = self.client.get(url, headers={"authorization": f"Bearer {token}"})
         self.assertEqual(response.data["count"], 3)
         self.assertEqual(len(response.data["results"]), 3)
         self.assertTrue("id" in response.data["results"][0])

--- a/lemarche/api/perimeters/views.py
+++ b/lemarche/api/perimeters/views.py
@@ -21,6 +21,7 @@ class PerimeterAutocompleteViewSet(mixins.ListModelMixin, viewsets.GenericViewSe
     queryset = Perimeter.objects.all()
     serializer_class = PerimeterSimpleSerializer
     filterset_class = PerimeterAutocompleteFilter
+    permission_classes = []  # override default permission, this endpoint is open
     pagination_class = None
     http_method_names = ["get"]
 

--- a/lemarche/api/sectors/tests.py
+++ b/lemarche/api/sectors/tests.py
@@ -14,7 +14,7 @@ class SectorApiTest(TestCase):
         UserFactory(api_key=cls.token)
 
     def test_should_return_sector_list(self):
-        url = reverse("api:sectors-list")  # anonymous user
+        url = reverse("api:sectors-list")
         response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 2)
         self.assertEqual(len(response.data["results"]), 2)

--- a/lemarche/api/sectors/tests.py
+++ b/lemarche/api/sectors/tests.py
@@ -10,11 +10,12 @@ class SectorApiTest(TestCase):
     def setUpTestData(cls):
         SectorFactory()
         SectorFactory()
-        UserFactory(api_key="admin")
+        cls.token = "a" * 64
+        UserFactory(api_key=cls.token)
 
     def test_should_return_sector_list(self):
         url = reverse("api:sectors-list")  # anonymous user
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.token}"})
         self.assertEqual(response.data["count"], 2)
         self.assertEqual(len(response.data["results"]), 2)
         self.assertTrue("slug" in response.data["results"][0])

--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -74,31 +74,3 @@ class SiaeDetailSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
-
-
-class SiaeListSerializer(SiaeDetailSerializer):
-    class Meta:
-        model = Siae
-        fields = [
-            "id",
-            "name",
-            "brand",
-            "slug",
-            "siret",
-            "nature",
-            "kind",
-            "kind_parent",
-            "contact_website",
-            "logo_url",
-            # additional contact_ fields available in detail
-            "address",
-            "city",
-            "post_code",
-            "department",
-            "region",
-            "is_active",
-            # is_ boolean fields available in detail
-            # M2M fields available in detail
-            "created_at",
-            "updated_at",
-        ]

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -64,13 +64,14 @@ class SiaeListFilterApiTest(TestCase):
         siae_with_network_2.networks.add(cls.network_2)
         cls.user_token = generate_random_string()
         UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
 
     def test_siae_count(self):
         self.assertEqual(Siae.objects.count(), 9)
 
     def test_should_return_siae_list(self):
         url = reverse("api:siae-list")
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 4 + 2 + 2)
         self.assertEqual(len(response.data["results"]), 4 + 2 + 2)
 
@@ -82,30 +83,30 @@ class SiaeListFilterApiTest(TestCase):
 
     def test_should_filter_siae_list_by_is_active(self):
         url = reverse("api:siae-list") + "?is_active=false"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         url = reverse("api:siae-list") + "?is_active=true"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 3 + 2 + 2)
         self.assertEqual(len(response.data["results"]), 3 + 2 + 2)
 
     def test_should_filter_siae_list_by_kind(self):
         # single
         url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
         url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}&kind={siae_constants.KIND_ACI}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_presta_type(self):
         # single
         url = reverse("api:siae-list") + f"?presta_types={siae_constants.PRESTA_BUILD}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
@@ -113,37 +114,37 @@ class SiaeListFilterApiTest(TestCase):
             reverse("api:siae-list")
             + f"?presta_types={siae_constants.PRESTA_BUILD}&presta_types={siae_constants.PRESTA_PREST}"
         )
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_department(self):
         url = reverse("api:siae-list") + "?department=38"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
 
     def test_should_filter_siae_list_by_sector(self):
         # single
         url = reverse("api:siae-list") + f"?sectors={self.sector_1.slug}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
         url = reverse("api:siae-list") + f"?sectors={self.sector_1.slug}&sectors={self.sector_2.slug}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_network(self):
         # single
         url = reverse("api:siae-list") + f"?networks={self.network_1.slug}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
         url = reverse("api:siae-list") + f"?networks={self.network_1.slug}&networks={self.network_2.slug}"
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
@@ -154,6 +155,7 @@ class SiaeDetailApiTest(TestCase):
         cls.siae = SiaeFactory()
         cls.user_token = generate_random_string()
         UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
 
     def test_should_return_4O4_if_siae_excluded(self):
         siae_opcs = SiaeFactory(kind="OPCS")
@@ -161,7 +163,7 @@ class SiaeDetailApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
         url = reverse("api:siae-detail", args=[siae_opcs.id])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_simple_siae_object_to_anonymous_users(self):
@@ -171,7 +173,7 @@ class SiaeDetailApiTest(TestCase):
 
     def test_should_return_detailed_siae_object_to_authenticated_users(self):
         url = reverse("api:siae-detail", args=[self.siae.id])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertTrue("id" in response.data)
         self.assertTrue("name" in response.data)
         self.assertTrue("siret" in response.data)
@@ -191,10 +193,11 @@ class SiaeRetrieveBySlugApiTest(TestCase):
         cls.user_token = generate_random_string()
         SiaeFactory(name="Une structure", siret="12312312312345", department="38")
         UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
 
     def test_should_return_404_if_slug_unknown(self):
         url = reverse("api:siae-retrieve-by-slug", args=["test-123"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_4O4_if_siae_excluded(self):
@@ -203,12 +206,12 @@ class SiaeRetrieveBySlugApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
         url = reverse("api:siae-retrieve-by-slug", args=[siae_opcs.slug])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_detailed_siae_object_to_authenticated_user(self):
         url = reverse("api:siae-retrieve-by-slug", args=["une-structure-38"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["siret"], "12312312312345")
         self.assertEqual(response.data["slug"], "une-structure-38")
@@ -223,16 +226,17 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222233333", department="69")
         cls.user_token = generate_random_string()
         UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
 
     def test_should_return_400_if_siren_malformed(self):
         for siren in ["123", "12312312312345"]:
             url = reverse("api:siae-retrieve-by-siren", args=[siren])
-            response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+            response = self.authenticated_client.get(url)
             self.assertEqual(response.status_code, 400)
 
     def test_should_return_empty_list_if_siren_unknown(self):
         url = reverse("api:siae-retrieve-by-siren", args=["444444444"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 0)
@@ -243,12 +247,12 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
         url = reverse("api:siae-retrieve-by-siren", args=[siae_opcs.siren])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(len(response.data), 0)
 
     def test_should_return_siae_list_if_siren_known(self):
         url = reverse("api:siae-retrieve-by-siren", args=["123123123"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
@@ -256,23 +260,23 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" not in response.data)
         url = reverse("api:siae-retrieve-by-siren", args=["222222222"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["siret"], "22222222233333")
         self.assertEqual(response.data[1]["siret"], "22222222233333")
         # authenticated user
-        url = reverse("api:siae-retrieve-by-siren", args=["123123123"]) + "?token=" + self.user_token
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        url = reverse("api:siae-retrieve-by-siren", args=["123123123"])
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["siret"], "12312312312345")
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" in response.data[0])
-        url = reverse("api:siae-retrieve-by-siren", args=["222222222"]) + "?token=" + self.user_token
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        url = reverse("api:siae-retrieve-by-siren", args=["222222222"])
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
@@ -289,16 +293,17 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         SiaeFactory(name="Une autre structure avec le meme siret", siret="22222222233333", department="69")
         cls.user_token = generate_random_string()
         UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
 
     def test_should_return_404_if_siret_malformed(self):
         for siret in ["123", "123123123123456", "123 123 123 12345"]:
             url = reverse("api:siae-retrieve-by-siret", args=[siret])
-            response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+            response = self.authenticated_client.get(url)
             self.assertEqual(response.status_code, 400)
 
     def test_should_return_empty_list_if_siret_unknown(self):
         url = reverse("api:siae-retrieve-by-siret", args=["44444444444444"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 0)
@@ -309,35 +314,35 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
         url = reverse("api:siae-retrieve-by-siret", args=[siae_opcs.siret])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(len(response.data), 0)
 
     def test_should_return_siae_list_if_siret_known(self):
         url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["siret"], "12312312312345")
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"])
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["siret"], "22222222233333")
         self.assertEqual(response.data[1]["siret"], "22222222233333")
         # authenticated user
-        url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"]) + "?token=" + self.user_token
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"])
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["siret"], "12312312312345")
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" in response.data[0])
-        url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"]) + "?token=" + self.user_token
-        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
+        url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"])
+        response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -159,14 +159,11 @@ class SiaeDetailApiTest(TestCase):
 
     def test_should_return_4O4_if_siae_excluded(self):
         siae_opcs = SiaeFactory(kind="OPCS")
-        url = reverse("api:siae-detail", args=[siae_opcs.id])  # anonymous
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
         url = reverse("api:siae-detail", args=[siae_opcs.id])
         response = self.authenticated_client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    def test_should_return_simple_siae_object_to_anonymous_users(self):
+    def test_should_return_401_to_anonymous_users(self):
         url = reverse("api:siae-detail", args=[self.siae.id])  # anonymous user
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -21,20 +21,11 @@ class SiaeListApiTest(TestCase):
     def test_should_return_siae_sublist_to_anonymous_users(self):
         url = reverse("api:siae-list")  # anonymous user
         response = self.client.get(url)
-        # self.assertEqual(response.data["count"], 12)
-        # self.assertEqual(len(response.data["results"]), 10)  # results aren't paginated
-        self.assertEqual(len(response.data), 10)
-        self.assertTrue("id" in response.data[0])
-        self.assertTrue("name" in response.data[0])
-        self.assertTrue("siret" in response.data[0])
-        self.assertTrue("kind" in response.data[0])
-        self.assertTrue("kind_parent" in response.data[0])
-        self.assertTrue("department" in response.data[0])
-        self.assertTrue("created_at" in response.data[0])
+        self.assertEqual(response.status_code, 401)
 
     def test_should_return_detailed_siae_list_with_pagination_to_authenticated_users(self):
-        url = reverse("api:siae-list") + "?token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list")
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 12)
         self.assertEqual(len(response.data["results"]), 12)
         self.assertTrue("id" in response.data["results"][0])
@@ -46,8 +37,8 @@ class SiaeListApiTest(TestCase):
         self.assertTrue("created_at" in response.data["results"][0])
 
     def test_should_return_401_if_token_unknown(self):
-        url = reverse("api:siae-list") + "?token=wrong"
-        response = self.client.get(url)
+        url = reverse("api:siae-list")
+        response = self.client.get(url, headers={"authorization": "wrong"})
         self.assertEqual(response.status_code, 401)
 
 
@@ -78,8 +69,8 @@ class SiaeListFilterApiTest(TestCase):
         self.assertEqual(Siae.objects.count(), 9)
 
     def test_should_return_siae_list(self):
-        url = reverse("api:siae-list") + "?token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list")
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 4 + 2 + 2)
         self.assertEqual(len(response.data["results"]), 4 + 2 + 2)
 
@@ -87,87 +78,72 @@ class SiaeListFilterApiTest(TestCase):
         # single
         url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}"  # anonymous user
         response = self.client.get(url)
-        # self.assertEqual(response.data["count"], 1)
-        # self.assertEqual(len(response.data["results"]), 4 + 2 + 2)  # results aren't paginated
-        self.assertEqual(len(response.data), 4 + 2 + 2)
+        self.assertEqual(response.status_code, 401)
 
     def test_should_filter_siae_list_by_is_active(self):
-        url = reverse("api:siae-list") + "?is_active=false&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + "?is_active=false"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
-        url = reverse("api:siae-list") + "?is_active=true&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + "?is_active=true"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 3 + 2 + 2)
         self.assertEqual(len(response.data["results"]), 3 + 2 + 2)
 
     def test_should_filter_siae_list_by_kind(self):
         # single
-        url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
-        url = (
-            reverse("api:siae-list")
-            + f"?kind={siae_constants.KIND_ETTI}&kind={siae_constants.KIND_ACI}&token="
-            + self.user_token
-        )
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?kind={siae_constants.KIND_ETTI}&kind={siae_constants.KIND_ACI}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_presta_type(self):
         # single
-        url = reverse("api:siae-list") + f"?presta_types={siae_constants.PRESTA_BUILD}&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?presta_types={siae_constants.PRESTA_BUILD}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
         url = (
             reverse("api:siae-list")
-            + f"?presta_types={siae_constants.PRESTA_BUILD}&presta_types={siae_constants.PRESTA_PREST}&token="
-            + self.user_token
+            + f"?presta_types={siae_constants.PRESTA_BUILD}&presta_types={siae_constants.PRESTA_PREST}"
         )
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_department(self):
-        url = reverse("api:siae-list") + "?department=38&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + "?department=38"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
 
     def test_should_filter_siae_list_by_sector(self):
         # single
-        url = reverse("api:siae-list") + f"?sectors={self.sector_1.slug}&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?sectors={self.sector_1.slug}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
-        url = (
-            reverse("api:siae-list")
-            + f"?sectors={self.sector_1.slug}&sectors={self.sector_2.slug}&token="
-            + self.user_token
-        )
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?sectors={self.sector_1.slug}&sectors={self.sector_2.slug}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
     def test_should_filter_siae_list_by_network(self):
         # single
-        url = reverse("api:siae-list") + f"?networks={self.network_1.slug}&token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?networks={self.network_1.slug}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         # multiple
-        url = (
-            reverse("api:siae-list")
-            + f"?networks={self.network_1.slug}&networks={self.network_2.slug}&token="
-            + self.user_token
-        )
-        response = self.client.get(url)
+        url = reverse("api:siae-list") + f"?networks={self.network_1.slug}&networks={self.network_2.slug}"
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
@@ -183,29 +159,19 @@ class SiaeDetailApiTest(TestCase):
         siae_opcs = SiaeFactory(kind="OPCS")
         url = reverse("api:siae-detail", args=[siae_opcs.id])  # anonymous
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
-        url = reverse("api:siae-detail", args=[siae_opcs.id]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        url = reverse("api:siae-detail", args=[siae_opcs.id])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_simple_siae_object_to_anonymous_users(self):
         url = reverse("api:siae-detail", args=[self.siae.id])  # anonymous user
         response = self.client.get(url)
-        self.assertTrue("id" in response.data)
-        self.assertTrue("name" in response.data)
-        self.assertTrue("siret" in response.data)
-        self.assertTrue("slug" in response.data)
-        self.assertTrue("kind" in response.data)
-        self.assertTrue("kind_parent" in response.data)
-        self.assertTrue("sectors" not in response.data)
-        self.assertTrue("networks" not in response.data)
-        self.assertTrue("offers" not in response.data)
-        self.assertTrue("client_references" not in response.data)
-        self.assertTrue("labels" not in response.data)
+        self.assertEqual(response.status_code, 401)
 
     def test_should_return_detailed_siae_object_to_authenticated_users(self):
-        url = reverse("api:siae-detail", args=[self.siae.id]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-detail", args=[self.siae.id])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertTrue("id" in response.data)
         self.assertTrue("name" in response.data)
         self.assertTrue("siret" in response.data)
@@ -227,31 +193,22 @@ class SiaeRetrieveBySlugApiTest(TestCase):
         UserFactory(api_key=cls.user_token)
 
     def test_should_return_404_if_slug_unknown(self):
-        url = reverse("api:siae-retrieve-by-slug", args=["test-123"])  # anonymous user
-        response = self.client.get(url)
+        url = reverse("api:siae-retrieve-by-slug", args=["test-123"])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 404)
 
     def test_should_return_4O4_if_siae_excluded(self):
         siae_opcs = SiaeFactory(kind="OPCS")
         url = reverse("api:siae-retrieve-by-slug", args=[siae_opcs.slug])  # anonymous
         response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        url = reverse("api:siae-retrieve-by-slug", args=[siae_opcs.slug])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 404)
-        url = reverse("api:siae-retrieve-by-slug", args=[siae_opcs.slug]) + "?token=" + self.user_token
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
-
-    def test_should_return_siae_if_slug_known(self):
-        url = reverse("api:siae-retrieve-by-slug", args=["une-structure-38"])  # anonymous user
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        # self.assertEqual(type(response.data), dict)
-        self.assertEqual(response.data["siret"], "12312312312345")
-        self.assertEqual(response.data["slug"], "une-structure-38")
-        self.assertTrue("sectors" not in response.data)
 
     def test_should_return_detailed_siae_object_to_authenticated_user(self):
-        url = reverse("api:siae-retrieve-by-slug", args=["une-structure-38"]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        url = reverse("api:siae-retrieve-by-slug", args=["une-structure-38"])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["siret"], "12312312312345")
         self.assertEqual(response.data["slug"], "une-structure-38")
@@ -271,13 +228,13 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         # anonymous user
         for siren in ["123", "12312312312345"]:
             url = reverse("api:siae-retrieve-by-siren", args=[siren])
-            response = self.client.get(url)
+            response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
             self.assertEqual(response.status_code, 400)
 
     def test_should_return_empty_list_if_siren_unknown(self):
         # anonymous user
         url = reverse("api:siae-retrieve-by-siren", args=["444444444"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 0)
@@ -286,15 +243,14 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         siae_opcs = SiaeFactory(kind="OPCS", siret="99999999999999")
         url = reverse("api:siae-retrieve-by-siren", args=[siae_opcs.siren])  # anonymous
         response = self.client.get(url)
-        self.assertEqual(len(response.data), 0)
-        url = reverse("api:siae-retrieve-by-siren", args=[siae_opcs.siren]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        url = reverse("api:siae-retrieve-by-siren", args=[siae_opcs.siren])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(len(response.data), 0)
 
     def test_should_return_siae_list_if_siren_known(self):
-        # anonymous user
         url = reverse("api:siae-retrieve-by-siren", args=["123123123"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
@@ -302,16 +258,15 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" not in response.data)
         url = reverse("api:siae-retrieve-by-siren", args=["222222222"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["siret"], "22222222233333")
         self.assertEqual(response.data[1]["siret"], "22222222233333")
-        self.assertTrue("sectors" not in response.data[0])
         # authenticated user
         url = reverse("api:siae-retrieve-by-siren", args=["123123123"]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
@@ -319,7 +274,7 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" in response.data[0])
         url = reverse("api:siae-retrieve-by-siren", args=["222222222"]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
@@ -338,16 +293,14 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         UserFactory(api_key=cls.user_token)
 
     def test_should_return_404_if_siret_malformed(self):
-        # anonymous user
         for siret in ["123", "123123123123456", "123 123 123 12345"]:
             url = reverse("api:siae-retrieve-by-siret", args=[siret])
-            response = self.client.get(url)
+            response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
             self.assertEqual(response.status_code, 400)
 
     def test_should_return_empty_list_if_siret_unknown(self):
-        # anonymous user
         url = reverse("api:siae-retrieve-by-siret", args=["44444444444444"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 0)
@@ -356,32 +309,29 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         siae_opcs = SiaeFactory(kind="OPCS", siret="99999999999999")
         url = reverse("api:siae-retrieve-by-siret", args=[siae_opcs.siret])  # anonymous
         response = self.client.get(url)
-        self.assertEqual(len(response.data), 0)
-        url = reverse("api:siae-retrieve-by-siret", args=[siae_opcs.siret]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        url = reverse("api:siae-retrieve-by-siret", args=[siae_opcs.siret])
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(len(response.data), 0)
 
     def test_should_return_siae_list_if_siret_known(self):
-        # anonymous user
         url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["siret"], "12312312312345")
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
-        self.assertTrue("sectors" not in response.data[0])
         url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"])
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["siret"], "22222222233333")
         self.assertEqual(response.data[1]["siret"], "22222222233333")
-        self.assertTrue("sectors" not in response.data[0])
         # authenticated user
         url = reverse("api:siae-retrieve-by-siret", args=["12312312312345"]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 1)
@@ -389,7 +339,7 @@ class SiaeRetrieveBySiretApiTest(TestCase):
         self.assertEqual(response.data[0]["slug"], "une-structure-38")
         self.assertTrue("sectors" in response.data[0])
         url = reverse("api:siae-retrieve-by-siret", args=["22222222233333"]) + "?token=" + self.user_token
-        response = self.client.get(url)
+        response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)
         # self.assertEqual(type(response.data), list)
         self.assertEqual(len(response.data), 2)
@@ -403,17 +353,10 @@ class SiaeChoicesApiTest(TestCase):
         # anonymous user
         url = reverse("api:siae-kinds-list")
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 10)
-        self.assertEqual(len(response.data["results"]), 10)
-        self.assertTrue("id" in response.data["results"][0])
-        self.assertTrue("name" in response.data["results"][0])
-        self.assertTrue("parent" in response.data["results"][0])
+        self.assertEqual(response.status_code, 401)
 
     def test_should_return_siae_presta_types_list(self):
         # anonymous user
         url = reverse("api:siae-presta-types-list")
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(len(response.data["results"]), 3)
-        self.assertTrue("id" in response.data["results"][0])
-        self.assertTrue("name" in response.data["results"][0])
+        self.assertEqual(response.status_code, 401)

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -225,14 +225,12 @@ class SiaeRetrieveBySirenApiTest(TestCase):
         UserFactory(api_key=cls.user_token)
 
     def test_should_return_400_if_siren_malformed(self):
-        # anonymous user
         for siren in ["123", "12312312312345"]:
             url = reverse("api:siae-retrieve-by-siren", args=[siren])
             response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
             self.assertEqual(response.status_code, 400)
 
     def test_should_return_empty_list_if_siren_unknown(self):
-        # anonymous user
         url = reverse("api:siae-retrieve-by-siren", args=["444444444"])
         response = self.client.get(url, headers={"authorization": f"Bearer {self.user_token}"})
         self.assertEqual(response.status_code, 200)

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -352,14 +352,26 @@ class SiaeRetrieveBySiretApiTest(TestCase):
 
 
 class SiaeChoicesApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_token = "a" * 64
+        UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
+
     def test_should_return_siae_kinds_list(self):
-        # anonymous user
         url = reverse("api:siae-kinds-list")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
+        response = self.authenticated_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 10)
+        self.assertEqual(len(response.data["results"]), 10)
+        self.assertTrue("id" in response.data["results"][0])
+        self.assertTrue("name" in response.data["results"][0])
 
     def test_should_return_siae_presta_types_list(self):
-        # anonymous user
         url = reverse("api:siae-presta-types-list")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
+        response = self.authenticated_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 3)
+        self.assertEqual(len(response.data["results"]), 3)
+        self.assertTrue("id" in response.data["results"][0])
+        self.assertTrue("name" in response.data["results"][0])

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -1,7 +1,7 @@
 from django.db.models import F
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, viewsets
 from rest_framework.response import Response
 
@@ -28,11 +28,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     @extend_schema(
         summary="Lister toutes les structures",
         tags=[Siae._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(
-                name="token", description="Token Utilisateur (pour compatibilité ancienne)", required=False, type=str
-            ),
-        ],
     )
     def list(self, request, format=None):
         """
@@ -54,11 +49,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     @extend_schema(
         summary="Détail d'une structure (par son id)",
         tags=[Siae._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(
-                name="token", description="Token Utilisateur (pour compatibilité ancienne)", required=False, type=str
-            ),
-        ],
         responses=SiaeDetailSerializer,
     )
     def retrieve(self, request, pk=None, format=None):
@@ -72,11 +62,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     @extend_schema(
         summary="Détail d'une structure (par son slug)",
         tags=[Siae._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(
-                name="token", description="Token Utilisateur (pour compatibilité ancienne)", required=False, type=str
-            ),
-        ],
         responses=SiaeDetailSerializer,
     )
     def retrieve_by_slug(self, request, slug=None, format=None):
@@ -91,11 +76,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     @extend_schema(
         summary="Détail d'une structure (par son siren)",
         tags=[Siae._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(
-                name="token", description="Token Utilisateur (pour compatibilité ancienne)", required=False, type=str
-            ),
-        ],
         responses=SiaeDetailSerializer,
     )
     def retrieve_by_siren(self, request, siren=None, format=None):
@@ -111,11 +91,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     @extend_schema(
         summary="Détail d'une structure (par son siret)",
         tags=[Siae._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(
-                name="token", description="Token Utilisateur (pour compatibilité ancienne)", required=False, type=str
-            ),
-        ],
         responses=SiaeDetailSerializer,
     )
     def retrieve_by_siret(self, request, siret=None, format=None):

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -6,7 +6,7 @@ from rest_framework import mixins, viewsets
 from rest_framework.response import Response
 
 from lemarche.api.siaes.filters import SiaeFilter
-from lemarche.api.siaes.serializers import SiaeDetailSerializer, SiaeListSerializer
+from lemarche.api.siaes.serializers import SiaeDetailSerializer
 from lemarche.api.utils import BasicChoiceSerializer, BasicChoiceWithParentSerializer
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.models import Siae
@@ -18,7 +18,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     """
 
     queryset = Siae.objects.api_query_set()
-    serializer_class = SiaeListSerializer
+    serializer_class = SiaeDetailSerializer
     filterset_class = SiaeFilter
 
     def get_queryset(self):
@@ -35,16 +35,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
 
         <i>Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.</i>
         """
-        if request.user.is_authenticated:
-            # Utilisateur authentifié : accès complet
-            return super().list(request, format)
-        else:
-            # Utilisateur non authentifié : limiter à 10 résultats
-            serializer = SiaeListSerializer(
-                self.get_queryset()[:10],
-                many=True,
-            )
-            return Response(serializer.data)
+        return super().list(request, format)
 
     @extend_schema(
         summary="Détail d'une structure (par son id)",
@@ -104,29 +95,17 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         return self._list_return(request, queryset, format)
 
     def _retrieve_return(self, request, queryset, format):
-        if not request.user.is_authenticated:
-            serializer = SiaeListSerializer(
-                queryset,
-                many=False,
-            )
-        else:
-            serializer = SiaeDetailSerializer(
-                queryset,
-                many=False,
-            )
+        serializer = SiaeDetailSerializer(
+            queryset,
+            many=False,
+        )
         return Response(serializer.data)
 
     def _list_return(self, request, queryset, format):
-        if not request.user.is_authenticated:
-            serializer = SiaeListSerializer(
-                queryset,
-                many=True,
-            )
-        else:
-            serializer = SiaeDetailSerializer(
-                queryset,
-                many=True,
-            )
+        serializer = SiaeDetailSerializer(
+            queryset,
+            many=True,
+        )
         return Response(serializer.data)
 
 

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -410,12 +410,26 @@ class TenderCreateApiPartnerTest(TestCase):
 
 
 class TenderChoicesApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_token = "a" * 64
+        UserFactory(api_key=cls.user_token)
+        cls.authenticated_client = cls.client_class(headers={"authorization": f"Bearer {cls.user_token}"})
+
     def test_should_return_tender_kinds_list(self):
-        url = reverse("api:tender-kinds-list")  # anonymous user
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
+        url = reverse("api:tender-kinds-list")
+        response = self.authenticated_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 3)
+        self.assertEqual(len(response.data["results"]), 3)
+        self.assertTrue("id" in response.data["results"][0])
+        self.assertTrue("name" in response.data["results"][0])
 
     def test_should_return_tender_amounts_list(self):
-        url = reverse("api:tender-amounts-list")  # anonymous user
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 401)
+        url = reverse("api:tender-amounts-list")
+        response = self.authenticated_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 14)
+        self.assertEqual(len(response.data["results"]), 14)
+        self.assertTrue("id" in response.data["results"][0])
+        self.assertTrue("name" in response.data["results"][0])

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -81,7 +81,7 @@ class TenderCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_user_with_unknown_api_key_cannot_create_tender(self):
-        url = reverse("api:tenders-list") + "?token=test"
+        url = reverse("api:tenders-list")
         response = self.client.post(
             url, data=TENDER_JSON, content_type="application/json", headers={"authorization": "Bearer !!!!!!"}
         )

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -413,15 +413,9 @@ class TenderChoicesApiTest(TestCase):
     def test_should_return_tender_kinds_list(self):
         url = reverse("api:tender-kinds-list")  # anonymous user
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(len(response.data["results"]), 3)
-        self.assertTrue("id" in response.data["results"][0])
-        self.assertTrue("name" in response.data["results"][0])
+        self.assertEqual(response.status_code, 401)
 
     def test_should_return_tender_amounts_list(self):
         url = reverse("api:tender-amounts-list")  # anonymous user
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 14)
-        self.assertEqual(len(response.data["results"]), 14)
-        self.assertTrue("id" in response.data["results"][0])
-        self.assertTrue("name" in response.data["results"][0])
+        self.assertEqual(response.status_code, 401)

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils import timezone
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
 
@@ -23,9 +23,6 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     @extend_schema(
         summary="Déposer un besoin d'achat",
         tags=[Tender._meta.verbose_name_plural],
-        parameters=[
-            OpenApiParameter(name="token", description="Token Utilisateur", required=True, type=str),
-        ],
     )
     def create(self, request, *args, **kwargs):
         return super().create(request, args, kwargs)

--- a/lemarche/api/tests.py
+++ b/lemarche/api/tests.py
@@ -38,25 +38,6 @@ class CustomBearerAuthenticationTest(TestCase):
         self.assertEqual(user, self.user)
         self.assertEqual(token, self.user_token)
 
-    def test_authentication_with_url_token(self):
-        """
-        Test the authentication process using a token provided in the URL.
-
-        This test simulates a GET request with a token appended to the URL query string.
-        It verifies that the authentication mechanism correctly identifies the user and
-        token from the request.
-
-        Assertions:
-            - The authenticated user should match the expected user.
-            - The token extracted from the request should match the expected user token.
-        """
-        request = self.factory.get(self.url + "?token=" + self.user_token)
-
-        user, token = self.authentication.authenticate(request)
-
-        self.assertEqual(user, self.user)
-        self.assertEqual(token, self.user_token)
-
     def test_authentication_with_short_token(self):
         """
         Test the authentication process with a short token.

--- a/lemarche/api/tests.py
+++ b/lemarche/api/tests.py
@@ -1,8 +1,7 @@
-from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from rest_framework.exceptions import AuthenticationFailed
 
-from lemarche.api.authentication import CustomBearerAuthentication, DeprecationWarningMiddleware
+from lemarche.api.authentication import CustomBearerAuthentication
 from lemarche.api.utils import generate_random_string
 from lemarche.users.factories import UserFactory
 
@@ -117,44 +116,3 @@ class CustomBearerAuthenticationTest(TestCase):
         result = self.authentication.authenticate(request)
 
         self.assertIsNone(result)
-
-
-class DeprecationWarningMiddlewareTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.middleware = DeprecationWarningMiddleware(lambda request: HttpResponse("Test response"))
-
-    def test_no_deprecation_warning(self):
-        """
-        Test that no deprecation warning is present in the response.
-
-        This test sends a GET request to a specific API endpoint and checks
-        that the response does not contain a 'Deprecation-Warning' attribute.
-        """
-        request = self.factory.get("/api/some-endpoint/")
-        response = self.middleware(request)
-
-        self.assertFalse(hasattr(response, "Deprecation-Warning"))
-
-    def test_with_deprecation_warning(self):
-        """
-        Test that a deprecation warning is included in the response when the request
-        contains the _deprecated_auth_warning marker.
-
-        This test simulates a request to an endpoint with the _deprecated_auth_warning
-        marker set to True. It then checks that the response includes a "Deprecation-Warning"
-        header with the expected deprecation message indicating that URL token authentication
-        is deprecated and will be removed by January 2025, and advises to use the Authorization
-        header with Bearer tokens instead.
-        """
-        request = self.factory.get("/api/some-endpoint/")
-        request._deprecated_auth_warning = True  # Ajouter le marqueur
-
-        response = self.middleware(request)
-
-        self.assertIn("Deprecation-Warning", response)
-        self.assertEqual(
-            response["Deprecation-Warning"],
-            "URL token authentication is deprecated and will be removed on 2025/01. "
-            "Please use Authorization header with Bearer tokens.",
-        )

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -64,12 +64,7 @@
 
                 <h4 class="h2">Comment se servir du token ?</h4>
 
-                <p>Rien de plus simple, il suffit de rajouter <code>token=&lt;VOTRE-TOKEN&gt;</code> dans l'URL de vos requêtes API</p>
-                <p>
-                    Exemples :<br />
-                    - <code>https://lemarche.inclusion.beta.gouv.fr/api/siae/?token=test</code><br />
-                    - <code>https://lemarche.inclusion.beta.gouv.fr/api/siae/?department=38&kind=ESAT&token=test</code>
-                </p>
+                <p>Rien de plus simple, il suffit de rajouter <code>token=&lt;VOTRE-TOKEN&gt;</code> dans le header "authorization" de vos requêtes API</p>
             </div>
         </div>
 

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -64,7 +64,7 @@
 
                 <h4 class="h2">Comment se servir du token ?</h4>
 
-                <p>Rien de plus simple, il suffit de rajouter <code>token=&lt;VOTRE-TOKEN&gt;</code> dans le header "authorization" de vos requêtes API</p>
+                <p>Rien de plus simple, il suffit de rajouter <strong><code>Bearer &lt;VOTRE-TOKEN&gt;</code></strong> dans le header "authorization" de vos requêtes API</p>
             </div>
         </div>
 


### PR DESCRIPTION
### Quoi ?

Ne plus autoriser les utilisateur à accéder librement à l'API

### Pourquoi ?

Les utilisateurs se connectent trop en anonyme, on ne peut pas faire de stats dessus

### Comment ?

- Exiger l'authentification sur chaque appel à l'API
- Modifier la documentation en conséquence