### PR TITLE
fix: Erreur du formulaire de réponse aux questions

### DIFF
--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -49,7 +49,7 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--equisized fr-btns-group--right">
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary" aria-controls="detail_contact_click_confirm_modal">Annuler</button>
+                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="detail_contact_click_confirm_modal">Annuler</button>
                                 </li>
                                 <li>
                                     <button type="submit" class="fr-btn">

--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -52,7 +52,7 @@
                                     <button class="fr-btn fr-btn--secondary" aria-controls="detail_contact_click_confirm_modal">Annuler</button>
                                 </li>
                                 <li>
-                                    <button type="submit" class="fr-btn" name="detail_contact_click_confirm" value="true">
+                                    <button type="submit" class="fr-btn">
                                     {% if questions_formset %}
                                         Envoyer mes réponses
                                     {% else %}

--- a/lemarche/templates/tenders/_detail_cta.html
+++ b/lemarche/templates/tenders/_detail_cta.html
@@ -8,7 +8,7 @@
                     {% if tender_response_is_anonymous %}
                         <form method="post" action="{% url 'tenders:detail-contact-click-stat' tender.slug %}?siae_id={{ siae_id }}">
                             {% csrf_token %}
-                            <button type="submit" class="fr-btn" name="detail_contact_click_confirm" value="true">{{ tender.cta_card_button_text|safe }}</button>
+                            <button type="submit" class="fr-btn">{{ tender.cta_card_button_text|safe }}</button>
                         </form>
                     {% else %}
                         <button type="button" id="show-tender-contact-modal-btn" class="fr-btn" data-fr-opened="false" aria-controls="detail_contact_click_confirm_modal" data-siae-id="{{ siae_id }}" title="{{ tender.cta_card_button_text|safe }}">

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -950,7 +950,10 @@ class TenderSiaeStatusFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         value = self.value()
-        return queryset.filter(status_annotated=value)
+        if value is None:
+            return queryset
+        else:
+            return queryset.filter(status_annotated=value)
 
 
 @admin.register(TenderSiae, site=admin_site)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1246,27 +1246,26 @@ class TenderDetailContactClickStatViewTest(TestCase):
         for user in [self.user_buyer_1, self.user_buyer_2, self.user_partner, self.user_admin]:
             self.client.force_login(user)
             response = self.client.post(
-                self.tender_contact_click_stat_url, data={"detail_contact_click_confirm": "false"}
+                self.tender_contact_click_stat_url,
             )
             self.assertEqual(response.status_code, 403)
         # authorized
         for user in [self.siae_user_1, self.siae_user_2]:
             self.client.force_login(user)
             response = self.client.post(
-                self.tender_contact_click_stat_url, data={"detail_contact_click_confirm": "false"}
+                self.tender_contact_click_stat_url,
             )
             self.assertEqual(response.status_code, 302)
         # authorized with siae_id parameter
         self.client.logout()
         response = self.client.post(
             f"{self.tender_contact_click_stat_url}?siae_id={self.siae.id}",
-            data={"detail_contact_click_confirm": "false"},
         )
         self.assertEqual(response.status_code, 302)
         # forbidden because wrong siae_id parameter
         self.client.logout()
         response = self.client.post(
-            f"{self.tender_contact_click_stat_url}?siae_id=test", data={"detail_contact_click_confirm": "false"}
+            f"{self.tender_contact_click_stat_url}?siae_id=test",
         )
         self.assertEqual(response.status_code, 403)
 
@@ -1289,7 +1288,6 @@ class TenderDetailContactClickStatViewTest(TestCase):
         response = self.client.post(
             self.tender_contact_click_stat_url,
             data={
-                "detail_contact_click_confirm": "true",
                 # No questions from buyer
                 "form-TOTAL_FORMS": 0,
                 "form-INITIAL_FORMS": 0,
@@ -1309,7 +1307,7 @@ class TenderDetailContactClickStatViewTest(TestCase):
         self.assertContains(response, self.cta_message_success)
         # clicking again on the button doesn't update detail_contact_click_date
         # Note: button will disappear on reload anyway
-        response = self.client.post(self.tender_contact_click_stat_url, data={"detail_contact_click_confirm": "false"})
+        response = self.client.post(self.tender_contact_click_stat_url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             self.tender.tendersiae_set.first().detail_contact_click_date, siae_2_detail_contact_click_date
@@ -1331,7 +1329,6 @@ class TenderDetailContactClickStatViewTest(TestCase):
         response = self.client.post(
             f"{self.tender_contact_click_stat_url}?siae_id={siae_2.id}",
             data={
-                "detail_contact_click_confirm": "true",
                 # No questions from buyer
                 "form-TOTAL_FORMS": 0,
                 "form-INITIAL_FORMS": 0,
@@ -1349,7 +1346,7 @@ class TenderDetailContactClickStatViewTest(TestCase):
         # clicking again on the button doesn't update detail_contact_click_date
         # Note: button will disappear on reload anyway
         response = self.client.post(
-            f"{self.tender_contact_click_stat_url}?siae_id={siae_2.id}", data={"detail_contact_click_confirm": "false"}
+            f"{self.tender_contact_click_stat_url}?siae_id={siae_2.id}",
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
@@ -1931,7 +1928,6 @@ class TenderQuestionAnswerTestCase(TestCase):
         self.assertEqual(response_get.status_code, 200)
 
         payload = {
-            "detail_contact_click_confirm": "true",
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "2",
             "form-MIN_NUM_FORMS": "0",
@@ -1968,7 +1964,6 @@ class TenderQuestionAnswerTestCase(TestCase):
 
         payload = {
             "siae": [self.siae_1.id, self.siae_2.id],
-            "detail_contact_click_confirm": "true",
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "2",
             "form-MIN_NUM_FORMS": "0",
@@ -2010,7 +2005,6 @@ class TenderQuestionAnswerTestCase(TestCase):
 
         payload = {
             "siae": [self.siae_1.id],
-            "detail_contact_click_confirm": "true",
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "2",
             "form-MIN_NUM_FORMS": "0",
@@ -2048,7 +2042,6 @@ class TenderQuestionAnswerTestCase(TestCase):
         self.assertEqual(response_get.status_code, 200)
 
         payload = {
-            "detail_contact_click_confirm": "true",
             "form-TOTAL_FORMS": "2",
             "form-INITIAL_FORMS": "2",
             "form-MIN_NUM_FORMS": "0",

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -547,7 +547,6 @@ class TenderDetailContactClickStatView(SiaeUserRequiredOrSiaeIdParamMixin, Updat
 
     def post(self, request, *args, **kwargs):
         user = self.request.user
-        detail_contact_click_confirm = self.request.POST.get("detail_contact_click_confirm", False) == "true"
         self.answers_formset = self.answers_formset_class(data=self.request.POST)
         if user.is_authenticated:
             if siae_list := self.request.POST.getlist("siae"):
@@ -557,62 +556,49 @@ class TenderDetailContactClickStatView(SiaeUserRequiredOrSiaeIdParamMixin, Updat
         else:
             siae_qs = Siae.objects.filter(id=self.siae_id)
 
-        if detail_contact_click_confirm:
-            if self.answers_formset.is_valid():
-                for answer_form in self.answers_formset:
-                    for siae in siae_qs:  # We copy the answer for each selected siae
-                        QuestionAnswer.objects.create(
-                            question=answer_form.cleaned_data["question"],
-                            answer=answer_form.cleaned_data["answer"],
-                            siae=siae,
-                        )
-            else:
-                messages.add_message(
-                    self.request, messages.ERROR, "Une erreur a eu lieu lors de la soumission du formulaire"
-                )
-                return HttpResponseRedirect(self.get_success_url(detail_contact_click_confirm, self.siae_id))
-
-            # update detail_contact_click_date
-            if user.is_authenticated:
-                TenderSiae.objects.filter(
-                    tender=self.object, siae__in=siae_qs, detail_contact_click_date__isnull=True
-                ).update(user=user, detail_contact_click_date=timezone.now(), updated_at=timezone.now())
-            else:
-                TenderSiae.objects.filter(
-                    tender=self.object, siae__in=siae_qs, detail_contact_click_date__isnull=True
-                ).update(detail_contact_click_date=timezone.now(), updated_at=timezone.now())
-
-            # notify the tender author
-            send_siae_interested_email_to_author(self.object)
-            messages.add_message(
-                self.request, messages.SUCCESS, self.get_success_message(detail_contact_click_confirm)
-            )
+        if self.answers_formset.is_valid():
+            for answer_form in self.answers_formset:
+                for siae in siae_qs:  # We copy the answer for each selected siae
+                    QuestionAnswer.objects.create(
+                        question=answer_form.cleaned_data["question"],
+                        answer=answer_form.cleaned_data["answer"],
+                        siae=siae,
+                    )
         else:
             messages.add_message(
-                self.request, messages.WARNING, self.get_success_message(detail_contact_click_confirm)
+                self.request, messages.ERROR, "Une erreur a eu lieu lors de la soumission du formulaire"
             )
-        # redirect
-        return HttpResponseRedirect(self.get_success_url(detail_contact_click_confirm, self.siae_id))
+            return HttpResponseRedirect(self.get_success_url(self.siae_id))
 
-    def get_success_url(self, detail_contact_click_confirm, siae_id=None):
+        # update detail_contact_click_date
+        if user.is_authenticated:
+            TenderSiae.objects.filter(
+                tender=self.object, siae__in=siae_qs, detail_contact_click_date__isnull=True
+            ).update(user=user, detail_contact_click_date=timezone.now(), updated_at=timezone.now())
+        else:
+            TenderSiae.objects.filter(
+                tender=self.object, siae__in=siae_qs, detail_contact_click_date__isnull=True
+            ).update(detail_contact_click_date=timezone.now(), updated_at=timezone.now())
+
+        # notify the tender author
+        send_siae_interested_email_to_author(self.object)
+        messages.add_message(self.request, messages.SUCCESS, self.get_success_message())
+
+        # redirect
+        return HttpResponseRedirect(self.get_success_url(self.siae_id))
+
+    def get_success_url(self, siae_id=None):
         success_url = reverse_lazy("tenders:detail", args=[self.kwargs.get("slug")])
-        if detail_contact_click_confirm:
-            success_url += "?nps=true"
-            if siae_id:
-                success_url += f"&siae_id={siae_id}"
+        success_url += "?nps=true"
+        if siae_id:
+            success_url += f"&siae_id={siae_id}"
         return success_url
 
-    def get_success_message(self, detail_contact_click_confirm):
-        if detail_contact_click_confirm:
-            return (
-                "<strong>Bravo !</strong><br />"
-                "Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur."
-                " Assurez-vous d'avoir une fiche commerciale bien renseignée."
-            )
+    def get_success_message(self):
         return (
-            f"<strong>{self.object.cta_card_button_text}</strong><br />"
-            f"Pour {self.object.cta_card_button_text.lower()},"
-            f" vous devez accepter d'être mis en relation avec l'acheteur."
+            "<strong>Bravo !</strong><br />"
+            "Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur."
+            " Assurez-vous d'avoir une fiche commerciale bien renseignée."
         )
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
### Quoi ?
 Quand un utilisateur répondait aux questions, il pouvait faire un retour en arrière avec le navigateur et essayer de soumettre une deuxième fois, déclenchant une erreur 500 à cause d'une contrainte d'intégrité.

### Comment ?

Une transaction et mise en place pour annuler toutes les questions en cas d'erreur, et une redirection avec un message d'erreur est effectuée au lieu de l'erreur 500.