### PR TITLE
fix: CSRF error des DDB

### DIFF
--- a/lemarche/templates/tenders/create_step_confirmation.html
+++ b/lemarche/templates/tenders/create_step_confirmation.html
@@ -35,33 +35,3 @@
         </button>
     </li>
 {% endblock submit_btn %}
-{% block extra_js %}
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    let formPreviousButton = document.getElementById('tender-create-form-previous-step-btn');
-    let formDraftButton = document.getElementById('tender-create-draft-form-btn');
-    let formSubmitButton = document.getElementById('tender-create-form-submit-btn');
-    let formSubmitAboveButton = document.getElementById('tender-create-form-submit-above-btn');
-
-    function submitForm() {
-        $(formPreviousButton).prop('disabled', true);
-        $(formDraftButton).prop('disabled', true);
-        $(formSubmitButton).prop('disabled', true);
-        $(formSubmitAboveButton).prop('disabled', true);
-        const body = document.querySelector('body');
-        let loader = '<div class="loader-in-all-page"><div class="loader-inner"></div></div>'
-        body.innerHTML += loader;
-        setTimeout(function() {
-            $('form').submit();
-        }, 1000);
-    };
-
-    formSubmitButton.addEventListener('click', function(e) {
-        submitForm();
-    });
-    formSubmitAboveButton.addEventListener('click', function(e) {
-        submitForm();
-    });
-});
-</script>
-{% endblock %}


### PR DESCRIPTION
### Quoi ?

Pour certaines personnes, sur le formulaire de DDB au moment de cliquer sur "Publier et diffuser" une erreur CSRF se déclenchait. Après examen, le payload POST contenait seulement `{"message":""}`, sans aucun rapport avec le formulaire, et donc sans le token CSRF.

### Pourquoi ?

Une histoire de cache ?

### Comment ?

Du code javascript, non documenté et d'une utilité pour le moins mystérieuse a été supprimé, sans suppression apparente de fonctionnalité. Les tests réalisés sans ce code ne donnent pas sur des erreurs CSRF.