### PR TITLE
Fix: Le logout doit se faire en POST

### DIFF
--- a/lemarche/templates/layouts/_header_nav_primary_items.html
+++ b/lemarche/templates/layouts/_header_nav_primary_items.html
@@ -29,9 +29,10 @@
 			</a>
 		</li>
 		<li>
-			<a href="{% url 'auth:logout' %}" class="fr-btn fr-icon-logout-box-r-line">
-				Déconnexion
-			</a>
+            <form id="logout-form" method="post" action="{% url 'auth:logout' %}">
+              {% csrf_token %}
+              <button class="fr-btn fr-icon-logout-box-r-line" type="submit">Déconnexion</button>
+            </form>
 		</li>
 	{% else %}
 		{% if page and page.slug == "accueil-structure" %}


### PR DESCRIPTION
### Quoi ?

Le logout ne marche plus de puis la mise à jour vers Django 5

### Pourquoi ?
C'est déprécié de passer en GET pour logout depuis [Django 4](https://docs.djangoproject.com/en/5.0/releases/4.1/#features-deprecated-in-4-1)

### Comment ?

Changement du bouton par un form en POST