### PR TITLE
chore: Ajout de 'token-duplicate-cal' dans la liste d'erreurs à ignorer

### DIFF
--- a/lemarche/utils/mtcaptcha.py
+++ b/lemarche/utils/mtcaptcha.py
@@ -27,7 +27,7 @@ def check_captcha_token(form_data):
             else:
                 # Log event only if the user is not responsible, see https://www.mtcaptcha.com/dev-guide
                 fail_codes = response.json()["fail_codes"]
-                if not fail_codes or fail_codes[0] not in ["token-expired", "invalid-token"]:
+                if not fail_codes or fail_codes[0] not in ["token-expired", "invalid-token", "token-duplicate-cal"]:
                     logger.exception("Token failed : %s", fail_codes)
         else:
             logger.exception("Bad status code when calling Mtcaptcha API-> check-token: %s", response)


### PR DESCRIPTION
### Quoi ?

Ajout de 'token-duplicate-cal' dans la liste d'erreurs à ignorer

### Pourquoi ?

Pour éviter cette erreur sur Sentry.