### PR TITLE
chore(API Entreprise): Ajout de la forme juridique "SCOP à directoire"

### DIFF
--- a/lemarche/siaes/management/commands/data/mapping_api_entreprise_forme_juridique.csv
+++ b/lemarche/siaes/management/commands/data/mapping_api_entreprise_forme_juridique.csv
@@ -40,6 +40,7 @@ Régime général de la Sécurité Sociale,8110,5,AUTRE
 SA à conseil d'administration (s.a.i.),5599,37,SA
 SA à directoire (s.a.i.),5699,10,SA
 SA coopérative ouvrière de production (SCOP) à conseil d'administration,5558,49,SA_COOP
+SA coopérative de production (SCOP) à directoire,5658,,SA_COOP
 SA d'économie mixte à conseil d'administration,5515,3,SA
 SA d'intérêt collectif agricole (SICA) à conseil d'administration,5532,1,SA
 SARL coopérative artisanale,5453,2,SARL_COOP

--- a/lemarche/siaes/management/commands/update_api_entreprise_fields.py
+++ b/lemarche/siaes/management/commands/update_api_entreprise_fields.py
@@ -44,12 +44,16 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--siret", type=str, default=None, help="Lancer sur un Siret spécifique")
         parser.add_argument("--limit", type=int, default=None, help="Limiter le nombre de structures à processer")
-        parser.add_argument("--wet-run", action="store_true", help="Exécuter les requêtes")
+        parser.add_argument("--wet-run", action="store_true", help="Exécuter les requêtes en base de données")
 
     @monitor(monitor_slug="update-api-entreprise-fields")
     def handle(self, *args, **options):
         self.stdout_info("-" * 80)
         self.stdout_info("Populating API Entreprise fields...")
+        if not options["wet_run"]:
+            self.stdout_warning(
+                "You are running in dry mode, no changes will be applied (use --wet-run to apply changes)"
+            )
 
         if options["siret"]:
             siae_queryset = Siae.objects.filter(siret=options["siret"])


### PR DESCRIPTION
### Quoi ?

Ajout de la forme légale 5658 "SA coopérative de production (SCOP) à directoire" ajouter le 1er septembre 2022 -> https://www.insee.fr/fr/information/2028129

### Pourquoi ?

La commande `update_api_entreprise_fields` échoue car le code de la forme juridique 5658 n'est pas reconnu.

### Comment ?

Ajout dans le fichier de correspondance.

### Autre

Ajout d'un avertissement quand la commande est lancée sans le "wet-run".