### PR TITLE
fix: doubles imports alpineJs

### DIFF
--- a/lemarche/templates/auth/signup.html
+++ b/lemarche/templates/auth/signup.html
@@ -233,7 +233,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }));
 });
 </script>
-<script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
 <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
 {% endblock extra_js %}
 

--- a/lemarche/templates/cms/home_page.html
+++ b/lemarche/templates/cms/home_page.html
@@ -72,10 +72,6 @@
 {% endblock %}
 {% block extra_js %}
     <script type="text/javascript" src="{% static 'js/multicarousel_items.js' %}"></script>
-    <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
-    <script>
         document.addEventListener('alpine:init', function() {
             {% comment %} improve in the futur to be more generic {% endcomment %}
             Alpine.data('ToggleComponent', () => (

--- a/lemarche/templates/dashboard/siae_edit_activities.html
+++ b/lemarche/templates/dashboard/siae_edit_activities.html
@@ -24,8 +24,5 @@
 {% endblock modals %}
 {% block extra_js %}
     <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
-    <script type="text/javascript"
             src="{% static 'js/siae_activity_delete.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/templates/dashboard/siae_users.html
+++ b/lemarche/templates/dashboard/siae_users.html
@@ -143,8 +143,5 @@
     {% include "siaes/_siae_user_delete_modal.html" %}
 {% endblock modals %}
 {% block extra_js %}
-    <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
     <script type="text/javascript" src="{% static 'js/siae_user_modals.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/templates/pages/impact-calculator.html
+++ b/lemarche/templates/pages/impact-calculator.html
@@ -125,9 +125,6 @@
     {% cms_advert %}
 {% endblock content %}
 {% block extra_js %}
-    <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
     <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
     <script type="text/javascript"
             src="{% static 'js/perimeter_autocomplete_field.js' %}"></script>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -226,9 +226,6 @@
 {% endblock modals %}
 {% block extra_js %}
     <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
-    <script type="text/javascript"
             src="{% static 'js/perimeter_autocomplete_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/search_form.js' %}"></script>

--- a/lemarche/templates/tenders/create_step_detail.html
+++ b/lemarche/templates/tenders/create_step_detail.html
@@ -68,9 +68,6 @@
     </div>
 {% endblock content_form %}
 {% block extra_js %}
-    <script type="text/javascript"
-            src="{% static 'vendor/alpinejs@3.11.1.min.js'%}"
-            defer></script>
     <script type="text/javascript" defer>
     function TenderQuestionForm() {
         return {


### PR DESCRIPTION
### Quoi ?

Bug d'interaction avec les questions des acheteurs et les widgets de selections, comportement erratiques

### Pourquoi ?

AlpineJs était importé en double dans certaines pages depuis le merge de cette PR https://github.com/gip-inclusion/le-marche/pull/1662/files#diff-0d77d56646096fea4401f180e76f3bf09831f56706fc9d3e6b80a722915d95f7R68

### Comment ?

Suppression des imports spécifiques au pages maintenant que l'import est global