### PR TITLE
fix: Affichage du bandeau d'environnement

### DIFF
--- a/lemarche/static/itou_marche/admin.css
+++ b/lemarche/static/itou_marche/admin.css
@@ -1,8 +1,10 @@
-#header-env-notice {
+#header-env-notice p {
+    color: black;
     line-height: 1.5;
     font-size: 1.5rem;
     text-transform: uppercase;
     text-align: center;
+    margin: 0;
 }
 
 /* fix bug for apply multiselect filter */

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -211,6 +211,12 @@ ul.summary-grid-list {
     text-align: center;
 }
 
+#header-env-notice p {
+    line-height: 1.5;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+}
+
 .bg-gray {
     background-color: var(--g300);
 }

--- a/lemarche/templates/includes/_header_env_notice.html
+++ b/lemarche/templates/includes/_header_env_notice.html
@@ -1,5 +1,5 @@
 <div id="header-env-notice" class="alert fs-lg font-weight-bold text-uppercase text-center fr-p-3" style="background-color:{{ BITOUBI_ENV_COLOR }}">
-    <p class="mb-0">
+    <p class="fr-mb-0">
         {{ BITOUBI_ENV }}
     </p>
 </div>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -1,4 +1,7 @@
 {% load i18n static theme_inclusion %}
+{% if BITOUBI_ENV not in "prod" %}
+    {% include "includes/_header_env_notice.html" %}
+{% endif %}
 {% if not user.is_authenticated %}
   {% if page.slug == "accueil-structure" %}
     {% include "includes/_header_for_buyers.html" %}


### PR DESCRIPTION
### Quoi ?

Affichage du bandeau d'environnement au-dessus du header.

### Pourquoi ?

Il n'apparaissait plus depuis la migration DSFR.

### Comment ?

En rajoutant un include de `_header_env_notice.html` dans `_header.html` qui avait été supprimé lors de la migration DSFR.

### Captures d'écran (optionnel)

Avant
![image](https://github.com/user-attachments/assets/bfdf2a83-43cb-4a5f-96e5-971d85a9a4c9)

Après
![header_app](https://github.com/user-attachments/assets/17585bd1-9569-4228-82f8-bb9f489404b6)

### Autre (optionnel)

- J'ai fix la margin-bottom dans le bandeau de l'admin : 

Avant
![image(1)](https://github.com/user-attachments/assets/fd8de11d-bbf3-4033-bf4f-6557d87653bd)

Après
![Capture d’écran du 2025-02-04 17-32-46](https://github.com/user-attachments/assets/ac92d4c4-a185-4e15-a3a9-c4a6adc064ac)
