### PR TITLE
chore(Log): Ajustement de la configuration des logs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -731,8 +731,8 @@ LOGGING = {
         "null": {"class": "logging.NullHandler"},
     },
     "loggers": {
+        "": {"handlers": ["console"], "level": env.str("DEFAULT_LOG_LEVEL", "INFO")},
         "django": {
-            "handlers": ["console"],
             "level": env.str("DJANGO_LOG_LEVEL", "INFO"),
         },
         # Silence `Invalid HTTP_HOST header` errors.
@@ -743,8 +743,7 @@ LOGGING = {
             "propagate": False,
         },
         "lemarche": {
-            "handlers": ["console"],
-            "level": env.str("DJANGO_LOG_LEVEL", "DEBUG"),
+            "level": env.str("LEMARCHE_LOG_LEVEL", "INFO"),
         },
     },
 }

--- a/config/settings/sentry.py
+++ b/config/settings/sentry.py
@@ -61,3 +61,4 @@ def sentry_init(dsn):
         # and is silently ignored when used in `context_processors.py` to get access to `request.user`.
     )
     ignore_logger("django.security.DisallowedHost")
+    ignore_logger("django_datadog_logger.middleware.request_log")

--- a/lemarche/utils/logging.py
+++ b/lemarche/utils/logging.py
@@ -7,7 +7,22 @@ class CustomDataDogJSONFormatter(datadog.DataDogJSONFormatter):
 
     def json_record(self, message, extra, record):
         log_entry_dict = super().json_record(message, extra, record)
+
+        # Remove the keys we don't want in the logs
         for log_key in self.LOG_KEYS_TO_REMOVE:
             if log_key in log_entry_dict:
                 del log_entry_dict[log_key]
+
+        # Redact the token in the URL
+        if "http.url" in log_entry_dict:
+            token_index = log_entry_dict["http.url"].find("token")
+            if token_index != -1:
+                log_entry_dict["http.url"] = log_entry_dict["http.url"][:token_index] + "token=[REDACTED]"
+
+        # Redact the token in the message
+        if "message" in log_entry_dict:
+            token_index = log_entry_dict["message"].find("token")
+            if token_index != -1:
+                log_entry_dict["message"] = log_entry_dict["message"][:token_index] + "token=[REDACTED]"
+
         return log_entry_dict


### PR DESCRIPTION
### Quoi ?

Limitation des logs envoyés vers Sentry.

### Pourquoi ?

Parce que le logger Datadog génère de nombreux logs sur Sentry

### Comment ?

On ignore le logger Datadog dans Sentry

### Autre

J'en ai profité pour offusquer les tokens d'API dans les logs
