### PR TITLE
fix: wrong GET ids

### DIFF
--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1275,10 +1275,7 @@ class TenderDetailNotInterestedClickView(TestCase):
     def test_user_can_notify_not_interested_wish_with_siae_id_in_url(self):
         # wrong siae_id
         response = self.client.post(f"{self.tender_not_interested_url}?siae_id=999999", data={}, follow=True)
-        self.assertContains(response, self.cta_message)
-        self.assertNotContains(response, 'id="login_or_signup_siae_tender_modal"')
-        self.assertContains(response, 'id="detail_not_interested_click_confirm_modal"')
-        self.assertNotContains(response, self.cta_message_success)
+        self.assertEqual(response.status_code, 404)
         # workflow
         tendersiae = TenderSiae.objects.get(tender=self.tender, siae=self.siae)
         self.assertIsNone(tendersiae.detail_not_interested_click_date)
@@ -1298,11 +1295,7 @@ class TenderDetailNotInterestedClickView(TestCase):
         response = self.client.post(
             f"{self.tender_not_interested_url}?siae_id=999999&not_interested=True", data={}, follow=True
         )
-        self.assertContains(response, self.cta_message)
-        self.assertNotContains(response, 'id="login_or_signup_siae_tender_modal"')
-        self.assertContains(response, 'dialog id="detail_not_interested_click_confirm_modal"')
-        self.assertNotContains(response, 'modal-siae show" id="detail_not_interested_click_confirm_modal"')
-        self.assertNotContains(response, self.cta_message_success)
+        self.assertEqual(response.status_code, 404)
         # workflow
         tendersiae = TenderSiae.objects.get(tender=self.tender, siae=self.siae)
         self.assertIsNone(tendersiae.detail_not_interested_click_date)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -350,16 +350,21 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotSentMixin, DetailView):
         user = self.request.user
         self.siae_id = request.GET.get("siae_id", None)
         self.user_id = request.GET.get("user_id", None)
+        if self.siae_id:
+            self.siae = get_object_or_404(Siae, id=self.siae_id)
+        if self.user_id:
+            self.siae_user = get_object_or_404(User, id=self.user_id)
+
         # update 'email_link_click_date'
         if self.siae_id:
             if self.user_id:  # TODO: check if user in siae ?
-                TenderSiae.objects.filter(
-                    tender=self.object, siae_id=int(self.siae_id), email_link_click_date=None
-                ).update(user_id=int(self.user_id), email_link_click_date=timezone.now(), updated_at=timezone.now())
+                TenderSiae.objects.filter(tender=self.object, siae=self.siae, email_link_click_date=None).update(
+                    user=self.user_id, email_link_click_date=timezone.now(), updated_at=timezone.now()
+                )
             else:
-                TenderSiae.objects.filter(
-                    tender=self.object, siae_id=int(self.siae_id), email_link_click_date=None
-                ).update(email_link_click_date=timezone.now(), updated_at=timezone.now())
+                TenderSiae.objects.filter(tender=self.object, siae=self.siae, email_link_click_date=None).update(
+                    email_link_click_date=timezone.now(), updated_at=timezone.now()
+                )
         # update 'detail_display_date'
         if user.is_authenticated:
             if user.kind == User.KIND_SIAE:


### PR DESCRIPTION
### Quoi ?

[Issue sentry](https://inclusion.sentry.io/issues/14804431/)

Créer un tender, puis avec son slug ex http://localhost:8000/besoins/ggfdg-admin?siae_id=448gfdg

### Pourquoi ?

Paramètres get mal parsés

### Comment ?

Erreur 404 si les paramètres GET ne correspondent à aucun véritable id
