### PR TITLE
fix: Prise en charge des ids malformés dans l'API des siae

### DIFF
--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -187,9 +187,14 @@ class SiaeDetailApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
 
+    def test_handle_wrong_type_id(self):
+        url = reverse("api:siae-detail", args=["very_wrong"])
+        response = self.authenticated_client.get(url)
+        self.assertEqual(response.status_code, 404)
+
     def test_should_return_detailed_siae_object_to_authenticated_users(self):
         url = reverse("api:siae-detail", args=[self.siae.id])
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.authenticated_client.get(url)
         self.assertTrue("id" in response.data)
         self.assertTrue("name" in response.data)

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -62,8 +62,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         Note : le slug est un champ unique.<br /><br />
         <i>Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.</i>
         """
-        queryset = self.get_queryset().prefetch_many_to_many().prefetch_many_to_one()
-        queryset_or_404 = get_object_or_404(queryset, slug=slug)
+        queryset_or_404 = get_object_or_404(self.get_queryset(), slug=slug)
         return self._retrieve_return(request, queryset_or_404, format)
 
     @extend_schema(
@@ -78,7 +77,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         """
         if len(siren) != 9:
             return HttpResponseBadRequest("siren must be 9 caracters long")
-        queryset = self.get_queryset().prefetch_many_to_many().prefetch_many_to_one().filter(siret__startswith=siren)
+        queryset = self.get_queryset().filter(siret__startswith=siren)
         return self._list_return(request, queryset, format)
 
     @extend_schema(
@@ -93,7 +92,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         """
         if len(siret) != 14:
             return HttpResponseBadRequest("siret must be 14 caracters long")
-        queryset = self.get_queryset().prefetch_many_to_many().prefetch_many_to_one().filter(siret=siret)
+        queryset = self.get_queryset().filter(siret=siret)
         return self._list_return(request, queryset, format)
 
     def _retrieve_return(self, request, queryset, format):

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -50,9 +50,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         """
         <i>Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.</i>
         """
-        queryset = self.get_queryset().prefetch_many_to_many().prefetch_many_to_one()
-        queryset_or_404 = get_object_or_404(queryset, pk=pk)
-        return self._retrieve_return(request, queryset_or_404, format)
+        return super().retrieve(request, pk, format)
 
     @extend_schema(
         summary="Détail d'une structure (par son slug)",


### PR DESCRIPTION
### Quoi ?

Lorsque du texte était passé à l'API au lieu d'un id, cela générait une erreur 500.

### Pourquoi ?

Arguments pas parsés correctement

### Comment ?

Retour aux méthodes de base de l'API qui prenait en charge les arguments, les optimisations étant déjà effectuées au niveau du queryset.
