### PR TITLE
fix: bug sur les secteurs dans l'API des SIAE

### DIFF
--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -35,7 +35,7 @@ class SiaeLabelOldSimpleSerializer(serializers.ModelSerializer):
 
 class SiaeDetailSerializer(serializers.ModelSerializer):
     kind_parent = serializers.ReadOnlyField()
-    sectors = SectorSimpleSerializer(many=True, source="sectors_annotated")
+    sectors = SectorSimpleSerializer(many=True, source="get_sectors")
     presta_types = serializers.MultipleChoiceField(choices=constants.PRESTA_CHOICES, source="presta_types_annotated")
     networks = NetworkSimpleSerializer(many=True)
     offers = SiaeOfferSimpleSerializer(many=True)

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -23,11 +23,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
 
     def get_queryset(self):
         """Annotate sectors to be directly available in the serializer"""
-        return (
-            super()
-            .get_queryset()
-            .annotate(sectors_annotated=F("activities__sectors"), presta_types_annotated=F("activities__presta_type"))
-        )
+        return super().get_queryset().annotate(presta_types_annotated=F("activities__presta_type"))
 
     @extend_schema(
         summary="Lister toutes les structures",

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -34,6 +34,7 @@ from phonenumber_field.modelfields import PhoneNumberField
 from simple_history.models import HistoricalRecords
 
 from lemarche.perimeters.models import Perimeter
+from lemarche.sectors.models import Sector
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.tasks import set_siae_coords
 from lemarche.stats.models import Tracker
@@ -1132,6 +1133,9 @@ class Siae(models.Model):
 
     def get_admin_url(self):
         return get_object_admin_url(self)
+
+    def get_sectors(self):
+        return Sector.objects.filter(siae_activities__siae=self)
 
     def set_super_badge(self):
         update_fields_list = ["super_badge"]


### PR DESCRIPTION
### Quoi ?

Erreur 500 dans l'api SIAE

### Pourquoi ?

L'annotation n'était pas correcte et ne revoyait pas de liste d'instance

### Comment ?

Correction de l'attribut `source` dans le champs drf