### PR TITLE
chore: Suppression de compteurs de structures dans admin de besoins

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -381,10 +381,6 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "partner_approch_id",
         "siae_count_annotated_with_link",
         "siae_email_send_count_annotated_with_link",
-        "siae_email_link_click_count_annotated_with_link",
-        "siae_detail_display_count_annotated_with_link",
-        "siae_email_link_click_or_detail_display_count_annotated",
-        "siae_email_link_click_or_detail_display_count_annotated_with_link",
         "siae_detail_contact_click_count_annotated_with_link",
         "siae_detail_not_interested_click_count_annotated_with_link",
         "siae_transactioned_source",
@@ -495,10 +491,6 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                 "fields": (
                     "siae_count_annotated_with_link",
                     "siae_email_send_count_annotated_with_link",
-                    "siae_email_link_click_count_annotated_with_link",
-                    "siae_detail_display_count_annotated_with_link",
-                    "siae_email_link_click_or_detail_display_count_annotated",
-                    # "siae_email_link_click_or_detail_display_count_annotated_with_link",
                     "siae_detail_contact_click_count_annotated_with_link",
                     "siae_detail_not_interested_click_count_annotated_with_link",
                 )
@@ -729,49 +721,6 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
 
     siae_email_send_count_annotated_with_link.short_description = "S. contactées"
     siae_email_send_count_annotated_with_link.admin_order_field = "siae_email_send_count_annotated"
-
-    def siae_email_link_click_count_annotated_with_link(self, tender):
-        url = (
-            reverse("admin:siaes_siae_changelist")
-            + f"?tenders__in={tender.id}&tendersiae__email_link_click_date__isnull=False"
-        )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_email_link_click_count_annotated", 0)}</a>')
-
-    siae_email_link_click_count_annotated_with_link.short_description = "S. cliquées"
-    siae_email_link_click_count_annotated_with_link.admin_order_field = "siae_email_link_click_count_annotated"
-
-    def siae_detail_display_count_annotated_with_link(self, tender):
-        url = (
-            reverse("admin:siaes_siae_changelist")
-            + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
-        )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_display_count_annotated", 0)}</a>')
-
-    siae_detail_display_count_annotated_with_link.short_description = "S. vues"
-    siae_detail_display_count_annotated_with_link.admin_order_field = "siae_detail_display_count_annotated"
-
-    def siae_email_link_click_or_detail_display_count_annotated(self, tender):
-        return getattr(tender, "siae_email_link_click_or_detail_display_count_annotated", 0)
-
-    siae_email_link_click_or_detail_display_count_annotated.short_description = "S. cliquées ou vues"
-    siae_email_link_click_or_detail_display_count_annotated.admin_order_field = (
-        "siae_email_link_click_or_detail_display_count_annotated"
-    )
-
-    def siae_email_link_click_or_detail_display_count_annotated_with_link(self, tender):
-        # TO FIX (if possible ?): wrong url, should be link_click OR detail_display
-        url = (
-            reverse("admin:siaes_siae_changelist")
-            + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
-        )
-        return format_html(
-            f'<a href="{url}">{getattr(tender, "siae_email_link_click_or_detail_display_count_annotated", 0)}</a>'
-        )
-
-    siae_email_link_click_or_detail_display_count_annotated_with_link.short_description = "S. cliquées ou vues"
-    siae_email_link_click_or_detail_display_count_annotated_with_link.admin_order_field = (
-        "siae_email_link_click_or_detail_display_count_annotated"
-    )
 
     def siae_detail_contact_click_count_annotated_with_link(self, tender):
         url = (


### PR DESCRIPTION
### Quoi ?

Les champs "S cliquées", "S Vues" et "S Cliquées ou Vues" n'étaient pas utilisés par les admins, ils ont donc été supprimés pour ne pas surcharger la page.
