### PR TITLE
fix: multiple select widget not displaying correctly

### DIFF
--- a/lemarche/templates/auth/signup.html
+++ b/lemarche/templates/auth/signup.html
@@ -233,6 +233,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }));
 });
 </script>
+<script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
+<script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
 {% endblock extra_js %}
 
 {% block extra_css %}

--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -9,6 +9,7 @@ from lemarche.utils import time
 from lemarche.utils.constants import EMPTY_CHOICE, HOW_MANY_CHOICES
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 from lemarche.utils.password_validation import CnilCompositionPasswordValidator
+from lemarche.utils.widgets import CustomSelectMultiple
 
 
 class SignupForm(UserCreationForm, DsfrBaseForm):
@@ -60,6 +61,7 @@ class SignupForm(UserCreationForm, DsfrBaseForm):
         choices_groupby="group",
         to_field_name="slug",
         required=False,
+        widget=CustomSelectMultiple(),
     )
 
     nb_of_inclusive_provider_last_year = forms.ChoiceField(


### PR DESCRIPTION
### Quoi ?

Sur la page d'inscription, en sélectionnant le type acheteur, le widget de choix de secteur d'activité ne s'affichait pas correctement
 
### Pourquoi ?

Pas de widget défini dans le formulaire




