### PR TITLE
chore: Migrer les DDB préfixées par HS en statut "rejeté"

### DIFF
--- a/lemarche/tenders/migrations/0098_update_rejected.py
+++ b/lemarche/tenders/migrations/0098_update_rejected.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from lemarche.tenders.constants import STATUS_REJECTED
+
+
+def update_rejected_tenders(apps, schema_editor):
+    """Before we set up the Tender status system, Tender title were prefixed with 'HS xxxxx'
+    to mark them as non-pertinent.
+    Here we update the prefixed tenders with the rejected status"""
+    Tender = apps.get_model("tenders", "Tender")
+    Tender.objects.filter(title__startswith="HS ").update(status=STATUS_REJECTED)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tenders", "0097_questionanswer"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_rejected_tenders,
+            migrations.RunPython.noop,
+        )
+    ]


### PR DESCRIPTION
### Quoi ?
Une migration pour mettre à jour le statut des anciens tenders qui avant la PR https://github.com/gip-inclusion/le-marche/pull/1596 étaient préfixés par "HS" pour les tagger comme hors sujet

