### PR TITLE
chore(Sync C1): Ajout d'info dans le log pour mieux comprendre les erreurs de duplication de nom commercial

### DIFF
--- a/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
+++ b/lemarche/siaes/management/commands/sync_with_emplois_inclusion.py
@@ -259,7 +259,8 @@ class Command(BaseCommand):
                 self.stdout_info(f"New Siae created / {siae.id} / {siae.name} / {siae.siret}")
             else:
                 logger.error(
-                    f"Brand name is already used by another SIAE: '{c1_siae['brand']}' / name: '{c1_siae['name']}'"
+                    "Brand name is already used by another SIAE during creation: %s",
+                    c1_siae,
                 )
 
     def c4_update_siae(self, c1_siae, c4_siae, dry_run):
@@ -289,7 +290,8 @@ class Command(BaseCommand):
                 Siae.objects.filter(c1_id=c4_siae.c1_id).update(**c1_siae_filtered)  # avoid updated_at change
             else:
                 logger.error(
-                    f"Brand name is already used by another SIAE: '{c1_siae['brand']}' / name: '{c1_siae['name']}'"
+                    "Brand name is already used by another SIAE during update: %s",
+                    c1_siae,
                 )
 
             # self.stdout_info(f"Siae updated / {c4_siae.id} / {c4_siae.siret}")

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -165,7 +165,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
             call_command("sync_with_emplois_inclusion")
 
         # Verify warning was logged
-        self.assertIn("Brand name is already used by another SIAE", log.output[0])
+        self.assertIn("Brand name is already used by another SIAE during creation", log.output[0])
 
         # Verify both SIAEs exist
         self.assertEqual(Siae.objects.count(), 1)
@@ -236,7 +236,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
             call_command("sync_with_emplois_inclusion")
 
         # Verify warning was logged
-        self.assertIn("Brand name is already used by another SIAE: 'Duplicate Brand'", log.output[0])
+        self.assertIn("Brand name is already used by another SIAE during update", log.output[0])
 
         # Verify both SIAEs exist
         self.assertEqual(Siae.objects.count(), 3)


### PR DESCRIPTION
### Quoi ?

Ajout d'info dans l'erreur de duplication de nom commercial durant la synchro avec le C1

### Pourquoi ?

Pour mieux comprendre les cas en erreur et savoir si il s'agit de mis à jour ou de création.

### Comment ?

En ajoutant le dict complet dans le log.