### PR TITLE
chore: Envoyer le mail de rattachement à tous les gestionnaires

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1242,12 +1242,6 @@ class SiaeUserRequestQuerySet(models.QuerySet):
     def pending(self):
         return self.filter(response=None)
 
-    def initiator(self, user):
-        return self.filter(initiator=user)
-
-    def assignee(self, user):
-        return self.filter(assignee=user)
-
 
 class SiaeUserRequest(models.Model):
     siae = models.ForeignKey("siaes.Siae", verbose_name="Structure", on_delete=models.CASCADE)

--- a/lemarche/templates/dashboard/siae_users.html
+++ b/lemarche/templates/dashboard/siae_users.html
@@ -35,13 +35,13 @@
                     <button data-fr-opened="false"
                             aria-controls="siae_user_delete_modal"
                             class="fr-hidden"></button>
-                    {% if siae.siaeuserrequest_set.pending.count %}
+                    {% if siae_user_pending_requests %}
                         <div class="fr-grid-row fr-mb-1w">
                             <div class="fr-col">
                                 <h2>En attente</h2>
                             </div>
                         </div>
-                        {% for siaeuserrequest in siae.siaeuserrequest_set.pending %}
+                        {% for siaeuserrequest in siae_user_pending_requests %}
                             <div class="fr-grid-row fr-grid-row--gutters">
                                 <div class="fr-col">
                                     <div class="fr-card fr-card--sm fr-card--grey">

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -75,7 +75,7 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
         - check if there isn't any pending SiaeUserRequest
         """
         context = super().get_context_data(**kwargs)
-        siae_user_pending_request = self.object.siaeuserrequest_set.initiator(self.request.user).pending()
+        siae_user_pending_request = self.object.siaeuserrequest_set.filter(initiator=self.request.user).pending()
         context["siae_user_pending_request"] = siae_user_pending_request
         context["breadcrumb_data"] = {
             "root_dir": settings_context_processors.expose_settings(self.request)["HOME_PAGE_PATH"],
@@ -124,7 +124,7 @@ class SiaeUsersView(SiaeMemberRequiredMixin, DetailView):
         - check if there isn't any pending SiaeUserRequest
         """
         context = super().get_context_data(**kwargs)
-        siae_user_pending_request = self.object.siaeuserrequest_set.assignee(self.request.user).pending()
+        siae_user_pending_request = self.object.siaeuserrequest_set.filter(assignee=self.request.user).pending()
         context["siae_user_pending_requests"] = siae_user_pending_request
         context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
         context["breadcrumb_current"] = f"{self.object.name_display} : collaborateurs"

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -98,14 +98,15 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
             return super().form_valid(form)
         else:
             # create SiaeUserRequest + send request email to assignee
-            siae_user_request = SiaeUserRequest.objects.create(
-                siae=self.object,
-                initiator=self.request.user,
-                assignee=self.object.users.first(),
-                logs=[{"action": "create", "timestamp": timezone.now().isoformat()}],
-            )
-            send_siae_user_request_email_to_assignee(siae_user_request)
-            success_message = f"La demande a été envoyée à {self.object.users.first().full_name}."
+            for assignee in self.object.users.all():
+                siae_user_request = SiaeUserRequest.objects.create(
+                    siae=self.object,
+                    initiator=self.request.user,
+                    assignee=assignee,
+                    logs=[{"action": "create", "timestamp": timezone.now().isoformat()}],
+                )
+                send_siae_user_request_email_to_assignee(siae_user_request)
+            success_message = "La demande a été envoyée aux gestionnaires de la strucure."
             messages.add_message(self.request, messages.SUCCESS, success_message)
             return HttpResponseRedirect(reverse_lazy("dashboard:home"))
 

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -125,7 +125,7 @@ class SiaeUsersView(SiaeMemberRequiredMixin, DetailView):
         """
         context = super().get_context_data(**kwargs)
         siae_user_pending_request = self.object.siaeuserrequest_set.assignee(self.request.user).pending()
-        context["siae_user_pending_request"] = siae_user_pending_request
+        context["siae_user_pending_requests"] = siae_user_pending_request
         context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
         context["breadcrumb_current"] = f"{self.object.name_display} : collaborateurs"
         return context


### PR DESCRIPTION
### Quoi ?
Seul le dernier gestionnaire était contacté pour approuver une demande de rattachement à une structure.
Désormais, tous les gestionnaires recevront le mail et pourront approuver ou non la demande.
