### PR TITLE
feat: Menu déroulant "Mon espace" dans le header

### DIFF
--- a/lemarche/static/itou_marche/components/_dropdown_menu.scss
+++ b/lemarche/static/itou_marche/components/_dropdown_menu.scss
@@ -20,3 +20,9 @@
 .dropdown-menu__menu--hidden {
     display: none;
 }
+
+@media (min-width: 62em) {
+    .lm-btn-logout {
+        width: 90% !important;
+    }
+}

--- a/lemarche/static/itou_marche/components/_dropdown_menu.scss
+++ b/lemarche/static/itou_marche/components/_dropdown_menu.scss
@@ -17,12 +17,9 @@
     width: max-content;
 }
 
-.dropdown-menu__menu--hidden {
-    display: none;
-}
-
 @media (min-width: 62em) {
     .lm-btn-logout {
         width: 90% !important;
+        padding-left: 0.5rem !important;
     }
 }

--- a/lemarche/static/itou_marche/components/_dropdown_menu.scss
+++ b/lemarche/static/itou_marche/components/_dropdown_menu.scss
@@ -1,0 +1,22 @@
+/* dropdown-menu__menu stays hidden before JS loading */
+[x-cloak] {
+    display: none !important;
+}
+
+.dropdown-menu {
+    position: relative;
+}
+
+@media (min-width: 62em) {
+    .dropdown-menu__menu {
+        right: 0;
+    }
+}
+
+.dropdown-menu__list {
+    width: max-content;
+}
+
+.dropdown-menu__menu--hidden {
+    display: none;
+}

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -1,3 +1,5 @@
+@import 'components/_dropdown_menu';
+
 $yellow-super-badge--bg-color: #fff7e0;
 $yellow-super-badge--borders-color: #fcc63a;
 

--- a/lemarche/static/js/dropdown_menu.js
+++ b/lemarche/static/js/dropdown_menu.js
@@ -1,0 +1,38 @@
+document.addEventListener('alpine:init', function() {
+    Alpine.data('DropdownMenu', () => ({
+        isOpen: false,
+
+        init() {
+            this.checkMenuState(); 
+
+           // Close menu when clicking on menu links
+            this.$nextTick(() => {  // Avoid transitions errors on menu close
+                const menuLinks = document.querySelectorAll('#menu-profile a');
+                menuLinks.forEach(link => {
+                    link.addEventListener('click', () => {
+                        this.closeMenu();
+                    });
+                });
+            });
+        },
+        
+        openMenu() {
+            this.isOpen = true;
+            document.getElementById('menu-profile')?.classList.remove('dropdown-menu__menu--hidden');
+            sessionStorage.setItem('menuOpen', 'true');
+        },
+
+        closeMenu() {
+            this.isOpen = false;
+            document.getElementById('menu-profile')?.classList.add('dropdown-menu__menu--hidden');
+            sessionStorage.setItem('menuOpen', 'false');
+        },
+
+        checkMenuState() {
+            this.isOpen = sessionStorage.getItem('menuOpen') === 'true';
+            if (!this.isOpen) {
+                document.getElementById('menu-profile')?.classList.add('dropdown-menu__menu--hidden');
+            }
+        }
+    }));
+});

--- a/lemarche/static/js/dropdown_menu.js
+++ b/lemarche/static/js/dropdown_menu.js
@@ -3,7 +3,6 @@ document.addEventListener('alpine:init', function() {
         isOpen: false,
 
         init() {
-            this.checkMenuState(); 
 
            // Close menu when clicking on menu links
             this.$nextTick(() => {  // Avoid transitions errors on menu close
@@ -18,21 +17,10 @@ document.addEventListener('alpine:init', function() {
         
         openMenu() {
             this.isOpen = true;
-            document.getElementById('menu-profile')?.classList.remove('dropdown-menu__menu--hidden');
-            sessionStorage.setItem('menuOpen', 'true');
         },
 
         closeMenu() {
             this.isOpen = false;
-            document.getElementById('menu-profile')?.classList.add('dropdown-menu__menu--hidden');
-            sessionStorage.setItem('menuOpen', 'false');
         },
-
-        checkMenuState() {
-            this.isOpen = sessionStorage.getItem('menuOpen') === 'true';
-            if (!this.isOpen) {
-                document.getElementById('menu-profile')?.classList.add('dropdown-menu__menu--hidden');
-            }
-        }
     }));
 });

--- a/lemarche/templates/dashboard/profile_edit.html
+++ b/lemarche/templates/dashboard/profile_edit.html
@@ -85,6 +85,5 @@
 </div>
 {% endblock content %}
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
 <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/templates/favorites/dashboard_favorite_list_detail.html
+++ b/lemarche/templates/favorites/dashboard_favorite_list_detail.html
@@ -93,6 +93,5 @@
 {% endblock modals %}
 
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
 <script type="text/javascript" src="{% static 'js/favorite_item.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/templates/includes/_dropdown_menu.html
+++ b/lemarche/templates/includes/_dropdown_menu.html
@@ -25,9 +25,16 @@
                 </li>
             {% endif %}
             <li>
-                <a id="header-logout" class="fr-nav__link fr-icon-logout-box-r-line fr-btn--icon-left" href="{% url 'auth:logout' %}" target="_self">
-                    Déconnexion
-                </a>
+                <form id="logout-form" method="post" action="{% url 'auth:logout' %}">
+                    {% csrf_token %}
+                    <button class="fr-btn fr-icon-logout-box-r-line fr-btn--icon-left fr-btn--tertiary 
+                                   fr-py-md-0 fr-pr-md-0
+                                   fr-mr-md-1w fr-my-md-2v
+                                   lm-btn-logout"
+                            type="submit">
+                            Déconnexion
+                    </button>   
+                </form>
             </li>
         </ul>
     </div>

--- a/lemarche/templates/includes/_dropdown_menu.html
+++ b/lemarche/templates/includes/_dropdown_menu.html
@@ -33,7 +33,7 @@
                                    fr-mr-md-1w fr-my-md-2v
                                    lm-btn-logout"
                             type="submit">
-                            Déconnexion
+                            <span class="fr-ml-1v">Déconnexion</span>
                     </button>   
                 </form>
             </li>

--- a/lemarche/templates/includes/_dropdown_menu.html
+++ b/lemarche/templates/includes/_dropdown_menu.html
@@ -1,5 +1,5 @@
-<div x-data="DropdownMenu" x-init="checkMenuState()" class="dropdown-menu">
-    <button class="fr-btn fr-btn--tertiary fr-icon-account-line fr-btn--icon-left fr-m-md-0" aria-controls="menu-profile" @click="openMenu()">Mon espace</button>
+<div x-data="DropdownMenu" class="dropdown-menu">
+    <button id="my-account" class="fr-btn fr-btn--tertiary fr-icon-account-line fr-btn--icon-left fr-m-md-0" aria-controls="menu-profile" @click="openMenu()">Mon espace</button>
     <div id="menu-profile" x-show="isOpen" @click.away="closeMenu()" x-cloak class="fr-menu dropdown-menu__menu">
         <ul class="fr-menu__list dropdown-menu__list">
             <li>
@@ -27,8 +27,9 @@
             <li>
                 <form id="logout-form" method="post" action="{% url 'auth:logout' %}">
                     {% csrf_token %}
-                    <button class="fr-btn fr-icon-logout-box-r-line fr-btn--icon-left fr-btn--tertiary 
+                    <button class="fr-btn fr-icon-logout-box-r-line fr-btn--tertiary
                                    fr-py-md-0 fr-pr-md-0
+                                   fr-ml-4v fr-ml-md-0
                                    fr-mr-md-1w fr-my-md-2v
                                    lm-btn-logout"
                             type="submit">

--- a/lemarche/templates/includes/_dropdown_menu.html
+++ b/lemarche/templates/includes/_dropdown_menu.html
@@ -1,0 +1,34 @@
+<div x-data="DropdownMenu" x-init="checkMenuState()" class="dropdown-menu">
+    <button class="fr-btn fr-btn--tertiary fr-icon-account-line fr-btn--icon-left fr-m-md-0" aria-controls="menu-profile" @click="openMenu()">Mon espace</button>
+    <div id="menu-profile" x-show="isOpen" @click.away="closeMenu()" x-cloak class="fr-menu dropdown-menu__menu">
+        <ul class="fr-menu__list dropdown-menu__list">
+            <li>
+                <a id="header-dashboard" class="fr-nav__link fr-icon-table-line fr-btn--icon-left" href="{% url 'dashboard:home' %}" target="_self">
+                    Tableau de bord
+                </a>
+            </li>
+            <li>
+                <a id="header-profile" class="fr-nav__link fr-icon-user-line fr-btn--icon-left" href="{% url 'dashboard:profile_edit' %}" target="_self">
+                    Mon profil
+                </a>
+            </li>
+            <li>
+                <a id="header-favorites" class="fr-nav__link fr-icon-star-line fr-btn--icon-left" href="{% url 'dashboard_favorites:list' %}" target="_self">
+                    Favoris <span class="fr-badge fr-badge--sm fr-ml-2v">{{ user.favorite_list_count }}</span>
+                </a>
+            </li>
+            {% if user.kind == user.KIND_SIAE or user.kind == user.KIND_BUYER %}
+                <li>
+                    <a id="header-notifications" class="fr-nav__link fr-icon-mail-line fr-btn--icon-left" href="{% url 'dashboard:notifications_edit' %}" target="_self">
+                        Notifications
+                    </a>
+                </li>
+            {% endif %}
+            <li>
+                <a id="header-logout" class="fr-nav__link fr-icon-logout-box-r-line fr-btn--icon-left" href="{% url 'auth:logout' %}" target="_self">
+                    Déconnexion
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/lemarche/templates/layouts/_header_nav_primary_items.html
+++ b/lemarche/templates/layouts/_header_nav_primary_items.html
@@ -1,65 +1,46 @@
 <ul class="fr-btns-group">
 	{% if user.is_authenticated %}
 		{% if user.kind == user.KIND_SIAE %}
-			<li>
-				<a href="{% url 'tenders:list' %}" class="fr-btn">
-					Demandes reçues{% if tender_siae_unread_count %}&nbsp;<span class="fr-badge fr-badge--sm fr-badge--green-emeraude">{{ tender_siae_unread_count }}</span>{% endif %}
-				</a>
-			</li>
+		<li>
+			<a class="fr-btn" href="{% url 'tenders:list' %}" target="_self">
+				Demandes reçues{% if tender_siae_unread_count %}&nbsp;<span class="fr-badge fr-badge--sm fr-ml-2v fr-badge--green-emeraude">{{ tender_siae_unread_count }}</span>{% endif %}
+			</a>
+		</li>
 		{% else %}
 			<li>
-				<a href="{% url 'tenders:create' %}" id="header-demande" class="fr-btn fr-icon-add-circle-line">
+				<a class="fr-btn fr-icon-add-circle-line fr-btn--icon-left" href="{% url 'tenders:create' %}" id="header-demande" target="_self">
 					<span>Publier un besoin d'achat</span>
 				</a>
 			</li>
 		{% endif %}
 		<li>
-			<a href="{% url 'dashboard:home' %}" class="fr-btn fr-icon-dashboard-3-line">
-				Tableau de bord
-			</a>
-		</li>
-		<li>
-			<a href="{% url 'dashboard_favorites:list' %}" id="header-favorites" class="fr-btn fr-icon-star-line">
-				Favoris <span class="fr-badge fr-badge--sm fr-ml-2v">{{ user.favorite_list_count }}</span>
-			</a>
-		</li>
-		<li>
-			<a href="{% url 'dashboard:profile_edit' %}" class="fr-btn fr-icon-user-line">
-				Mon profil
-			</a>
-		</li>
-		<li>
-            <form id="logout-form" method="post" action="{% url 'auth:logout' %}">
-              {% csrf_token %}
-              <button class="fr-btn fr-icon-logout-box-r-line" type="submit">Déconnexion</button>
-            </form>
+			{% include "includes/_dropdown_menu.html" %}
 		</li>
 	{% else %}
 		{% if page and page.slug == "accueil-structure" %}
-			<li>
-				<a href="{% url 'auth:signup' %}" id="header-signup-siae" class="fr-btn fr-icon-account-line">
+			<li class="fr-nav__item">
+				<a class="fr-nav__link" href="{% url 'auth:signup' %}" id="header-demande" target="_self">
 					<span>Référencer ma structure</span>
 				</a>
 			</li>
-			<li>
-				<a href="{% url 'auth:login' %}" id="h_login" class="fr-btn fr-icon-lock-line">
+			<li class="fr-nav__item">
+				<a class="fr-nav__link" href="{% url 'auth:login' %}" id="h_login" target="_self">
 					<span>Se connecter</span>
 				</a>
 			</li>
 		{% else %}
-			<li>
-				<a href="{% url 'tenders:create' %}" id="header-demande"
-					class="fr-btn fr-icon-add-circle-line {% if is_mobile %}mh-auto fr-p-0{% endif %}">
-					Publier un besoin d'achat
+			<li class="fr-nav__item">
+				<a class="fr-nav__link fr-icon-add-circle-line fr-btn--icon-left" href="{% url 'tenders:create' %}" id="header-demande" target="_self">
+					<span>Publier un besoin d'achat</span>
 				</a>
 			</li>
-			<li>
-				<a href="{% url 'auth:signup' %}" id="h_signup" class="fr-btn fr-icon-account-line">
+			<li class="fr-nav__item">
+				<a class="fr-nav__link" href="{% url 'auth:signup' %}" id="header-demande" target="_self">
 					<span>S'inscrire</span>
 				</a>
 			</li>
-			<li>
-				<a href="{% url 'auth:login' %}" id="h_login" class="fr-btn fr-icon-lock-line">
+			<li class="fr-nav__item">
+				<a class="fr-nav__link" href="{% url 'auth:login' %}" id="h_login" target="_self">
 					<span>Se connecter</span>
 				</a>
 			</li>

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -65,6 +65,7 @@
     {% block modals %}
     {% endblock modals %}
     {% dsfr_js nonce=request.csp_nonce %}
+    <script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.4.1/dist/jquery.min.js"
             integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
             crossorigin="anonymous"></script>
@@ -76,6 +77,7 @@
     <script type="text/javascript"
             src="{% static 'vendor/htmx-1.9.12/htmx.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/utils.js'%}"></script>
+    <script type="text/javascript" src="{% static 'js/dropdown_menu.js' %}"></script>
     {% if BITOUBI_ENV not in "dev" %}
       {% include "includes/_tracker_tarteaucitron.html" %}
       {% include "includes/_tracker_itou.html" %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -113,7 +113,6 @@
         <script type="text/javascript" src="{% static 'js/mtcaptcha.js' %}"></script>
     {% endif %}
     {% if user.is_authenticated %}
-        <script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
         <script type="text/javascript" src="{% static 'js/favorite_item.js' %}"></script>
     {% endif %}
 {% endblock extra_js %}

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -72,7 +72,6 @@
 {% endblock content_form %}
 
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
 <script type="text/javascript">window.CKEDITOR_BASEPATH = '/static/ckeditor/ckeditor/';</script>
 <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
 <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -139,7 +139,6 @@
     {% include "includes/_super_siae_arguments_badge.html" %}
 {% endblock content %}
 {% block extra_js %}
-    <script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
     <script type="text/javascript" src="{% static 'js/perimeter_autocomplete_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
     

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -137,8 +137,18 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(User.objects.count(), 1)
         # user should be automatically logged in
         header = self.driver.find_element(By.CSS_SELECTOR, "header#header")
-        self.assertTrue("Tableau de bord" in header.text)
         self.assertTrue("Connexion" not in header.text)
+
+        menu_button = self.driver.find_element(By.ID, "my-account")
+        menu_button.click()
+
+        dashboard_link = self.driver.find_element(By.LINK_TEXT, "Tableau de bord")
+        self.assertIsNotNone(dashboard_link)
+
+        if self.SIAE or self.BUYER:
+            notifications_link = self.driver.find_element(By.LINK_TEXT, "Notifications")
+            self.assertIsNotNone(notifications_link)
+
         # should redirect to redirect_url
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{redirect_url}")
         # message should be displayed

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -124,7 +124,7 @@ class SignupFormTest(StaticLiveServerTestCase):
             submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
             scroll_to_and_click_element(self.driver, submit_element)
 
-    def _assert_signup_success(self, redirect_url: str) -> list:
+    def _assert_signup_success(self, redirect_url: str, user_kind=None) -> list:
         """Assert the success signup and returns the sucess messages
 
         Args:
@@ -145,9 +145,12 @@ class SignupFormTest(StaticLiveServerTestCase):
         dashboard_link = self.driver.find_element(By.LINK_TEXT, "Tableau de bord")
         self.assertIsNotNone(dashboard_link)
 
-        if self.SIAE or self.BUYER:
-            notifications_link = self.driver.find_element(By.LINK_TEXT, "Notifications")
-            self.assertIsNotNone(notifications_link)
+        notifications_link = self.driver.find_elements(By.LINK_TEXT, "Notifications")
+        if user_kind in [User.KIND_SIAE, User.KIND_BUYER]:
+            self.assertTrue(len(notifications_link) > 0)
+        else:
+            # find_elements returns an empty list if no element found and doesn't raise an error
+            self.assertFalse(notifications_link)
 
         # should redirect to redirect_url
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{redirect_url}")
@@ -160,7 +163,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self._complete_form(user_profile=self.SIAE, with_submit=True)
 
         # should redirect SIAE to dashboard
-        messages = self._assert_signup_success(redirect_url=reverse("dashboard:home"))
+        messages = self._assert_signup_success(redirect_url=reverse("dashboard:home"), user_kind=User.KIND_SIAE)
 
         self.assertTrue("Vous pouvez maintenant ajouter votre structure" in messages.text)
 
@@ -195,7 +198,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         scroll_to_and_click_element(self.driver, submit_element)
 
         # should redirect BUYER to search
-        self._assert_signup_success(redirect_url=reverse("siae:search_results"))
+        self._assert_signup_success(redirect_url=reverse("siae:search_results"), user_kind=User.KIND_BUYER)
 
     def test_buyer_submits_signup_form_success_extra_data(self):
         self._complete_form(user_profile=self.BUYER, with_submit=False)
@@ -277,7 +280,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         submit_element = self.driver.find_element(By.CSS_SELECTOR, "form button[type='submit']")
         scroll_to_and_click_element(self.driver, submit_element)
 
-        self._assert_signup_success(redirect_url=next_url)
+        self._assert_signup_success(redirect_url=next_url, user_kind=User.KIND_SIAE)
 
     @classmethod
     def tearDownClass(cls):

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -1,4 +1,3 @@
-import random
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -149,30 +148,3 @@ class DisabledEmailEditViewTest(TestCase):
         self.assertContains(response, "Vos préférences de notifications ont été mises à jour.")
         self.user.refresh_from_db()
         self.assertEqual(self.user.disabled_emails.count(), 0)
-
-
-class NotificationLinkDisplayTest(TestCase):
-    """
-    Test that the notifications link is displayed only for buyers and siaes
-    """
-
-    def setUp(self):
-        user_kinds = [User.KIND_INDIVIDUAL, User.KIND_PARTNER, User.KIND_ADMIN]
-        self.user = UserFactory(kind=random.choice(user_kinds))
-        self.user_buyer = UserFactory(kind=User.KIND_BUYER)
-        self.user_siae = UserFactory(kind=User.KIND_SIAE)
-        self.url = reverse("dashboard:home")
-
-    def test_no_notifications_link_for_non_buyer_or_siae(self):
-        self.client.force_login(self.user)
-        response = self.client.get(self.url)
-        self.assertNotContains(response, "Notifications")
-
-    def test_notifications_link_for_buyer_and_siae(self):
-        self.client.force_login(self.user_buyer)
-        response = self.client.get(self.url)
-        self.assertContains(response, "Notifications")
-
-        self.client.force_login(self.user_siae)
-        response = self.client.get(self.url)
-        self.assertContains(response, "Notifications")

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -418,7 +418,8 @@ class TenderListViewTest(TestCase):
         self.assertEqual(len(response.context["tenders"]), 2)
         # The badge in header, only one because one is outdated
         self.assertContains(
-            response, 'Demandes reçues&nbsp;<span class="fr-badge fr-badge--sm fr-badge--green-emeraude">1</span>'
+            response,
+            'Demandes reçues&nbsp;<span class="fr-badge fr-badge--sm fr-ml-2v fr-badge--green-emeraude">1</span>',
         )
         # The badge in tender list
         self.assertContains(response, '<p class="fr-badge fr-badge--sm fr-badge--green-emeraude">Nouveau</p>', 1)


### PR DESCRIPTION
### Quoi ?

Ajout d'un menu déroulant "Mon espace" et intégration du lien "Notifications" dans ce menu pour les acheteurs et les structures.

### Pourquoi ?

Pour organiser le header et être en accord avec la doc dsfr qui recommande 3 liens maximum dans le header.

### Comment ?

3 fichiers principaux pour gérer le dropdown : 
- _dropdown_menu.html
- _dropdown_menu.scss
-  dropdown_menu.js

Le JS a été simplifié.

### Captures d'écran (optionnel)

#### Version desktop
Acheteurs
![menu_buyer](https://github.com/user-attachments/assets/5df2de88-2452-4810-98f3-3091b8f1c48c)

Structures (l'icône du bouton Déconnexion est maintenant alignée avec les autres)
![menu_siae](https://github.com/user-attachments/assets/916be5da-fc2c-462c-9a08-7f6fa9ff6e0c)

Autres utilisateurs
![menu](https://github.com/user-attachments/assets/a9530e2c-16e1-4ce4-a3f6-e9c92de8e70d)

#### Version mobile
![menu_siae_mobile](https://github.com/user-attachments/assets/f30effc7-1229-48a8-92d9-e26778058c52)

### Autre

- J'ai supprimé tous les imports à AlpineJS pour en garder un dans base.html.
