### PR TITLE
fix: duplication des siae dans l'API

### DIFF
--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -34,7 +34,7 @@ class SiaeLabelOldSimpleSerializer(serializers.ModelSerializer):
 
 class SiaeDetailSerializer(serializers.ModelSerializer):
     kind_parent = serializers.ReadOnlyField()
-    sectors = SectorSimpleSerializer(many=True, source="get_sectors")
+    sectors = serializers.SerializerMethodField()
     presta_types = serializers.SerializerMethodField()
     networks = NetworkSimpleSerializer(many=True)
     offers = SiaeOfferSimpleSerializer(many=True)
@@ -77,3 +77,8 @@ class SiaeDetailSerializer(serializers.ModelSerializer):
     def get_presta_types(self, obj) -> list:
         """Return a list of distinct presta types found in the activities of an Siae"""
         return list(set(presta for activity in obj.activities.all() for presta in activity.presta_type))
+
+    def get_sectors(self, obj) -> list:
+        """Return unique list of serialized sectors"""
+        sectors = set(sector for activity in obj.activities.all() for sector in activity.sectors.all())
+        return [SectorSimpleSerializer(sector).data for sector in sectors]

--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 
 from lemarche.api.networks.serializers import NetworkSimpleSerializer
 from lemarche.api.sectors.serializers import SectorSimpleSerializer
-from lemarche.siaes import constants
 from lemarche.siaes.models import Siae, SiaeClientReference, SiaeLabelOld, SiaeOffer
 
 
@@ -36,7 +35,7 @@ class SiaeLabelOldSimpleSerializer(serializers.ModelSerializer):
 class SiaeDetailSerializer(serializers.ModelSerializer):
     kind_parent = serializers.ReadOnlyField()
     sectors = SectorSimpleSerializer(many=True, source="get_sectors")
-    presta_types = serializers.MultipleChoiceField(choices=constants.PRESTA_CHOICES, source="presta_types_annotated")
+    presta_types = serializers.SerializerMethodField()
     networks = NetworkSimpleSerializer(many=True)
     offers = SiaeOfferSimpleSerializer(many=True)
     client_references = SiaeClientReferenceSimpleSerializer(many=True)
@@ -74,3 +73,7 @@ class SiaeDetailSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
+
+    def get_presta_types(self, obj) -> list:
+        """Return a list of distinct presta types found in the activities of an Siae"""
+        return list(set(presta for activity in obj.activities.all() for presta in activity.presta_type))

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -204,9 +204,13 @@ class SiaeDetailApiTest(TestCase):
         self.assertQuerySetEqual(
             response.data["presta_types"], [siae_constants.PRESTA_BUILD, siae_constants.PRESTA_DISP], ordered=False
         )
-        self.assertEqual(
+        self.assertIn(
+            {"name": "sector1", "slug": "sector1"},
             response.data["sectors"],
-            [{"name": "sector1", "slug": "sector1"}, {"name": "sector2", "slug": "sector2"}],
+        )
+        self.assertIn(
+            {"name": "sector2", "slug": "sector2"},
+            response.data["sectors"],
         )
 
 

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -160,8 +160,14 @@ class SiaeDetailApiTest(TestCase):
         self.siae = SiaeFactory()
         SiaeActivityFactory(siae=self.siae, presta_type=[siae_constants.PRESTA_BUILD])
         # Duplicated to see if there is no duplicates in presta_types serialized value
-        SiaeActivityFactory(siae=self.siae, presta_type=[siae_constants.PRESTA_BUILD, siae_constants.PRESTA_DISP])
-        SiaeActivityFactory(siae=self.siae, presta_type=[siae_constants.PRESTA_DISP])
+        sector_1 = SectorFactory()
+        sector_2 = SectorFactory()
+        SiaeActivityFactory(
+            siae=self.siae,
+            sectors=[sector_1, sector_2],
+            presta_type=[siae_constants.PRESTA_BUILD, siae_constants.PRESTA_DISP],
+        )
+        SiaeActivityFactory(siae=self.siae, sectors=[sector_1], presta_type=[siae_constants.PRESTA_DISP])
 
     def test_should_return_4O4_if_siae_excluded(self):
         siae_opcs = SiaeFactory(kind="OPCS")
@@ -192,6 +198,7 @@ class SiaeDetailApiTest(TestCase):
         self.assertQuerySetEqual(
             response.data["presta_types"], [siae_constants.PRESTA_BUILD, siae_constants.PRESTA_DISP], ordered=False
         )
+        self.assertEqual(len(response.data["sectors"]), 2)
 
 
 class SiaeRetrieveBySlugApiTest(TestCase):

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -158,10 +158,17 @@ class SiaeDetailApiTest(TestCase):
 
     def setUp(self):
         self.siae = SiaeFactory()
+        siae2 = SiaeFactory()
         SiaeActivityFactory(siae=self.siae, presta_type=[siae_constants.PRESTA_BUILD])
         # Duplicated to see if there is no duplicates in presta_types serialized value
-        sector_1 = SectorFactory()
-        sector_2 = SectorFactory()
+        sector_1 = SectorFactory(name="sector1")
+        sector_2 = SectorFactory(name="sector2")
+        sector_3 = SectorFactory(name="sector3")
+        SiaeActivityFactory(
+            siae=siae2,
+            sectors=[sector_3],
+        )
+
         SiaeActivityFactory(
             siae=self.siae,
             sectors=[sector_1, sector_2],
@@ -190,7 +197,6 @@ class SiaeDetailApiTest(TestCase):
         self.assertTrue("slug" in response.data)
         self.assertTrue("kind" in response.data)
         self.assertTrue("kind_parent" in response.data)
-        self.assertTrue("sectors" in response.data)
         self.assertTrue("networks" in response.data)
         self.assertTrue("offers" in response.data)
         self.assertTrue("client_references" in response.data)
@@ -198,7 +204,10 @@ class SiaeDetailApiTest(TestCase):
         self.assertQuerySetEqual(
             response.data["presta_types"], [siae_constants.PRESTA_BUILD, siae_constants.PRESTA_DISP], ordered=False
         )
-        self.assertEqual(len(response.data["sectors"]), 2)
+        self.assertEqual(
+            response.data["sectors"],
+            [{"name": "sector1", "slug": "sector1"}, {"name": "sector2", "slug": "sector2"}],
+        )
 
 
 class SiaeRetrieveBySlugApiTest(TestCase):

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -24,7 +24,9 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         return (
             super()
             .get_queryset()
-            .prefetch_related("activities", "networks", "offers", "client_references", "labels_old")
+            .prefetch_related(
+                "activities", "activities__sectors", "networks", "offers", "client_references", "labels_old"
+            )
         )
 
     @extend_schema(

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -21,7 +21,11 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     filterset_class = SiaeFilter
 
     def get_queryset(self):
-        return super().get_queryset().prefetch_related("activities")
+        return (
+            super()
+            .get_queryset()
+            .prefetch_related("activities", "networks", "offers", "client_references", "labels_old")
+        )
 
     @extend_schema(
         summary="Lister toutes les structures",

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -1,4 +1,3 @@
-from django.db.models import F
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
@@ -22,8 +21,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     filterset_class = SiaeFilter
 
     def get_queryset(self):
-        """Annotate sectors to be directly available in the serializer"""
-        return super().get_queryset().annotate(presta_types_annotated=F("activities__presta_type"))
+        return super().get_queryset().prefetch_related("activities")
 
     @extend_schema(
         summary="Lister toutes les structures",

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1135,7 +1135,8 @@ class Siae(models.Model):
         return get_object_admin_url(self)
 
     def get_sectors(self):
-        return Sector.objects.filter(siae_activities__siae=self)
+        """Used in the api to get all distinct related sectors"""
+        return Sector.objects.filter(siae_activities__siae=self).distinct()
 
     def set_super_badge(self):
         update_fields_list = ["super_badge"]

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -34,7 +34,6 @@ from phonenumber_field.modelfields import PhoneNumberField
 from simple_history.models import HistoricalRecords
 
 from lemarche.perimeters.models import Perimeter
-from lemarche.sectors.models import Sector
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.tasks import set_siae_coords
 from lemarche.stats.models import Tracker
@@ -1133,10 +1132,6 @@ class Siae(models.Model):
 
     def get_admin_url(self):
         return get_object_admin_url(self)
-
-    def get_sectors(self):
-        """Used in the api to get all distinct related sectors"""
-        return Sector.objects.filter(siae_activities__siae=self).distinct()
 
     def set_super_badge(self):
         update_fields_list = ["super_badge"]


### PR DESCRIPTION
### Quoi ?
Les siaes étaient dupliqués dans la liste de l'API, et leur fiche de détail n'était plus accessible

### Pourquoi ?
 Une mauvaise annotation en était la cause 
