### PR TITLE
chore: Mise à jour de la liste des auto assign Github

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,6 @@ addReviewers: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:  # gip-inclusion/admins-le-marche
-  - chloend
   - madjid-asa
   - SebastienReuiller
   - Guilouf


### PR DESCRIPTION
### Quoi ?

Mise à jour de la liste des auto assign Github

### Pourquoi ?

L'autoassign semble ne plus fonctionner

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Mise à jour de auto_assign.yml
