### PR TITLE
chore(API Entreprise): Mise à jour des données via l'API Recherche Entreprise

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -507,6 +507,9 @@ API_ENTREPRISE_CONTEXT = "emplois.inclusion.beta.gouv.fr"
 API_ENTREPRISE_RECIPIENT = env.str("API_ENTREPRISE_RECIPIENT", "")
 API_ENTREPRISE_TOKEN = env.str("API_ENTREPRISE_TOKEN", "")
 
+# API Recherche Entreprises.
+API_RECHERCHE_ENTREPRISES_BASE_URL = "https://recherche-entreprises.api.gouv.fr"
+
 # API QPV
 # API_QPV_RELATIVE_DAYS_TO_UPDATE is used to check last modification of SIAE.is_QPV
 #   if SIAE.is_QPV was update after `today-API_QPV_RELATIVE_DAYS_TO_UPDATE`, we call the API to QPV

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -20,8 +20,6 @@ SIAE_LEGAL_FORM_MAPPING_FILE_PATH = (
 
 
 def read_csv(file_path):
-    row_list = list()
-
     with open(file_path) as csv_file:
         row_list = list(csv.DictReader(csv_file, delimiter=","))
 
@@ -73,10 +71,6 @@ class Command(BaseCommand):
             progress += 1
             if (progress % 50) == 0:
                 self.stdout_info(f"{progress}...")
-
-            if not siae.siret:
-                self.stdout_error(f"SIAE {siae.id} without SIRET")
-                continue
 
             success = self._process_single_siae(siae, mapping_file_row_list, wet_run)
             if success:

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -23,9 +23,7 @@ def read_csv(file_path):
     row_list = list()
 
     with open(file_path) as csv_file:
-        csvreader = csv.DictReader(csv_file, delimiter=",")
-        for index, row in enumerate(csvreader):
-            row_list.append(row)
+        row_list = list(csv.DictReader(csv_file, delimiter=","))
 
     return row_list
 

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -1,44 +1,56 @@
+import csv
+import os
 import time
 
 from django.db.models import Q
+from django.utils import timezone
+from sentry_sdk.crons import monitor
 
+from lemarche.siaes.constants import SIAE_LEGAL_FORM_CHOICE_LIST
 from lemarche.siaes.models import Siae
 from lemarche.utils.apis import api_slack
-from lemarche.utils.apis.api_entreprise import siae_update_entreprise, siae_update_etablissement, siae_update_exercice
+from lemarche.utils.apis.api_recherche_entreprises import recherche_entreprises_get_or_error
 from lemarche.utils.commands import BaseCommand
 
 
-SCOPE_ALLOWED_VALUES = ("all", "entreprise", "etablissement", "exercice")
+SIAE_LEGAL_FORM_MAPPING_FILE_NAME = "data/mapping_api_entreprise_forme_juridique.csv"
+SIAE_LEGAL_FORM_MAPPING_FILE_PATH = (
+    os.path.dirname(os.path.realpath(__file__)) + "/" + SIAE_LEGAL_FORM_MAPPING_FILE_NAME
+)
+
+
+def read_csv(file_path):
+    row_list = list()
+
+    with open(file_path) as csv_file:
+        csvreader = csv.DictReader(csv_file, delimiter=",")
+        for index, row in enumerate(csvreader):
+            row_list.append(row)
+
+    return row_list
 
 
 class Command(BaseCommand):
     """
-    Populates API Entreprise fields
+    Populates API Entreprise fields with API Recherche Entreprises
 
     Note: Only on Siae who have api_entreprise_*_last_sync_date as None
 
-    TODO: filter only on Siae not updated since a certain date?
-
     Usage:
     - poetry run python manage.py update_api_entreprise_fields
-    - poetry run python manage.py update_api_entreprise_fields --scope etablissement
     - poetry run python manage.py update_api_entreprise_fields --siret 01234567891011
     - poetry run python manage.py update_api_entreprise_fields --limit 100
     """
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--scope", type=str, default="all", help="Options are 'entreprise', 'etablissement', 'exercice', or 'all'"
-        )
         parser.add_argument("--siret", type=str, default=None, help="Lancer sur un Siret spécifique")
         parser.add_argument("--limit", type=int, default=None, help="Limiter le nombre de structures à processer")
+        parser.add_argument("--wet-run", action="store_true", help="Exécuter les requêtes")
 
+    @monitor(monitor_slug="update-api-entreprise-fields")
     def handle(self, *args, **options):
         self.stdout_info("-" * 80)
         self.stdout_info("Populating API Entreprise fields...")
-
-        if options["scope"] not in SCOPE_ALLOWED_VALUES:
-            raise Exception(f"scope not in {SCOPE_ALLOWED_VALUES}")
 
         if options["siret"]:
             siae_queryset = Siae.objects.filter(siret=options["siret"])
@@ -52,124 +64,82 @@ class Command(BaseCommand):
         if options["limit"]:
             siae_queryset = siae_queryset[: options["limit"]]
 
-        # self.stdout_info(f"Found {siae_queryset.count()} Siae")
+        self._update_siae_api_entreprise_fields(siae_queryset, wet_run=options["wet_run"])
 
-        if options["scope"] in ("all", "entreprise"):
-            self.update_api_entreprise_entreprise_fields(siae_queryset)
-
-        if options["scope"] in ("all", "etablissement"):
-            self.update_api_entreprise_etablissement_fields(siae_queryset)
-
-        if options["scope"] in ("all", "exercice"):
-            self.update_api_entreprise_exercice_fields(siae_queryset)
-
-    # API Entreprise: entreprises
-    def update_api_entreprise_entreprise_fields(self, siae_queryset):
-        progress = 0
+    def _update_siae_api_entreprise_fields(self, siae_queryset, wet_run=False):
         results = {"success": 0, "error": 0}
-        siae_queryset_entreprise = siae_queryset.filter(api_entreprise_entreprise_last_sync_date=None)
-        self.stdout_info("-" * 80)
-        self.stdout_info(f"Populating 'entreprise' for {siae_queryset_entreprise.count()} Siae...")
 
-        for siae in siae_queryset_entreprise:
-            try:
-                progress += 1
-                if (progress % 50) == 0:
-                    self.stdout_info(f"{progress}...")
-                # self.stdout_info("-" * 80)
-                # self.stdout_info(f"{siae.id} / {siae.name} / {siae.siret}")
-                response, message = siae_update_entreprise(siae)
-                if response:
-                    results["success"] += 1
-                else:
-                    self.stdout_error(str(message))
-                    results["error"] += 1
-                # small delay to avoid going above the API limitation
-                # "max. 250 requêtes/min/jeton cumulées sur tous les endpoints"
-                time.sleep(0.5)
-            except Exception as e:
-                self.stdout_error(str(e))
-                api_slack.send_message_to_channel("Erreur lors de la synchronisation API entreprises: entreprises")
+        mapping_file_row_list = read_csv(SIAE_LEGAL_FORM_MAPPING_FILE_PATH)
+
+        progress = 0
+        for siae in siae_queryset:
+            progress += 1
+            if (progress % 50) == 0:
+                self.stdout_info(f"{progress}...")
+
+            if not siae.siret:
+                self.stdout_error(f"SIAE {siae.id} without SIRET")
+                continue
+
+            update_data = dict()
+
+            entreprise, error = recherche_entreprises_get_or_error(siae.siret)
+            if error:
+                results["error"] += 1
+                self.stdout_error(str(error))
+            else:
+                # Entreprise
+                if entreprise.forme_juridique_code:
+                    siae_mapping_row = next(
+                        (
+                            mapping_row
+                            for mapping_row in mapping_file_row_list
+                            if mapping_row["input_code"] == entreprise.forme_juridique_code
+                        ),
+                        None,
+                    )
+                    if siae_mapping_row:
+                        if siae_mapping_row["output_name"] in SIAE_LEGAL_FORM_CHOICE_LIST:
+                            update_data["api_entreprise_forme_juridique"] = siae_mapping_row["output_name"]
+                            update_data["api_entreprise_forme_juridique_code"] = entreprise.forme_juridique_code
+                            update_data["api_entreprise_entreprise_last_sync_date"] = timezone.now()
+                        else:
+                            results["error"] += 1
+                            self.stdout_error(f"unknown output_name {siae_mapping_row['output_name']}")
+                    else:
+                        results["error"] += 1
+                        self.stdout_error(f"unknown input_name {entreprise.forme_juridique_code}")
+
+                # Etablissement
+                update_data["api_entreprise_employees"] = (
+                    entreprise.employees if (entreprise.employees != "Unités non employeuses") else "Non renseigné"
+                )
+                update_data["api_entreprise_employees_year_reference"] = entreprise.employees_date_reference
+                update_data["api_entreprise_date_constitution"] = entreprise.date_creation
+                update_data["api_entreprise_etablissement_last_sync_date"] = timezone.now()
+
+                # Exercice
+                if entreprise.ca:
+                    update_data["api_entreprise_ca"] = entreprise.ca
+                    # api_entreprise_ca_date_fin_exercice is missing in this API but seems to be used in the frontend
+                    update_data["api_entreprise_exercice_last_sync_date"] = timezone.now()
+
+                results["success"] += 1
+
+            if wet_run:
+                Siae.objects.filter(id=siae.id).update(**update_data)
+            else:
+                self.stdout_info(f"Would update SIAE {siae.id} with {update_data=}")
+
+            # small delay to avoid going above the API limitation, one loop generates 3 requests
+            # "max. 250 requêtes/min/jeton cumulées sur tous les endpoints"
+            time.sleep(1)
 
         msg_success = [
-            "----- Synchronisation API Entreprise (/entreprises) -----",
-            f"Done! Processed {siae_queryset_entreprise.count()} siae",
-            f"success count: {results['success']}/{siae_queryset_entreprise.count()}",
-            f"error count: {results['error']}/{siae_queryset_entreprise.count()} (voir les logs)",
-        ]
-        self.stdout_messages_success(msg_success)
-        api_slack.send_message_to_channel("\n".join(msg_success))
-
-    # API Entreprise: etablissements
-    def update_api_entreprise_etablissement_fields(self, siae_queryset):
-        progress = 0
-        results = {"success": 0, "error": 0}
-        siae_queryset_etablissement = siae_queryset.filter(api_entreprise_etablissement_last_sync_date=None)
-        self.stdout_info("-" * 80)
-        self.stdout_info(f"Populating 'etablissement' for {siae_queryset_etablissement.count()} Siae...")
-
-        for siae in siae_queryset_etablissement:
-            try:
-                progress += 1
-                if (progress % 50) == 0:
-                    self.stdout_info(f"{progress}...")
-                # self.stdout_info("-" * 80)
-                # self.stdout_info(f"{siae.id} / {siae.name} / {siae.siret}")
-                response, message = siae_update_etablissement(siae)
-                if response:
-                    results["success"] += 1
-                else:
-                    self.stdout_error(str(message))
-                    results["error"] += 1
-                # small delay to avoid going above the API limitation
-                # "max. 250 requêtes/min/jeton cumulées sur tous les endpoints"
-                time.sleep(0.5)
-            except Exception as e:
-                self.stdout_error(str(e))
-                api_slack.send_message_to_channel("Erreur lors de la synchronisation API entreprises: etablissements")
-
-        msg_success = [
-            "----- Synchronisation API Entreprise (/etablissements) -----",
-            f"Done! Processed {siae_queryset_etablissement.count()} siae",
-            f"success count: {results['success']}/{siae_queryset_etablissement.count()}",
-            f"error count: {results['error']}/{siae_queryset_etablissement.count()} (voir les logs)",
-        ]
-        self.stdout_messages_success(msg_success)
-        api_slack.send_message_to_channel("\n".join(msg_success))
-
-    # API Entreprise: exercices
-    def update_api_entreprise_exercice_fields(self, siae_queryset):
-        progress = 0
-        results = {"success": 0, "error": 0}
-        siae_queryset_exercice = siae_queryset.filter(api_entreprise_exercice_last_sync_date=None)
-        self.stdout_info("-" * 80)
-        self.stdout_info(f"Populating 'exercice' for {siae_queryset_exercice.count()} Siae...")
-
-        for siae in siae_queryset_exercice:
-            try:
-                progress += 1
-                if (progress % 50) == 0:
-                    self.stdout_info(f"{progress}...")
-                # self.stdout_info("-" * 80)
-                # self.stdout_info(f"{siae.id} / {siae.name} / {siae.siret}")
-                response, message = siae_update_exercice(siae)
-                if response:
-                    results["success"] += 1
-                else:
-                    self.stdout_error(str(message))
-                    results["error"] += 1
-                # small delay to avoid going above the API limitation
-                # "max. 250 requêtes/min/jeton cumulées sur tous les endpoints"
-                time.sleep(0.5)
-            except Exception as e:
-                self.stdout_error(str(e))
-                api_slack.send_message_to_channel("Erreur lors de la synchronisation API entreprises: exercices")
-
-        msg_success = [
-            "----- Synchronisation API Entreprise (/exercices) -----",
-            f"Done! Processed {siae_queryset_exercice.count()} siae",
-            f"success count: {results['success']}/{siae_queryset_exercice.count()}",
-            f"error count: {results['error']}/{siae_queryset_exercice.count()} (voir les logs)",
+            "----- Synchronisation API Entreprise -----",
+            f"Done! Processed {siae_queryset.count()} siae",
+            f"success count: {results['success']}/{siae_queryset.count()}",
+            f"error count: {results['error']}/{siae_queryset.count()} (voir les logs)",
         ]
         self.stdout_messages_success(msg_success)
         api_slack.send_message_to_channel("\n".join(msg_success))

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -9,7 +9,10 @@ from sentry_sdk.crons import monitor
 from lemarche.siaes.constants import SIAE_LEGAL_FORM_CHOICE_LIST
 from lemarche.siaes.models import Siae
 from lemarche.utils.apis import api_slack
-from lemarche.utils.apis.api_recherche_entreprises import recherche_entreprises_get_or_error
+from lemarche.utils.apis.api_recherche_entreprises import (
+    RechercheEntreprisesAPIException,
+    recherche_entreprises_get_or_error,
+)
 from lemarche.utils.commands import BaseCommand
 
 
@@ -101,7 +104,7 @@ class Command(BaseCommand):
             else:
                 self.stdout_info(f"Would update SIAE {siae.id} with {update_data=}")
             return True
-        except Exception as e:
+        except RechercheEntreprisesAPIException as e:
             self.stdout_error(str(e))
             return False
 

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -129,9 +129,9 @@ class Command(BaseCommand):
             else:
                 self.stdout_info(f"Would update SIAE {siae.id} with {update_data=}")
 
-            # small delay to avoid going above the API limitation, one loop generates 3 requests
-            # "max. 250 requêtes/min/jeton cumulées sur tous les endpoints"
-            time.sleep(1)
+            # small delay to avoid going above the API limitation
+            # "max. 7 requests per second"
+            time.sleep(0.2)
 
         msg_success = [
             "----- Synchronisation API Entreprise -----",

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -81,12 +81,8 @@ class Command(BaseCommand):
 
             update_data = dict()
 
-            entreprise, error = recherche_entreprises_get_or_error(siae.siret)
-            if error:
-                results["error"] += 1
-                self.stdout_error(str(error))
-            else:
-                # Entreprise
+            try:
+                entreprise = recherche_entreprises_get_or_error(siae.siret)
                 if entreprise.forme_juridique_code:
                     siae_mapping_row = next(
                         (
@@ -123,6 +119,10 @@ class Command(BaseCommand):
                     update_data["api_entreprise_exercice_last_sync_date"] = timezone.now()
 
                 results["success"] += 1
+            except Exception as e:
+                results["error"] += 1
+                self.stdout_error(str(e))
+                continue
 
             if wet_run:
                 Siae.objects.filter(id=siae.id).update(**update_data)

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -529,3 +529,20 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TransactionTestCase):
         call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True)
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
+
+    @patch("lemarche.utils.apis.api_recherche_entreprises.requests.get")
+    def test_update_api_entreprise_fields_with_siret_not_found(self, mock_requests_get):
+        """
+        Check that the field is updated correctly with a siret not found
+        """
+        mock_requests_get.return_value.status_code = 200
+        mock_requests_get.return_value.json.return_value = {
+            "results": [],
+            "total_results": 0,
+            "page": 1,
+            "per_page": 10,
+            "total_pages": 1,
+        }
+        out = StringIO()
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=out)
+        self.assertIn("SIRET not found", out.getvalue())

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import factory
 from django.core.management import call_command
 from django.db.models import signals
-from django.test import TransactionTestCase
+from django.test import TestCase, TransactionTestCase
 
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.factories import SiaeActivityFactory, SiaeFactory
@@ -379,7 +379,7 @@ class SiaeUpdateCountFieldsCommandTest(TransactionTestCase):
         self.assertEqual(siae_not_updated.sector_count, 0)
 
 
-class SiaeUpdateApiEntrepriseFieldsCommandTest(TransactionTestCase):
+class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
 
     def setUp(self):
         super().setUp()

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -40,6 +40,10 @@ class RechercheEntreprisesResponse:
     ca_date_reference: date | None
 
 
+class RechercheEntreprisesAPIException(Exception):
+    pass
+
+
 def recherche_entreprises_get_or_error(siret):
     # Doc : https://recherche-entreprises.api.gouv.fr/docs/
     url = f"{settings.API_RECHERCHE_ENTREPRISES_BASE_URL}/search?q={siret}"
@@ -50,9 +54,9 @@ def recherche_entreprises_get_or_error(siret):
         response_data = response.json()
 
         if response_data["total_results"] == 0:
-            raise Exception("SIRET not found")
+            raise RechercheEntreprisesAPIException("SIRET not found")
         elif response_data["total_results"] > 1:
-            raise Exception("SIRET found but multiple results")
+            raise RechercheEntreprisesAPIException("SIRET found but multiple results")
         else:
             # get interesting data
             data = response_data["results"][0]
@@ -68,7 +72,7 @@ def recherche_entreprises_get_or_error(siret):
 
             if len(data["matching_etablissements"]) != 1:
                 # Did never happen because SIRET is unique, but just in case
-                raise Exception("Multiple matching establishments found")
+                raise RechercheEntreprisesAPIException("Multiple matching establishments found")
 
             etablissement = data["matching_etablissements"][0]
             return RechercheEntreprisesResponse(
@@ -85,4 +89,4 @@ def recherche_entreprises_get_or_error(siret):
             )
 
     except requests.exceptions.HTTPError as e:
-        raise Exception(f"Error while fetching `{url}`: {e}")
+        raise RechercheEntreprisesAPIException(f"Error while fetching `{url}`: {e}")

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -41,7 +41,7 @@ class RechercheEntreprisesResponse:
 
 
 def recherche_entreprises_get_or_error(siret):
-
+    # Doc : https://recherche-entreprises.api.gouv.fr/docs/
     url = f"{settings.API_RECHERCHE_ENTREPRISES_BASE_URL}/search?q={siret}"
 
     try:

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -50,9 +50,9 @@ def recherche_entreprises_get_or_error(siret):
         response_data = response.json()
 
         if response_data["total_results"] == 0:
-            return None, "SIRET not found"
+            raise Exception("SIRET not found")
         elif response_data["total_results"] > 1:
-            return None, "SIRET found but multiple results"
+            raise Exception("SIRET found but multiple results")
         else:
             # get interesting data
             data = response_data["results"][0]
@@ -67,21 +67,18 @@ def recherche_entreprises_get_or_error(siret):
                 ca = sorted_finances[0][1]["ca"]
 
             etablissement = data["matching_etablissements"][0]
-            return (
-                RechercheEntreprisesResponse(
-                    siret=etablissement["siret"],
-                    forme_juridique_code=data["nature_juridique"],
-                    date_creation=etablissement["date_creation"],
-                    naf=etablissement["activite_principale"],
-                    is_closed=etablissement["etat_administratif"] == "F",
-                    is_head_office=etablissement["est_siege"],
-                    employees=TRANCHES_EFFECTIF_SALARIE_MAPPING.get(etablissement["tranche_effectif_salarie"], ""),
-                    employees_date_reference=etablissement["annee_tranche_effectif_salarie"],
-                    ca=ca,
-                    ca_date_reference=ca_date_reference,
-                ),
-                None,
+            return RechercheEntreprisesResponse(
+                siret=etablissement["siret"],
+                forme_juridique_code=data["nature_juridique"],
+                date_creation=etablissement["date_creation"],
+                naf=etablissement["activite_principale"],
+                is_closed=etablissement["etat_administratif"] == "F",
+                is_head_office=etablissement["est_siege"],
+                employees=TRANCHES_EFFECTIF_SALARIE_MAPPING.get(etablissement["tranche_effectif_salarie"], ""),
+                employees_date_reference=etablissement["annee_tranche_effectif_salarie"],
+                ca=ca,
+                ca_date_reference=ca_date_reference,
             )
 
     except requests.exceptions.HTTPError as e:
-        return None, f"Error while fetching `{url}`: {e}"
+        raise Exception(f"Error while fetching `{url}`: {e}")

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -66,6 +66,10 @@ def recherche_entreprises_get_or_error(siret):
                 ca_date_reference = sorted_finances[0][0]
                 ca = sorted_finances[0][1]["ca"]
 
+            if len(data["matching_etablissements"]) != 1:
+                # Did never happen because SIRET is unique, but just in case
+                raise Exception("Multiple matching establishments found")
+
             etablissement = data["matching_etablissements"][0]
             return RechercheEntreprisesResponse(
                 siret=etablissement["siret"],

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -36,8 +36,8 @@ class RechercheEntreprisesResponse:
     is_head_office: bool
     employees: str
     employees_date_reference: date
-    ca: str
-    ca_date_reference: date
+    ca: str | None
+    ca_date_reference: date | None
 
 
 def recherche_entreprises_get_or_error(siret):

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from datetime import date
+
+import requests
+from django.conf import settings
+
+
+# https://sirene.fr/static-resources/htm/v_sommaire_311.htm#27
+TRANCHES_EFFECTIF_SALARIE_MAPPING = {
+    "NN": "Etablissement non-employeur",
+    "00": "0 salarié",
+    "01": "1 ou 2 salariés",
+    "02": "3 à 5 salariés",
+    "03": "6 à 9 salariés",
+    "11": "10 à 19 salariés",
+    "12": "20 à 49 salariés",
+    "21": "50 à 99 salariés",
+    "22": "100 à 199 salariés",
+    "31": "200 à 249 salariés",
+    "32": "250 à 499 salariés",
+    "41": "500 à 999 salariés",
+    "42": "1 000 à 1 999 salariés",
+    "51": "2 000 à 4 999 salariés",
+    "52": "5 000 à 9 999 salariés",
+    "53": "10 000 salariés et plus",
+}
+
+
+@dataclass
+class RechercheEntreprisesResponse:
+    siret: str
+    forme_juridique_code: str
+    date_creation: date
+    naf: str
+    is_closed: bool
+    is_head_office: bool
+    employees: str
+    employees_date_reference: date
+    ca: str
+    ca_date_reference: date
+
+
+def recherche_entreprises_get_or_error(siret):
+
+    url = f"{settings.API_RECHERCHE_ENTREPRISES_BASE_URL}/search?q={siret}"
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        response_data = response.json()
+
+        if response_data["total_results"] == 0:
+            return None, "SIRET not found"
+        elif response_data["total_results"] > 1:
+            return None, "SIRET found but multiple results"
+        else:
+            # get interesting data
+            data = response_data["results"][0]
+
+            ca = None
+            ca_date_reference = None
+            if "finances" in data and data["finances"]:
+                finances = data["finances"]
+                ca_date_reference = next(iter(finances.keys()))
+                ca = finances[ca_date_reference]["ca"]
+
+            etablissement = data["matching_etablissements"][0]
+            return (
+                RechercheEntreprisesResponse(
+                    siret=etablissement["siret"],
+                    forme_juridique_code=data["nature_juridique"],
+                    date_creation=etablissement["date_creation"],
+                    naf=etablissement["activite_principale"],
+                    is_closed=etablissement["etat_administratif"] == "F",
+                    is_head_office=etablissement["est_siege"],
+                    employees=TRANCHES_EFFECTIF_SALARIE_MAPPING.get(etablissement["tranche_effectif_salarie"], ""),
+                    employees_date_reference=etablissement["annee_tranche_effectif_salarie"],
+                    ca=ca,
+                    ca_date_reference=ca_date_reference,
+                ),
+                None,
+            )
+
+    except requests.exceptions.HTTPError as e:
+        return None, f"Error while fetching `{url}`: {e}"

--- a/lemarche/utils/apis/api_recherche_entreprises.py
+++ b/lemarche/utils/apis/api_recherche_entreprises.py
@@ -61,8 +61,10 @@ def recherche_entreprises_get_or_error(siret):
             ca_date_reference = None
             if "finances" in data and data["finances"]:
                 finances = data["finances"]
-                ca_date_reference = next(iter(finances.keys()))
-                ca = finances[ca_date_reference]["ca"]
+                # Sort the finances data by year in descending order
+                sorted_finances = sorted(finances.items(), key=lambda x: x[0], reverse=True)
+                ca_date_reference = sorted_finances[0][0]
+                ca = sorted_finances[0][1]["ca"]
 
             etablissement = data["matching_etablissements"][0]
             return (


### PR DESCRIPTION
### Quoi ?

Mise à jour des champs "api_entreprise_*" avec l'API de Recherche Entreprise

### Pourquoi ?

API Entreprise a été mise à jour et nous n'avons pas les accès à la nouvelle version. La PR #1599 ne peut donc pas être mise en production.
L'API Recherche Entreprise est quant à elle ouverte. 

### Comment ?

Appel en GET à l'API de Recherche Entreprise

### Autre

L'ajout de `from sentry_sdk.crons import monitor` permettra de suivre la bonne exécution de la tache planifiée.

Prochaine étape :
- mettre à jour aussi les données anciennes, pas uniquement que les structures pour lesquelles le champs n'a jamais été renseigné.
- gérer le quota d'appel à l'API