### PR TITLE
chore: Mise à jour des compteurs uniquement des besoins en cours ou expiré il y a moins d'un mois

### DIFF
--- a/lemarche/tenders/management/commands/update_tender_count_fields.py
+++ b/lemarche/tenders/management/commands/update_tender_count_fields.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from sentry_sdk.crons import monitor
 
 from lemarche.tenders.models import Tender
 from lemarche.utils.apis import api_slack
@@ -24,6 +25,7 @@ class Command(BaseCommand):
             "--fields", action="append", default=[], help="Filtrer sur les champs count à mettre à jour"
         )
 
+    @monitor(monitor_slug="update-tender-count-fields")
     def handle(self, *args, **options):
         self.stdout_messages_info("Updating Tender count fields (only for tenders not outdated a month ago)...")
 

--- a/lemarche/tenders/management/commands/update_tender_count_fields.py
+++ b/lemarche/tenders/management/commands/update_tender_count_fields.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
 from lemarche.tenders.models import Tender
 from lemarche.utils.apis import api_slack
 from lemarche.utils.commands import BaseCommand
@@ -21,10 +25,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        self.stdout_messages_info("Updating Tender count fields...")
+        self.stdout_messages_info("Updating Tender count fields (only for tenders not outdated a month ago)...")
 
         # Step 1a: build the queryset
-        tender_queryset = Tender.objects.with_siae_stats().all()
+        one_month_ago = timezone.now() - timedelta(days=30)
+        tender_queryset = Tender.objects.is_not_outdated(one_month_ago).with_siae_stats().all()
         if options["id"]:
             tender_queryset = tender_queryset.filter(id=options["id"])
         self.stdout_messages_info(f"Found {tender_queryset.count()} tenders")

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -209,9 +209,7 @@ class TenderQuerySet(models.QuerySet):
         Enrich each Tender with stats on their linked Siae
         """
         return self.annotate(
-            siae_count_annotated=Count(
-                "siaes", filter=~Q(tendersiae__source=tender_constants.TENDER_SIAE_SOURCE_AI), distinct=True
-            ),
+            siae_count_annotated=Count("siaes", distinct=True),
             siae_email_send_count_annotated=Sum(
                 Case(When(tendersiae__email_send_date__isnull=False, then=1), default=0, output_field=IntegerField())
             ),

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -212,13 +212,6 @@ class TenderQuerySet(models.QuerySet):
             siae_count_annotated=Count(
                 "siaes", filter=~Q(tendersiae__source=tender_constants.TENDER_SIAE_SOURCE_AI), distinct=True
             ),
-            siae_ai_count_annotated=Count(
-                "siaes",
-                filter=Q(
-                    tendersiae__source=tender_constants.TENDER_SIAE_SOURCE_AI,
-                ),
-                distinct=True,
-            ),
             siae_email_send_count_annotated=Sum(
                 Case(When(tendersiae__email_send_date__isnull=False, then=1), default=0, output_field=IntegerField())
             ),

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -97,8 +97,8 @@ class TenderQuerySet(models.QuerySet):
             ]
         )
 
-    def is_not_outdated(self):
-        return self.filter(Q(deadline_date__isnull=True) | Q(deadline_date__gte=datetime.today()))
+    def is_not_outdated(self, limit_date=datetime.today()):
+        return self.filter(Q(deadline_date__isnull=True) | Q(deadline_date__gte=limit_date))
 
     def is_live(self):
         return self.sent().is_not_outdated()

--- a/lemarche/tenders/tests/test_commands.py
+++ b/lemarche/tenders/tests/test_commands.py
@@ -2,7 +2,9 @@ from datetime import timedelta
 from io import StringIO
 from unittest.mock import patch
 
+import factory
 from django.core.management import call_command
+from django.db.models import signals
 from django.test import TestCase
 from django.utils import timezone
 
@@ -221,3 +223,100 @@ class UpdateTenderStatusToRejectedCommandTest(TestCase):
         self.assertEqual(tender_recent.status, tender_constants.STATUS_DRAFT)
         self.assertEqual(tender_expired.status, tender_constants.STATUS_REJECTED)
         self.assertEqual(tender_with_no_modification_request.status, tender_constants.STATUS_DRAFT)
+
+
+class UpdateTenderCountFieldsCommandTest(TestCase):
+    @factory.django.mute_signals(signals.post_save, signals.m2m_changed)
+    def test_update_count_fields(self):
+        """
+        Create two tenders with siaes, and check that the count fields are updated correctly
+        """
+        siae_1 = SiaeFactory()
+        siae_2 = SiaeFactory()
+        siae_3 = SiaeFactory()
+
+        tender_1 = TenderFactory(siaes=[siae_1, siae_2, siae_3])
+        tender_2 = TenderFactory(siaes=[siae_1, siae_2])
+
+        deadline_date = timezone.now() - timedelta(days=35)
+        tender_3 = TenderFactory(siaes=[siae_3], deadline_date=deadline_date)
+
+        TenderSiae.objects.create(
+            tender=tender_1,
+            siae=siae_1,
+            email_send_date=timezone.now(),
+            email_link_click_date=timezone.now(),
+            detail_display_date=timezone.now(),
+        )
+        TenderSiae.objects.create(
+            tender=tender_1,
+            siae=siae_2,
+            email_send_date=timezone.now(),
+            email_link_click_date=timezone.now(),
+            detail_not_interested_click_date=timezone.now(),
+            detail_not_interested_feedback="test",
+        )
+        TenderSiae.objects.create(
+            tender=tender_1,
+            siae=siae_3,
+            email_send_date=timezone.now(),
+            detail_display_date=timezone.now(),
+            detail_contact_click_date=timezone.now(),
+        )
+
+        self.assertEqual(tender_1.siae_count, 0)
+        self.assertEqual(tender_1.siae_email_send_count, 0)
+        self.assertEqual(tender_1.siae_email_link_click_count, 0)
+        self.assertEqual(tender_1.siae_detail_display_count, 0)
+        self.assertEqual(tender_1.siae_detail_contact_click_count, 0)
+        self.assertEqual(tender_1.siae_detail_not_interested_click_count, 0)
+        self.assertEqual(tender_1.siae_email_link_click_or_detail_display_count, 0)
+
+        self.assertEqual(tender_2.siae_count, 0)
+        self.assertEqual(tender_2.siae_email_send_count, 0)
+        self.assertEqual(tender_2.siae_email_link_click_count, 0)
+        self.assertEqual(tender_2.siae_detail_display_count, 0)
+        self.assertEqual(tender_2.siae_detail_contact_click_count, 0)
+        self.assertEqual(tender_2.siae_detail_not_interested_click_count, 0)
+        self.assertEqual(tender_2.siae_email_link_click_or_detail_display_count, 0)
+
+        self.assertEqual(tender_3.siae_count, 0)
+        self.assertEqual(tender_3.siae_email_send_count, 0)
+        self.assertEqual(tender_3.siae_email_link_click_count, 0)
+        self.assertEqual(tender_3.siae_detail_display_count, 0)
+        self.assertEqual(tender_3.siae_detail_contact_click_count, 0)
+        self.assertEqual(tender_3.siae_detail_not_interested_click_count, 0)
+        self.assertEqual(tender_3.siae_email_link_click_or_detail_display_count, 0)
+
+        std_out = StringIO()
+        call_command("update_tender_count_fields", stdout=std_out)
+        self.assertIn("Done! Processed 2 tenders", std_out.getvalue())
+
+        tender_1.refresh_from_db()
+        tender_2.refresh_from_db()
+        tender_3.refresh_from_db()
+
+        # two first tenders should be updated
+        self.assertEqual(tender_1.siae_count, 3)
+        self.assertEqual(tender_1.siae_email_send_count, 3)
+        self.assertEqual(tender_1.siae_email_link_click_count, 2)
+        self.assertEqual(tender_1.siae_detail_display_count, 2)
+        self.assertEqual(tender_1.siae_detail_contact_click_count, 1)
+        self.assertEqual(tender_1.siae_detail_not_interested_click_count, 1)
+        self.assertEqual(tender_1.siae_email_link_click_or_detail_display_count, 3)
+        self.assertEqual(tender_2.siae_count, 2)
+        self.assertEqual(tender_2.siae_email_send_count, 0)
+        self.assertEqual(tender_2.siae_email_link_click_count, 0)
+        self.assertEqual(tender_2.siae_detail_display_count, 0)
+        self.assertEqual(tender_2.siae_detail_contact_click_count, 0)
+        self.assertEqual(tender_2.siae_detail_not_interested_click_count, 0)
+        self.assertEqual(tender_2.siae_email_link_click_or_detail_display_count, 0)
+
+        # third tender should not be updated because it's outdated a more than 30 days ago
+        self.assertEqual(tender_3.siae_count, 0)
+        self.assertEqual(tender_3.siae_email_send_count, 0)
+        self.assertEqual(tender_3.siae_email_link_click_count, 0)
+        self.assertEqual(tender_3.siae_detail_display_count, 0)
+        self.assertEqual(tender_3.siae_detail_contact_click_count, 0)
+        self.assertEqual(tender_3.siae_detail_not_interested_click_count, 0)
+        self.assertEqual(tender_3.siae_email_link_click_or_detail_display_count, 0)


### PR DESCRIPTION
### Quoi ?

La mise à jour des compteurs ne se fait désormais que pour les besoins non clôturés et clôturés récemment (moins de 30 jours).

### Pourquoi ?

Des indisponibilités nocturnes laissent à penser que cette tâche est trop lourde.

### Comment ?

Restriction des besoins à mettre à jour.

J'ai mis un délai de 30 jours pour garder une marge, notamment lorsque le cron passe le lendemain de la clôture.