### PR TITLE
feat(Email Notifications): Mise à jour côté Brevo du choix pour les communications Marketing

### DIFF
--- a/lemarche/conversations/models.py
+++ b/lemarche/conversations/models.py
@@ -195,6 +195,8 @@ class Conversation(models.Model):
 
 
 class EmailGroup(models.Model):
+    COMMUNICATION_MARKETING = "Communication marketing"
+
     display_name = models.CharField(verbose_name="Nom", max_length=255, blank=True)
     description = models.TextField(verbose_name="Description", blank=True)
     relevant_user_kind = models.CharField(

--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -99,6 +99,18 @@ def update_contact(user_identifier: str, attributes_to_update: dict):
         logger.error(f"Exception when calling Brevo->ContactsApi->update_contact: {e}")
 
 
+def update_contact_email_blacklisted(user_identifier: str, email_blacklisted: bool):
+    api_client = get_api_client()
+    api_instance = sib_api_v3_sdk.ContactsApi(api_client)
+
+    update_contact = sib_api_v3_sdk.UpdateContact(email_blacklisted=email_blacklisted)
+    try:
+        api_response = api_instance.update_contact(identifier=user_identifier, update_contact=update_contact)
+        logger.info(f"Success Brevo->ContactsApi->update_contact: {api_response}")
+    except ApiException as e:
+        logger.error(f"Exception when calling Brevo->ContactsApi->update_contact: {e}")
+
+
 def remove_contact_from_list(user, list_id: int):
     api_client = get_api_client()
     api_instance = sib_api_v3_sdk.ContactsApi(api_client)

--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -106,9 +106,9 @@ def update_contact_email_blacklisted(user_identifier: str, email_blacklisted: bo
     update_contact = sib_api_v3_sdk.UpdateContact(email_blacklisted=email_blacklisted)
     try:
         api_response = api_instance.update_contact(identifier=user_identifier, update_contact=update_contact)
-        logger.info(f"Success Brevo->ContactsApi->update_contact: {api_response}")
+        logger.info(f"Success Brevo->ContactsApi->update_contact to update email_blacklisted: {api_response}")
     except ApiException as e:
-        logger.error(f"Exception when calling Brevo->ContactsApi->update_contact: {e}")
+        logger.error(f"Exception when calling Brevo->ContactsApi->update_contact to update email_blacklisted: {e}")
 
 
 def remove_contact_from_list(user, list_id: int):

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -91,6 +91,10 @@ def add_to_contact_list(user, type: str, tender=None, source: str = user_constan
         api_mailjet.add_to_contact_list_async(user.email, properties, contact_list_id)
 
 
+def update_contact_email_blacklisted(email, email_blacklisted: bool):
+    api_brevo.update_contact_email_blacklisted(email, email_blacklisted)
+
+
 @task()
 def send_mail_async(
     email_subject,

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -90,8 +90,11 @@ class DisabledEmailEditViewTest(TestCase):
             self.assertContains(response, group.display_name)
             self.assertContains(response, " checked>", count=2)
 
-    @patch("lemarche.utils.apis.api_brevo.sib_api_v3_sdk.UpdateContact")
-    def test_form_submission_updates_preferences_with_marketing_disabled(self, mock_update_contact):
+    @patch("lemarche.utils.apis.api_brevo.sib_api_v3_sdk.ContactsApi")
+    def test_form_submission_updates_preferences_with_marketing_disabled(self, mock_contacts_api):
+        # Setup the mock
+        mock_api_instance = mock_contacts_api.return_value
+
         self.assertEqual(self.user.disabled_emails.count(), 0)
         self.client.force_login(self.user)
         response = self.client.post(
@@ -102,14 +105,23 @@ class DisabledEmailEditViewTest(TestCase):
             },
             follow=True,
         )
+
+        # Verify the API was called correctly
+        mock_api_instance.update_contact.assert_called_once()
+        call_args = mock_api_instance.update_contact.call_args
+        self.assertEqual(call_args[1]["identifier"], self.user.email)
+        self.assertEqual(call_args[1]["update_contact"].email_blacklisted, True)
+
         self.assertContains(response, "Vos préférences de notifications ont été mises à jour.")
-        mock_update_contact.assert_called_once_with(self.user.email, True)
         self.user.refresh_from_db()
         self.assertEqual(self.user.disabled_emails.count(), 1)
         self.assertEqual(self.user.disabled_emails.first().group.pk, 2)
 
-    @patch("lemarche.utils.apis.api_brevo.sib_api_v3_sdk.UpdateContact")
-    def test_form_submission_updates_preferences_with_marketing_enabled(self, mock_update_contact):
+    @patch("lemarche.utils.apis.api_brevo.sib_api_v3_sdk.ContactsApi")
+    def test_form_submission_updates_preferences_with_marketing_enabled(self, mock_contacts_api):
+        # Setup the mock
+        mock_api_instance = mock_contacts_api.return_value
+
         self.assertEqual(self.user.disabled_emails.count(), 0)
         self.client.force_login(self.user)
         response = self.client.post(
@@ -120,7 +132,13 @@ class DisabledEmailEditViewTest(TestCase):
             },
             follow=True,
         )
+
+        # Verify the API was called correctly
+        mock_api_instance.update_contact.assert_called_once()
+        call_args = mock_api_instance.update_contact.call_args
+        self.assertEqual(call_args[1]["identifier"], self.user.email)
+        self.assertEqual(call_args[1]["update_contact"].email_blacklisted, False)
+
         self.assertContains(response, "Vos préférences de notifications ont été mises à jour.")
-        mock_update_contact.assert_called_once_with(self.user.email, False)
         self.user.refresh_from_db()
         self.assertEqual(self.user.disabled_emails.count(), 0)


### PR DESCRIPTION
### Quoi ?

Le choix concernant les mails "Communication Marketing" est poussé côté Brevo.

### Pourquoi ?

Pour que les emails des campagnes ne partent plus vers les utilisateurs qui ne le souhaitent plus.

### Comment ?

Avec l'API Brevo et le champs `email_blacklisted`

### Captures d'écran

Côté Brevo

![image](https://github.com/user-attachments/assets/6adbdb25-5c15-402c-adfb-d677a5de35a4)

### Autre

À noter que la désinscription aux envois de mail faite côté Brevo (en bas des mails par exemple), n'est pas répercuté de notre côté. À voir si il faut faire un script de synchro ou juste aller chercher l'info avant d'afficher les formulaires.
