### PR TITLE
feat(API Swagger): Possibilité d'ajouter son token dans Swagger 

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -591,6 +591,17 @@ SPECTACULAR_SETTINGS = {
         "DepartmentEnum": "lemarche.siaes.models.Siae.DEPARTMENT_CHOICES",
     },
     "SWAGGER_UI_SETTINGS": {"defaultModelsExpandDepth": -1},  # hide model schemas
+    "SECURITY": [{"bearerAuth": []}],
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "Ajoutez votre token d'API dans le header de la requête.",
+            },
+        },
+    },
 }
 
 


### PR DESCRIPTION
### Quoi ?

Ajout de la configuration du "bearer token" dans la configuration de drf-spectacular.

### Pourquoi ?

Pour permettre aux usagers de tester directement en ligne avec leur jeton d'API.

### Comment ?

Configuration SPECTACULAR_SETTINGS.

### Captures d'écran

![image](https://github.com/user-attachments/assets/72b57003-aec8-47fa-95b7-0ce7d0950f5f)

