### PR TITLE
chore: Suppression du fuzzy testing

### DIFF
--- a/content_manager/management/commands/create_demo_pages.py
+++ b/content_manager/management/commands/create_demo_pages.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from faker import Faker
 from forms.models import FormField, FormPage
 from taggit.models import slugify
 from wagtail.models import Site
@@ -12,8 +11,6 @@ from content_manager.models import ContentPage, MegaMenu, MegaMenuCategory
 
 
 ALL_ALLOWED_SLUGS = ["blog_index", "publications", "menu_page", "form"]
-
-fake = Faker("fr_FR")
 
 
 class Command(BaseCommand):
@@ -157,8 +154,8 @@ class Command(BaseCommand):
 
                 body = []
                 text = ""
-                for p in fake.paragraphs():
-                    text += f"<p>{p}</p>\n"
+                for i in range(10):
+                    text += "<p> blabla +</p>\n"
                     body.append(("paragraph", RichText(text)))
 
                 new_page = self.create_content_page(

--- a/lemarche/companies/factories.py
+++ b/lemarche/companies/factories.py
@@ -9,7 +9,7 @@ class CompanyFactory(DjangoModelFactory):
         model = Company
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("company", locale="fr_FR")
+    name = factory.Sequence("Some Company N°:{0}".format)
     # slug: auto-generated
     website = "https://example.com"
 

--- a/lemarche/conversations/factories.py
+++ b/lemarche/conversations/factories.py
@@ -9,20 +9,17 @@ class ConversationFactory(DjangoModelFactory):
     class Meta:
         model = Conversation
 
-    title = factory.Faker("name", locale="fr_FR")
-    sender_first_name = factory.Faker("name", locale="fr_FR")
-    sender_last_name = factory.Faker("name", locale="fr_FR")
+    title = "Some Conversation Title"
+    sender_first_name = "Jean"
+    sender_last_name = "Lejean"
     sender_email = factory.Sequence("email{0}@inclusion.gouv.fr".format)
     siae = factory.SubFactory(SiaeFactory)
-    initial_body_message = factory.Faker("name", locale="fr_FR")
+    initial_body_message = "Bien ou bien ?"
 
 
 class EmailGroupFactory(DjangoModelFactory):
     class Meta:
         model = EmailGroup
-
-    display_name = factory.Faker("name", locale="fr_FR")
-    description = factory.Faker("name", locale="fr_FR")
 
 
 class TemplateTransactionalFactory(DjangoModelFactory):
@@ -30,6 +27,6 @@ class TemplateTransactionalFactory(DjangoModelFactory):
         model = TemplateTransactional
         django_get_or_create = ("code",)
 
-    name = factory.Faker("name", locale="fr_FR")
-    code = factory.Faker("name", locale="fr_FR")
+    name = "Some TemplateTransactional"
+    code = "FAKE_CODE"
     group = factory.SubFactory(EmailGroupFactory)

--- a/lemarche/cpv/factories.py
+++ b/lemarche/cpv/factories.py
@@ -1,4 +1,4 @@
-import factory.fuzzy
+import factory
 from factory.django import DjangoModelFactory
 
 from lemarche.cpv.models import Code

--- a/lemarche/cpv/factories.py
+++ b/lemarche/cpv/factories.py
@@ -1,5 +1,3 @@
-import string
-
 import factory.fuzzy
 from factory.django import DjangoModelFactory
 
@@ -11,9 +9,9 @@ class CodeFactory(DjangoModelFactory):
         model = Code
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = factory.Sequence("Some Code name N°:{0}".format)
     # slug: auto-generated
-    cpv_code = factory.fuzzy.FuzzyText(length=8, chars=string.digits)
+    cpv_code = "12345678"
 
     @factory.post_generation
     def sectors(self, create, extracted, **kwargs):

--- a/lemarche/favorites/factories.py
+++ b/lemarche/favorites/factories.py
@@ -9,7 +9,7 @@ class FavoriteListFactory(DjangoModelFactory):
         model = FavoriteList
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("company", locale="fr_FR")
+    name = "Some FavoriteList"
     # slug: auto-generated
 
     @factory.post_generation

--- a/lemarche/labels/factories.py
+++ b/lemarche/labels/factories.py
@@ -9,7 +9,6 @@ class LabelFactory(DjangoModelFactory):
         model = Label
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("company", locale="fr_FR")
     # slug: auto-generated
     website = "https://example.com"
 

--- a/lemarche/networks/factories.py
+++ b/lemarche/networks/factories.py
@@ -9,7 +9,7 @@ class NetworkFactory(DjangoModelFactory):
         model = Network
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("company", locale="fr_FR")
+    name = "Some Network"
     # slug: auto-generated
     website = "https://example.com"
 

--- a/lemarche/notes/factories.py
+++ b/lemarche/notes/factories.py
@@ -1,4 +1,3 @@
-import factory
 from factory.django import DjangoModelFactory
 
 from lemarche.notes.models import Note
@@ -8,4 +7,4 @@ class NoteFactory(DjangoModelFactory):
     class Meta:
         model = Note
 
-    text = factory.Faker("paragraph", nb_sentences=2, locale="fr_FR")
+    text = "Ceci est une note de test"

--- a/lemarche/perimeters/factories.py
+++ b/lemarche/perimeters/factories.py
@@ -1,19 +1,17 @@
 import factory
-import factory.fuzzy
 from django.contrib.gis.geos import Point
 from factory.django import DjangoModelFactory
 
 from lemarche.perimeters.models import Perimeter
-from lemarche.siaes.models import Siae
 
 
 class PerimeterFactory(DjangoModelFactory):
     class Meta:
         model = Perimeter
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = "Paris"
     # slug: auto-generated
     kind = Perimeter.KIND_CITY
     insee_code = factory.Sequence(lambda n: n)
     coords = Point(48.86385199985207, 2.337071483848432)  # Paris
-    department_code = factory.fuzzy.FuzzyChoice([key for (key, value) in Siae.DEPARTMENT_CHOICES])
+    department_code = "75"

--- a/lemarche/sectors/factories.py
+++ b/lemarche/sectors/factories.py
@@ -8,7 +8,7 @@ class SectorGroupFactory(DjangoModelFactory):
     class Meta:
         model = SectorGroup
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = factory.Sequence("Some SectorGroup N°:{0}".format)
     # slug auto-generated
 
 
@@ -17,7 +17,7 @@ class SectorFactory(DjangoModelFactory):
         model = Sector
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = factory.Sequence("Some Sector N°:{0}".format)
     # slug auto-generated
     group = factory.SubFactory(SectorGroupFactory)
 

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -93,25 +93,21 @@ class SiaeOfferFactory(DjangoModelFactory):
     class Meta:
         model = SiaeOffer
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = "Some SiaeOffer"
 
 
 class SiaeClientReferenceFactory(DjangoModelFactory):
     class Meta:
         model = SiaeClientReference
 
-    name = factory.Faker("name", locale="fr_FR")
-
 
 class SiaeLabelOldFactory(DjangoModelFactory):
     class Meta:
         model = SiaeLabelOld
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = "Some SiaeLabelOld"
 
 
 class SiaeImageFactory(DjangoModelFactory):
     class Meta:
         model = SiaeImage
-
-    name = factory.Faker("name", locale="fr_FR")

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -1,6 +1,4 @@
-import string
-
-import factory.fuzzy
+import factory
 from factory.django import DjangoModelFactory
 
 from lemarche.sectors.factories import SectorGroupFactory
@@ -21,7 +19,7 @@ class SiaeGroupFactory(DjangoModelFactory):
         model = SiaeGroup
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("company", locale="fr_FR")
+    name = factory.Sequence("Some SiaeGroup{0}".format)
     # slug auto-generated
 
     @factory.post_generation
@@ -35,20 +33,20 @@ class SiaeFactory(DjangoModelFactory):
         model = Siae
         skip_postgeneration_save = True
 
-    name = factory.Faker("company", locale="fr_FR")
+    name = factory.Sequence("Some Siae N°{0}".format)
     # slug auto-generated
     kind = siae_constants.KIND_EI
-    nature = factory.fuzzy.FuzzyChoice([key for (key, value) in siae_constants.NATURE_CHOICES])
+    nature = [siae_constants.NATURE_HEAD_OFFICE]
     # Don't start a SIRET with 0.
-    siret = factory.fuzzy.FuzzyText(length=13, chars=string.digits, prefix="1")
-    address = factory.Faker("street_address", locale="fr_FR")
-    city = factory.Faker("city", locale="fr_FR")
-    post_code = factory.Faker("postalcode")
+    siret = "1234567891234"
+    address = "1 rue de la paix"
+    city = "Rennes"
+    post_code = "35000"
     department = "35"
     region = "Bretagne"
     contact_email = factory.Sequence("siae_contact_email{0}@inclusion.gouv.fr".format)
-    contact_first_name = factory.Faker("name", locale="fr_FR")
-    contact_last_name = factory.Faker("name", locale="fr_FR")
+    contact_first_name = "Jean"
+    contact_last_name = "Lejean"
 
     @factory.post_generation
     def users(self, create, extracted, **kwargs):
@@ -70,7 +68,7 @@ class SiaeActivityFactory(DjangoModelFactory):
         with_country_perimeter = factory.Trait(geo_range=siae_constants.GEO_RANGE_COUNTRY)
         with_custom_distance_perimeter = factory.Trait(
             geo_range=siae_constants.GEO_RANGE_CUSTOM,
-            geo_range_custom_distance=factory.fuzzy.FuzzyInteger(1, 100),
+            geo_range_custom_distance=30,
         )
         with_zones_perimeter = factory.Trait(geo_range=siae_constants.GEO_RANGE_ZONES)
 

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -472,7 +472,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         mock_requests_get.return_value.status_code = 200
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        SiaeFactory()
+        SiaeFactory(siret="1222222222222")
         self.siae.refresh_from_db()
 
         out = StringIO()

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -15,7 +15,7 @@ class TenderFactory(DjangoModelFactory):
         model = Tender
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    title = factory.Faker("name", locale="fr_FR")
+    title = factory.Sequence("Some TenderFactory Title N°{0}".format)
     # slug auto-generated
     kind = tender_constants.KIND_QUOTE
     presta_type = []
@@ -68,7 +68,7 @@ class TenderQuestionFactory(DjangoModelFactory):
     class Meta:
         model = TenderQuestion
 
-    text = factory.Faker("paragraph", nb_sentences=1, locale="fr_FR")
+    text = "Est ce que donnez des échantillons gratuits ?"
 
 
 class PartnerShareTenderFactory(DjangoModelFactory):
@@ -76,9 +76,9 @@ class PartnerShareTenderFactory(DjangoModelFactory):
         model = PartnerShareTender
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = factory.Faker("name", locale="fr_FR")
+    name = "Some PartnerShare Name"
 
-    contact_email_list = factory.LazyFunction(lambda: [factory.Faker("email", locale="fr_FR") for i in range(4)])
+    contact_email_list = ["email.partenaire1@test.com", "email.partenaire2@test.com"]
 
     @factory.post_generation
     def perimeters(self, create, extracted, **kwargs):

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -24,8 +24,8 @@ class TenderFactory(DjangoModelFactory):
         tender_constants.RESPONSE_KIND_TEL,
         tender_constants.RESPONSE_KIND_EXTERNAL,
     ]
-    description = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
-    constraints = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
+    description = "Ceci est un pagagraphe de test"
+    constraints = "Ceci est un pagagraphe de test"
     deadline_date = date.today() + timedelta(days=10)
     start_working_date = date.today() + timedelta(days=50)
     author = factory.SubFactory(UserFactory)

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -1,7 +1,6 @@
-import random
 from datetime import date, timedelta
 
-import factory.fuzzy
+import factory
 from django.utils import timezone
 from factory.django import DjangoModelFactory
 
@@ -20,24 +19,22 @@ class TenderFactory(DjangoModelFactory):
     # slug auto-generated
     kind = tender_constants.KIND_QUOTE
     presta_type = []
-    response_kind = factory.List(
-        [
-            factory.fuzzy.FuzzyChoice([key for (key, _) in tender_constants.RESPONSE_KIND_CHOICES]),
-        ]
-    )
+    response_kind = [
+        tender_constants.RESPONSE_KIND_EMAIL,
+        tender_constants.RESPONSE_KIND_TEL,
+        tender_constants.RESPONSE_KIND_EXTERNAL,
+    ]
     description = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
     constraints = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
     deadline_date = date.today() + timedelta(days=10)
-    start_working_date = date.today() + timedelta(days=random.randint(12, 90))
+    start_working_date = date.today() + timedelta(days=50)
     author = factory.SubFactory(UserFactory)
     external_link = "https://www.example.com"
     # Contact fields
     contact_first_name = factory.Sequence("first_name{0}".format)
     contact_last_name = factory.Sequence("last_name{0}".format)
     contact_email = factory.Sequence("email_contact_tender{0}@example.com".format)
-    contact_phone = "0123456789"  # factory.fuzzy.FuzzyText(length=10, chars=string.digits)
-    # amount = tender_constants.AMOUNT_RANGE_100_150
-    # marche_benefits = factory.fuzzy.FuzzyChoice([key for (key, _) in constants.MARCHE_BENEFIT_CHOICES])
+    contact_phone = "0123456789"
     status = tender_constants.STATUS_SENT
     validated_at = timezone.now()
     first_sent_at = timezone.now()
@@ -81,9 +78,7 @@ class PartnerShareTenderFactory(DjangoModelFactory):
 
     name = factory.Faker("name", locale="fr_FR")
 
-    contact_email_list = factory.LazyFunction(
-        lambda: [factory.Faker("email", locale="fr_FR") for i in range(random.randint(1, 4))]
-    )
+    contact_email_list = factory.LazyFunction(lambda: [factory.Faker("email", locale="fr_FR") for i in range(4)])
 
     @factory.post_generation
     def perimeters(self, create, extracted, **kwargs):

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -15,7 +15,7 @@ class TenderFactory(DjangoModelFactory):
         model = Tender
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    title = factory.Sequence("Some TenderFactory Title N°{0}".format)
+    title = factory.Faker("name", locale="fr_FR")
     # slug auto-generated
     kind = tender_constants.KIND_QUOTE
     presta_type = []
@@ -68,7 +68,7 @@ class TenderQuestionFactory(DjangoModelFactory):
     class Meta:
         model = TenderQuestion
 
-    text = "Est ce que donnez des échantillons gratuits ?"
+    text = factory.Faker("paragraph", nb_sentences=1, locale="fr_FR")
 
 
 class PartnerShareTenderFactory(DjangoModelFactory):
@@ -76,9 +76,9 @@ class PartnerShareTenderFactory(DjangoModelFactory):
         model = PartnerShareTender
         skip_postgeneration_save = True  # Prevents unnecessary save
 
-    name = "Some PartnerShare Name"
+    name = factory.Faker("name", locale="fr_FR")
 
-    contact_email_list = ["email.partenaire1@test.com", "email.partenaire2@test.com"]
+    contact_email_list = factory.LazyFunction(lambda: [factory.Faker("email", locale="fr_FR") for i in range(4)])
 
     @factory.post_generation
     def perimeters(self, create, extracted, **kwargs):

--- a/lemarche/tenders/tests/test_matching.py
+++ b/lemarche/tenders/tests/test_matching.py
@@ -18,8 +18,10 @@ class TenderMatchingActivitiesTest(TestCase):
         cls.sectors = [SectorFactory() for i in range(10)]
         cls.other_sector = SectorFactory()
         cls.perimeter_paris = PerimeterFactory(department_code="75", post_codes=["75019", "75018"])
-        cls.perimeter_marseille = PerimeterFactory(coords=Point(43.35101634452076, 5.379616625955892))
-        cls.perimeters = [cls.perimeter_paris, PerimeterFactory()]
+        cls.perimeter_marseille = PerimeterFactory(
+            name="Marseille", department_code="13", coords=Point(43.35101634452076, 5.379616625955892)
+        )
+        cls.perimeters = [cls.perimeter_paris, cls.perimeter_marseille]
         # by default is Paris
         coords_paris = Point(48.86385199985207, 2.337071483848432)
 
@@ -159,7 +161,9 @@ class TenderMatchingActivitiesTest(TestCase):
         siae_marseille_activity.sectors.add(self.sectors[0])
 
         # create tender in Azay-le-rideau (near Tours ~25km)
-        perimeter_azaylerideau = PerimeterFactory(coords=Point(47.262352, 0.466372))
+        perimeter_azaylerideau = PerimeterFactory(
+            name="Azay-le-rideau", department_code="37", coords=Point(47.262352, 0.466372)
+        )
         tender = TenderFactory(
             location=perimeter_azaylerideau,
             distance_location=30,

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -861,15 +861,17 @@ class TenderSiaeModelAndQuerysetTest(TestCase):
 
 
 class TenderAdminTest(TestCase):
-    def setUp(cls):
+    @classmethod
+    def setUpTestData(cls):
         cls.factory = RequestFactory()
         cls.site = MarcheAdminSite()
         cls.admin = TenderAdmin(Tender, cls.site)
         cls.user = User.objects.create_superuser(email="admin@example.com", password="admin")
         cls.sectors = [SectorFactory() for i in range(10)]
         cls.perimeter_paris = PerimeterFactory(department_code="75", post_codes=["75019", "75018"])
-        cls.perimeter_marseille = PerimeterFactory(coords=Point(43.35101634452076, 5.379616625955892))
-        cls.perimeters = [cls.perimeter_paris, PerimeterFactory()]
+        cls.perimeter_marseille = PerimeterFactory(
+            name="Marseille", department_code="13", coords=Point(43.35101634452076, 5.379616625955892)
+        )
         # by default is Paris
         coords_paris = Point(48.86385199985207, 2.337071483848432)
 

--- a/lemarche/users/factories.py
+++ b/lemarche/users/factories.py
@@ -1,7 +1,6 @@
 import functools
-import string
 
-import factory.fuzzy
+import factory
 from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
 
@@ -25,7 +24,7 @@ class UserFactory(DjangoModelFactory):
     last_name = factory.Sequence("last_name{0}".format)
     email = factory.Sequence("email{0}@example.com".format)
     password = factory.LazyFunction(default_password)
-    phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
+    phone = "0666666666"
     kind = User.KIND_SIAE
 
     @factory.post_generation


### PR DESCRIPTION
### Quoi ?

Les tests aléatoires ont provoqués beaucoup de flacky tests difficiles à résoudre, sans apporter d'avantages particuliers. Le fuzzy testing peut être utilise pour détecter de nouveau cas à tester, mais pas adapté aux tests unitaires.

Dernier cas détecté dans `CompanyQuerysetTest`, la factory `CompanyFactory` était instancié deux fois, et, très rarement, le nom aléatoire choisit était le même, levant une erreur d'intégrité.

### Comment ?
Plutôt que de devoir gérer au fil de l'eau des flacky tests difficiles à remonter, supprimer toute notion d'aléatoire dans les tests pour qu'ils soient reproductibles.