### PR TITLE
fix: Ajout d'un label pour le type d'utilisateur

### DIFF
--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -22,7 +22,9 @@ class SignupForm(UserCreationForm, DsfrBaseForm):
     FORM_BUYER_KIND_DETAIL_CHOICES = EMPTY_CHOICE + user_constants.BUYER_KIND_DETAIL_CHOICES
     FORM_PARTNER_KIND_CHOICES = EMPTY_CHOICE + user_constants.PARTNER_KIND_CHOICES
 
-    kind = forms.ChoiceField(label="", widget=forms.RadioSelect, choices=KIND_CHOICES_FORM, required=True)
+    kind = forms.ChoiceField(
+        label="Indiquez votre profil", widget=forms.RadioSelect, choices=KIND_CHOICES_FORM, required=True
+    )
     first_name = forms.CharField(label="Votre prénom", required=True)
     last_name = forms.CharField(label="Votre nom", required=True)
     phone = forms.CharField(


### PR DESCRIPTION
### Quoi ?

Ajout d'un label pour le champ type d'utilisateur dans le formulaire d'inscription.

### Pourquoi ?

Un astérisque se baladait tout seul dans le formulaire.

### Captures d'écran (optionnel)

Avant
![old](https://github.com/user-attachments/assets/d0985728-e178-4c77-aeef-113adf0bfee4)

Après
![new](https://github.com/user-attachments/assets/fc624a70-43f8-4e14-8c7d-a024d610d22a)
