### PR TITLE
chore(brevo): remove contact informations update logic

### DIFF
--- a/lemarche/utils/apis/api_brevo.py
+++ b/lemarche/utils/apis/api_brevo.py
@@ -87,17 +87,6 @@ def create_contact(user, list_id: int, tender=None):
         logger.error(f"Exception when calling Brevo->ContactsApi->create_contact (list_id : {list_id}): {e.body}")
 
 
-def update_contact(user_identifier: str, attributes_to_update: dict):
-    api_client = get_api_client()
-    api_instance = sib_api_v3_sdk.ContactsApi(api_client)
-    update_contact = sib_api_v3_sdk.UpdateContact(attributes=attributes_to_update)
-    try:
-        api_response = api_instance.update_contact(identifier=user_identifier, update_contact=update_contact)
-        logger.info(f"Success Brevo->ContactsApi->update_contact: {api_response}")
-    except ApiException as e:
-        logger.error(f"Exception when calling Brevo->ContactsApi->update_contact: {e}")
-
-
 def update_contact_email_blacklisted(user_identifier: str, email_blacklisted: bool):
     api_client = get_api_client()
     api_instance = sib_api_v3_sdk.ContactsApi(api_client)


### PR DESCRIPTION
### Quoi ?

Dans le contexte de l'amélioration de la synchronisation de la plateforme et de Brevo (CRM). 
Afin de réduire le nombre de dépendances, je retire la méthode de mise à jour de contacts `update_contact()`

Je modifie les tests pour que ceux-ci testent (et mockent) directement la fonction `update_contact_email_blacklisted` pour éviter une confusion éventuelle.

### Pourquoi ?

N/A 

### Comment ?

N/A

### Captures d'écran (optionnel)

N/A 

### Autre (optionnel)

N/A