### PR TITLE
feat: Interdiction des mails personnels pour l'inscription des acheteurs

### DIFF
--- a/lemarche/users/validators.py
+++ b/lemarche/users/validators.py
@@ -1,0 +1,31 @@
+from django.core.exceptions import ValidationError
+
+
+def professional_email_validator(value):
+    excluded_domains = [
+        "gmail.com",
+        "hotmail.com",
+        "hotmail.fr",
+        "yahoo.com",
+        "yahoo.fr",
+        "laposte.fr",
+        "laposte.net",
+        "live.com",
+        "live.fr",
+        "outlook.com",
+        "outlook.fr",
+        "sfr.fr",
+        "free.fr",
+        "orange.fr",
+        "wanadoo.fr",
+        "bbox.fr",
+        "icloud.com",
+        "aol.com",
+        "msn.com",
+        "gmx.com",
+    ]
+
+    domain = value.split("@")[1]
+
+    if domain in excluded_domains:
+        raise ValidationError(f"Seules les adresses professionnelles sont autorisées, {domain} n'en fait pas partie")

--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -5,6 +5,7 @@ from dsfr.forms import DsfrBaseForm
 from lemarche.sectors.models import Sector
 from lemarche.users import constants as user_constants
 from lemarche.users.models import User
+from lemarche.users.validators import professional_email_validator
 from lemarche.utils import time
 from lemarche.utils.constants import EMPTY_CHOICE, HOW_MANY_CHOICES
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
@@ -130,6 +131,9 @@ class SignupForm(UserCreationForm, DsfrBaseForm):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if self.cleaned_data["kind"] == User.KIND_BUYER:
+            professional_email_validator(email)
+
         return email.lower()
 
     def save(self, commit=True):

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -10,6 +10,7 @@ from selenium.webdriver.support.select import Select
 from lemarche.cms.snippets import Paragraph
 from lemarche.users.factories import DEFAULT_PASSWORD, UserFactory
 from lemarche.users.models import User
+from lemarche.www.auth.forms import SignupForm
 
 
 def scroll_to_and_click_element(driver, element, click=True):
@@ -298,6 +299,47 @@ class SignupFormTest(StaticLiveServerTestCase):
     def tearDownClass(cls):
         cls.driver.close()
         super().tearDownClass()
+
+
+class SignupSimpleTestcase(TestCase):
+    """Without integration testing"""
+
+    def setUp(self):
+        EXAMPLE_PASSWORD = "c*[gkp`0="
+        self.form_data = {
+            "accept_rgpd": True,
+            "first_name": "Prenom",
+            "last_name": "Nom",
+            "phone": "0123456789",
+            "company_name": "Ma boite",
+            "position": "Role important",
+            "password1": EXAMPLE_PASSWORD,
+            "password2": EXAMPLE_PASSWORD,
+        }
+
+    def test_personal_email_buyer(self):
+        self.form_data["kind"] = User.KIND_BUYER
+        self.form_data["email"] = "buyer@gmail.com"
+
+        form = SignupForm(data=self.form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("email", form.errors)
+
+    def test_personnal_email_individual(self):
+        """For individuals, or other kind except BUYER, address should not be necessary professional"""
+        self.form_data["kind"] = User.KIND_INDIVIDUAL
+        self.form_data["email"] = "buyer@gmail.com"
+
+        form = SignupForm(data=self.form_data)
+        self.assertTrue(form.is_valid())
+
+    def test_professional_email_buyer(self):
+        """This email is a professional one, it should pass"""
+        self.form_data["kind"] = User.KIND_INDIVIDUAL
+        self.form_data["email"] = "buyer@veryprofessional.com"
+
+        form = SignupForm(data=self.form_data)
+        self.assertTrue(form.is_valid())
 
 
 @override_settings(GOOGLE_AGENDA_IFRAME_URL="some_google_url")

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -8,6 +8,7 @@ from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.enums import SurveyDoesNotExistQuestionChoices, SurveyScaleQuestionChoices
 from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
+from lemarche.users.validators import professional_email_validator
 from lemarche.utils import constants
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 from lemarche.utils.widgets import CustomSelectMultiple
@@ -196,6 +197,8 @@ class TenderCreateStepContactForm(forms.ModelForm):
         self.user = user
         user_is_anonymous = not user.is_authenticated
         user_does_not_have_company_name = user_is_anonymous or not user.company_name
+
+        self.fields["contact_email"].validators.append(professional_email_validator)
 
         # display response_is_anonymous only if the tender is a project
         if self.instance and (self.instance.kind != tender_constants.KIND_PROJECT):


### PR DESCRIPTION
### Quoi ?

Des acheteurs s'inscrivaient avec le mails perso, problèmes pour les contacter

### Comment ?

Validation de l'extension des mails et rejet si appartenant a des fournisseurs liés généralement aux particuliers

