### PR TITLE
feat(API): ajout de la notion de dépendance économique à l'évaluation du potentiel inclusif

### DIFF
--- a/lemarche/api/inclusive_potential/constants.py
+++ b/lemarche/api/inclusive_potential/constants.py
@@ -1,0 +1,66 @@
+RECOMMENDATIONS = {
+    "reservation": {
+        "title": "Réservation totale",
+        "response": "Vous pouvez réserver l’ensemble de votre projet d’achat à des fournisseurs inclusifs !",
+        "explanation": (
+            "Après analyse, nous identifions {siaes_count} fournisseurs potentiels avec un taux de "
+            "dépendance économique moyen de {eco_dependency}% et un chiffre d'affaires moyen de {ca_average}€.\n\n"
+            "Votre projet d'achat présente donc un fort potentiel inclusif. L'analyse croisée du nombre de "
+            "fournisseurs inclusifs et le niveau de dépendance économique démontre que l'offre locale est suffisante "
+            "et bien dimensionnée pour répondre à l'ensemble de votre projet d'achat.\n\n"
+            "Vous pouvez donc envisager de réserver l'ensemble du marché à des fournisseurs inclusifs (art. L.2113-12"
+            " et 13, L.3113-2-1), si le besoin est homogène."
+        ),
+    },
+    "lot": {
+        "title": "Lot réservé",
+        "response": "Vous pouvez allotir votre projet d'achat et en réserver certains lots !",
+        "explanation": (
+            "Après analyse, nous identifions {siaes_count} fournisseurs potentiels avec un taux de "
+            "dépendance économique moyen de {eco_dependency}% et un chiffre d'affaires moyen de {ca_average}€.\n\n"
+            "Votre projet d'achat a donc un très bon potentiel inclusif, mais il ne peut pas être totalement couvert "
+            "par un fournisseur inclusif seul car l'offre n'est pas suffisamment dimensionnée pour répondre à "
+            "l'ensemble de votre projet.\n\n"
+            "Cependant, nous vous recommandons d'allotir votre projet d'achat et d'en réserver un ou plusieurs lots "
+            "pour n'en réserver qu'une partie à des fournisseurs inclusifs."
+        ),
+    },
+    "clause": {
+        "title": "Clause sociale d'exécution",
+        "response": "Vous pouvez intégrer une clause sociale d'exécution dans votre projet d'achat !",
+        "explanation": (
+            "Après analyse, nous identifions {siaes_count} fournisseurs potentiels avec un taux de "
+            "dépendance économique moyen de {eco_dependency}% et un chiffre d'affaires moyen de {ca_average}€.\n\n"
+            "Votre projet d'achat a donc un bon potentiel inclusif, mais il ne peut pas être totalement couvert par "
+            "un fournisseur inclusif seul car l'analyse économique de l'offre inclusive montre des risques de "
+            "dépendances économiques. Cependant, nous vous recommandons d'opter pour l'intégration d'une clause "
+            "sociale d'insertion (art. L.2112-2), c'est-à-dire une obligation pour le titulaire du marché de "
+            "réaliser un volume d'heures d'insertion (ex : embaucher une personne éloignée de l'emploi ou "
+            "sous-traiter à un fournisseur inclusif)."
+            "Cette clause permet d'agir sans modifier profondément la procédure."
+        ),
+    },
+    "critere": {
+        "title": "Critère social d'attribution",
+        "response": "Vous pouvez introduire un critère social dans l'analyse des offres !",
+        "explanation": (
+            "Après analyse, nous identifions {siaes_count} fournisseurs potentiels avec un taux de "
+            "dépendance économique moyen de {eco_dependency}% et un chiffre d'affaires moyen de {ca_average}€.\n\n"
+            "L'analyse montre un potentiel inclusif faible : l'offre inclusive locale est limitée pour justifier une "
+            "clause ou une réservation. Mais vous pouvez toujours introduire un critère social dans l'analyse des "
+            "offres (art. R.2152-7). Ce critère permet de valoriser les soumissionnaires qui font des efforts pour "
+            "embaucher localement, travailler avec le secteur de l'inclusion, former du public, etc. Ce levier est "
+            "pertinent pour encourager des pratiques responsables sans contraindre le déroulement de votre marché."
+        ),
+    },
+    "aucun": {
+        "title": "Aucun potentiel inclusif identifié",
+        "response": "Malheureusement, le potentiel inclusif de votre projet d'achat est trop faible !",
+        "explanation": (
+            "Votre projet d'achat ne permet pas, à ce stade, d'intégrer un dispositif inclusif : il génère trop de "
+            "dépendance économique ou il n'existe aucun fournisseur inclusif en capacité d'y répondre dans votre zone "
+            "géographique. Cependant, pour vérifier la faisabilité de votre projet d'achat, nous vous "
+            "recommandons de lancer un sourcing inversé sur le Marché de l'inclusion."
+        ),
+    },
+}

--- a/lemarche/api/inclusive_potential/serializers.py
+++ b/lemarche/api/inclusive_potential/serializers.py
@@ -22,3 +22,4 @@ class InclusivePotentialQuerySerializer(serializers.Serializer):
             "does_not_exist": "Le périmètre avec ce slug n'existe pas.",
         },
     )
+    budget = serializers.IntegerField(required=False)

--- a/lemarche/api/inclusive_potential/serializers.py
+++ b/lemarche/api/inclusive_potential/serializers.py
@@ -22,4 +22,10 @@ class InclusivePotentialQuerySerializer(serializers.Serializer):
             "does_not_exist": "Le périmètre avec ce slug n'existe pas.",
         },
     )
-    budget = serializers.IntegerField(required=False)
+    budget = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        error_messages={
+            "min_value": "Le budget doit être un nombre positif.",
+        },
+    )

--- a/lemarche/api/inclusive_potential/tests.py
+++ b/lemarche/api/inclusive_potential/tests.py
@@ -56,6 +56,14 @@ class InclusivePotentialViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_no_siaes(self):
+        """Test with no siaes"""
+        other_sector = SectorFactory(group=self.sector.group)
+        response = self.authenticated_client.get(self.url, {"sector": other_sector.slug})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["potential_siaes"], 0)
+
     def test_with_sector_and_perimeter(self):
         """Test with valid sector and perimeter"""
 
@@ -71,6 +79,11 @@ class InclusivePotentialViewTests(TestCase):
         self.assertEqual(response.data["insertion_siaes"], 2)
         self.assertEqual(response.data["handicap_siaes"], 1)
         self.assertEqual(response.data["siaes_with_super_badge"], 1)
+
+        # if there is no budget, there is no recommendation
+        self.assertNotIn("recommendation", response.data)
+        self.assertNotIn("ca_average", response.data)
+        self.assertNotIn("eco_dependency", response.data)
 
     def test_with_sector_only(self):
         """Test with only a valid sector (without perimeter)"""
@@ -98,3 +111,68 @@ class InclusivePotentialViewTests(TestCase):
         self.assertEqual(response.data["ca_average"], 600000)
         # 100000 / 600000 * 100 = 16.67 -> round to 17
         self.assertEqual(response.data["eco_dependency"], 17)
+        self.assertEqual(response.data["recommendation"]["title"], "Clause sociale d'exécution")
+
+    def test_recommendation_more_than_30_siaes(self):
+        """
+        Test with more than 30 siaes
+        Create 31 siaes with CA values take times but it's necessary for the calculation of ca average and eco dep
+        """
+        # Specific sector with 31 siaes to avoid interference with existing SIAEs and avoid random failure
+        specific_sector = SectorFactory(group=self.sector.group)
+        # Create 31 SIAEs with CA values
+        siaes = SiaeFactory.create_batch(31, ca=1000000)
+        for siae in siaes:
+            siae_activity_1 = SiaeActivityFactory(
+                siae=siae,
+                sector_group=specific_sector.group,
+                with_zones_perimeter=True,
+            )
+            siae_activity_1.sectors.add(specific_sector)
+            siae_activity_1.locations.set([self.perimeter_department])
+
+        response = self.authenticated_client.get(self.url, {"sector": specific_sector.slug, "budget": 50000})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["potential_siaes"], 31)
+        self.assertEqual(response.data["ca_average"], 1000000)
+        self.assertEqual(response.data["eco_dependency"], 5.0)  # 50000 / 1000000 * 100
+        self.assertEqual(response.data["recommendation"]["title"], "Réservation totale")
+
+        response = self.authenticated_client.get(self.url, {"sector": specific_sector.slug, "budget": 500000})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["potential_siaes"], 31)
+        self.assertEqual(response.data["ca_average"], 1000000)
+        self.assertEqual(response.data["eco_dependency"], 50.0)  # 500000 / 1000000 * 100
+        self.assertEqual(response.data["recommendation"]["title"], "Lot réservé")
+
+    def test_recommendation_more_than_10_siaes(self):
+        # Specific sector with 11 siaes
+        specific_sector = SectorFactory(group=self.sector.group)
+        # Create 11 SIAEs with CA values
+        siaes = SiaeFactory.create_batch(11, ca=1000000)
+        for siae in siaes:
+            siae_activity_1 = SiaeActivityFactory(
+                siae=siae,
+                sector_group=specific_sector.group,
+                with_zones_perimeter=True,
+            )
+            siae_activity_1.sectors.add(specific_sector)
+            siae_activity_1.locations.set([self.perimeter_department])
+
+        response = self.authenticated_client.get(self.url, {"sector": specific_sector.slug, "budget": 50000})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["potential_siaes"], 11)
+        self.assertEqual(response.data["recommendation"]["title"], "Lot réservé")
+
+    def test_recommendation_no_siae(self):
+        # Specific sector with 0 siaes
+        specific_sector = SectorFactory(group=self.sector.group)
+
+        response = self.authenticated_client.get(self.url, {"sector": specific_sector.slug, "budget": 50000})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["potential_siaes"], 0)
+        self.assertEqual(response.data["recommendation"]["title"], "Aucun potentiel inclusif identifié")

--- a/lemarche/api/inclusive_potential/tests.py
+++ b/lemarche/api/inclusive_potential/tests.py
@@ -95,5 +95,6 @@ class InclusivePotentialViewTests(TestCase):
         self.assertEqual(response.data["potential_siaes"], 3)
 
         # siaes with ca: 200000 + 1000000 = 1200000 (2 siaes so avg = 600000)
+        self.assertEqual(response.data["ca_average"], 600000)
         # 100000 / 600000 * 100 = 16.67
         self.assertEqual(response.data["eco_dependency"], 16.67)

--- a/lemarche/api/inclusive_potential/tests.py
+++ b/lemarche/api/inclusive_potential/tests.py
@@ -50,9 +50,9 @@ class InclusivePotentialViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_invalid_budget(self):
-        """Test with an invalid budget"""
-        response = self.authenticated_client.get(self.url, {"sector": self.sector.slug, "budget": "cent"})
+    def test_negative_budget(self):
+        """Test with a negative budget"""
+        response = self.authenticated_client.get(self.url, {"sector": self.sector.slug, "budget": -1})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -96,5 +96,5 @@ class InclusivePotentialViewTests(TestCase):
 
         # siaes with ca: 200000 + 1000000 = 1200000 (2 siaes so avg = 600000)
         self.assertEqual(response.data["ca_average"], 600000)
-        # 100000 / 600000 * 100 = 16.67
-        self.assertEqual(response.data["eco_dependency"], 16.67)
+        # 100000 / 600000 * 100 = 16.67 -> round to 17
+        self.assertEqual(response.data["eco_dependency"], 17)

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -42,8 +42,8 @@ class InclusivePotentialView(APIView):
             ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
 
             if ca_values:
-                ca_average = sum(ca_values) / len(ca_values)
-                eco_dependency = round(budget / ca_average * 100, 2)
+                ca_average = round(sum(ca_values) / len(ca_values))
+                eco_dependency = round(budget / ca_average * 100)
 
         return Response(
             {

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -36,6 +36,7 @@ class InclusivePotentialView(APIView):
                 siaes_with_super_badge += 1
 
         eco_dependency = None
+        ca_average = None
         if budget:
             # Get all valid CA values from siaes
             ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
@@ -54,5 +55,6 @@ class InclusivePotentialView(APIView):
                 "handicap_siaes": handicap_siaes,
                 "siaes_with_super_badge": siaes_with_super_badge,
                 "eco_dependency": eco_dependency,
+                "ca_average": ca_average,
             }
         )

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from lemarche.api.inclusive_potential.constants import RECOMMENDATIONS
 from lemarche.api.inclusive_potential.serializers import InclusivePotentialQuerySerializer
 from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
 from lemarche.siaes.models import Siae
@@ -9,11 +10,8 @@ from lemarche.siaes.models import Siae
 
 class InclusivePotentialView(APIView):
 
-    @extend_schema(
-        parameters=[InclusivePotentialQuerySerializer],
-        responses={200: None},
-    )
-    def get(self, request):
+    @extend_schema(exclude=True)
+    def get(self, request):  # noqa: C901
         serializer = InclusivePotentialQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
@@ -35,26 +33,49 @@ class InclusivePotentialView(APIView):
             if siae.super_badge:
                 siaes_with_super_badge += 1
 
-        eco_dependency = None
-        ca_average = None
+        siaes_count = siaes.count()
+        analysis_data = {}
         if budget:
-            # Get all valid CA values from siaes
+            # Get all valid CA values from siaes and calculate the average manually to avoid to many fat queries
             ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
-
             if ca_values:
-                ca_average = round(sum(ca_values) / len(ca_values))
-                eco_dependency = round(budget / ca_average * 100)
+                analysis_data["ca_average"] = round(sum(ca_values) / len(ca_values))
+                analysis_data["eco_dependency"] = round(budget / analysis_data["ca_average"] * 100)
 
-        return Response(
-            {
-                "sector_name": sector.name,
-                "perimeter_name": perimeter.name if perimeter else None,
-                "perimeter_kind": perimeter.kind if perimeter else None,
-                "potential_siaes": siaes.count(),
-                "insertion_siaes": insertion_siaes,
-                "handicap_siaes": handicap_siaes,
-                "siaes_with_super_badge": siaes_with_super_badge,
-                "eco_dependency": eco_dependency,
-                "ca_average": ca_average,
-            }
-        )
+            if siaes_count > 30:
+                if "eco_dependency" in analysis_data and analysis_data["eco_dependency"] < 30:
+                    recommendation = RECOMMENDATIONS["reservation"].copy()
+                else:
+                    recommendation = RECOMMENDATIONS["lot"].copy()
+            elif siaes_count > 10:
+                recommendation = RECOMMENDATIONS["lot"].copy()
+            elif siaes_count > 1:
+                recommendation = RECOMMENDATIONS["clause"].copy()
+            else:
+                recommendation = RECOMMENDATIONS["aucun"].copy()
+
+            # check if eco_dependency and ca_average exist as they are needed to format the explanation
+            recommendation["explanation"] = (
+                recommendation["explanation"].format(
+                    siaes_count=siaes_count,
+                    eco_dependency=analysis_data["eco_dependency"],
+                    ca_average=analysis_data["ca_average"],
+                )
+                if "eco_dependency" in analysis_data and "ca_average" in analysis_data
+                else None
+            )
+            analysis_data["recommendation"] = recommendation
+
+        data = {
+            "sector_name": sector.name,
+            "perimeter_name": perimeter.name if perimeter else None,
+            "perimeter_kind": perimeter.kind if perimeter else None,
+            "potential_siaes": siaes_count,
+            "insertion_siaes": insertion_siaes,
+            "handicap_siaes": handicap_siaes,
+            "siaes_with_super_badge": siaes_with_super_badge,
+        }
+        if budget:
+            data.update(analysis_data)
+
+        return Response(data)

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -19,6 +19,7 @@ class InclusivePotentialView(APIView):
 
         sector = serializer.validated_data.get("sector")
         perimeter = serializer.validated_data.get("perimeter")
+        budget = serializer.validated_data.get("budget")
 
         siaes = Siae.objects.filter_with_potential_through_activities(sector, perimeter)
 
@@ -34,6 +35,15 @@ class InclusivePotentialView(APIView):
             if siae.super_badge:
                 siaes_with_super_badge += 1
 
+        eco_dependency = None
+        if budget:
+            # Get all valid CA values from siaes
+            ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
+
+            if ca_values:
+                ca_average = sum(ca_values) / len(ca_values)
+                eco_dependency = round(budget / ca_average * 100, 2)
+
         return Response(
             {
                 "sector_name": sector.name,
@@ -43,5 +53,6 @@ class InclusivePotentialView(APIView):
                 "insertion_siaes": insertion_siaes,
                 "handicap_siaes": handicap_siaes,
                 "siaes_with_super_badge": siaes_with_super_badge,
+                "eco_dependency": eco_dependency,
             }
         )


### PR DESCRIPTION
### Quoi ?

Ajout de calcul de la dépendance économique à partir du budget de l'acheteur et de la moyenne des chiffres d'affaires des structures concernées.

### Pourquoi ?

Le chiffre d'affaire d'un fournisseur est un critère pour les acheteurs privés et est une contrainte pour les marchés publics.

### Comment ?

En divisant le budget par le chiffre d'affaire moyen.