### PR TITLE
feat(API Potentiel inclusif): Ajout du nombre d'employés moyen

### DIFF
--- a/lemarche/api/inclusive_potential/constants.py
+++ b/lemarche/api/inclusive_potential/constants.py
@@ -1,3 +1,8 @@
+LIMIT_FOR_RESERVATION = 30
+LIMIT_FOR_LOT = 10
+LIMIT_FOR_CLAUSE = 1
+LIMIT_FOR_ECO_DEPENDENCY = 30
+
 RECOMMENDATIONS = {
     "reservation": {
         "title": "Réservation totale",

--- a/lemarche/api/inclusive_potential/tests.py
+++ b/lemarche/api/inclusive_potential/tests.py
@@ -86,8 +86,8 @@ class InclusivePotentialViewTests(TestCase):
         self.assertEqual(response.data["insertion_siaes"], 2)
         self.assertEqual(response.data["handicap_siaes"], 1)
         self.assertEqual(response.data["siaes_with_super_badge"], 1)
-        self.assertEqual(response.data["employees_insertion"], 40)
-        self.assertEqual(response.data["employees_permanent"], 16)
+        self.assertEqual(response.data["employees_insertion_average"], 13.33)
+        self.assertEqual(response.data["employees_permanent_average"], 5.33)
 
         # if there is no budget, there is no recommendation
         self.assertNotIn("recommendation", response.data)

--- a/lemarche/api/inclusive_potential/tests.py
+++ b/lemarche/api/inclusive_potential/tests.py
@@ -19,9 +19,17 @@ class InclusivePotentialViewTests(TestCase):
             name="Paris", kind=Perimeter.KIND_DEPARTMENT, insee_code="75", region_code="11"
         )
 
-        siae_1 = SiaeFactory(kind=KIND_INSERTION_LIST[0], api_entreprise_ca=200000)
-        siae_2 = SiaeFactory(kind=KIND_INSERTION_LIST[1], super_badge=True, ca=1000000, api_entreprise_ca=500000)
-        siae_3 = SiaeFactory(kind=KIND_HANDICAP_LIST[0])
+        siae_1 = SiaeFactory(kind=KIND_INSERTION_LIST[0], api_entreprise_ca=200000, c2_etp_count=10)
+        siae_2 = SiaeFactory(
+            kind=KIND_INSERTION_LIST[1],
+            super_badge=True,
+            ca=1000000,
+            api_entreprise_ca=500000,
+            c2_etp_count=20,
+            employees_insertion_count=15,  # will be ignored by the calculation because use c2_etp_count instead
+            employees_permanent_count=9,
+        )
+        siae_3 = SiaeFactory(kind=KIND_HANDICAP_LIST[0], employees_insertion_count=10, employees_permanent_count=7)
 
         for siae in [siae_1, siae_2, siae_3]:
             siae_activity = SiaeActivityFactory(
@@ -78,6 +86,8 @@ class InclusivePotentialViewTests(TestCase):
         self.assertEqual(response.data["insertion_siaes"], 2)
         self.assertEqual(response.data["handicap_siaes"], 1)
         self.assertEqual(response.data["siaes_with_super_badge"], 1)
+        self.assertEqual(response.data["employees_insertion"], 40)
+        self.assertEqual(response.data["employees_permanent"], 16)
 
         # if there is no budget, there is no recommendation
         self.assertNotIn("recommendation", response.data)

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -39,8 +39,7 @@ def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tu
             handicap_siaes += 1
             employees_insertion_count += siae.employees_insertion_count or 0
 
-        if siae.super_badge:
-            siaes_with_super_badge += 1
+        siaes_with_super_badge += 1 if siae.super_badge else 0
 
         employees_permanent_count += siae.employees_permanent_count or 0
 

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
 
-from lemarche.api.inclusive_potential.constants import RECOMMENDATIONS
+from lemarche.api.inclusive_potential.constants import (
+    LIMIT_FOR_CLAUSE,
+    LIMIT_FOR_ECO_DEPENDENCY,
+    LIMIT_FOR_LOT,
+    LIMIT_FOR_RESERVATION,
+    RECOMMENDATIONS,
+)
 from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
 from lemarche.siaes.models import Siae
 
@@ -52,14 +58,14 @@ def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tu
             analysis_data["ca_average"] = round(sum(ca_values) / len(ca_values))
             analysis_data["eco_dependency"] = round(budget / analysis_data["ca_average"] * 100)
 
-        if siaes_count > 30:
-            if "eco_dependency" in analysis_data and analysis_data["eco_dependency"] < 30:
+        if siaes_count > LIMIT_FOR_RESERVATION:
+            if "eco_dependency" in analysis_data and analysis_data["eco_dependency"] < LIMIT_FOR_ECO_DEPENDENCY:
                 recommendation = RECOMMENDATIONS["reservation"].copy()
             else:
                 recommendation = RECOMMENDATIONS["lot"].copy()
-        elif siaes_count > 10:
+        elif siaes_count > LIMIT_FOR_LOT:
             recommendation = RECOMMENDATIONS["lot"].copy()
-        elif siaes_count > 1:
+        elif siaes_count > LIMIT_FOR_CLAUSE:
             recommendation = RECOMMENDATIONS["clause"].copy()
         else:
             recommendation = RECOMMENDATIONS["aucun"].copy()

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -32,12 +32,14 @@ def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tu
 
     # Calculate the number of siaes by kind and the number of employees
     # Prefer to loop over siaes rather than using querysets to avoid lots of big queries
+    siaes_count = 0
     insertion_siaes = 0
     handicap_siaes = 0
     siaes_with_super_badge = 0
     employees_insertion_count = 0
     employees_permanent_count = 0
     for siae in siaes:
+        siaes_count += 1
         if siae.kind in KIND_INSERTION_LIST:
             insertion_siaes += 1
             employees_insertion_count += siae.c2_etp_count or 0
@@ -49,7 +51,6 @@ def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tu
 
         employees_permanent_count += siae.employees_permanent_count or 0
 
-    siaes_count = siaes.count()
     analysis_data = {}
     if budget:
         # Get all valid CA values from siaes and calculate the average manually to avoid to many fat queries

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -11,8 +11,8 @@ class PotentialData:
     insertion_siaes: int
     handicap_siaes: int
     siaes_with_super_badge: int
-    employees_insertion_count: int
-    employees_permanent_count: int
+    employees_insertion_average: int
+    employees_permanent_average: int
 
 
 def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tuple[PotentialData, dict]:
@@ -83,8 +83,8 @@ def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tu
             insertion_siaes=insertion_siaes,
             handicap_siaes=handicap_siaes,
             siaes_with_super_badge=siaes_with_super_badge,
-            employees_insertion_count=employees_insertion_count,
-            employees_permanent_count=employees_permanent_count,
+            employees_insertion_average=round(employees_insertion_count / siaes_count, 2) if siaes_count else 0,
+            employees_permanent_average=round(employees_permanent_count / siaes_count, 2) if siaes_count else 0,
         ),
         analysis_data,
     )

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+
+from lemarche.api.inclusive_potential.constants import RECOMMENDATIONS
+from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
+from lemarche.siaes.models import Siae
+
+
+@dataclass
+class PotentialData:
+    potential_siaes: int
+    insertion_siaes: int
+    handicap_siaes: int
+    siaes_with_super_badge: int
+    employees_insertion_count: int
+    employees_permanent_count: int
+
+
+def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tuple[PotentialData, dict]:
+    """
+    Get the potential data for a given sector and perimeter.
+    Budget is optional and is used to calculate the eco-dependency.
+    """
+
+    # Get all siaes with potential through activities
+    siaes = Siae.objects.filter_with_potential_through_activities(sector, perimeter)
+
+    # Calculate the number of siaes by kind and the number of employees
+    # Prefer to loop over siaes rather than using querysets to avoid lots of big queries
+    insertion_siaes = 0
+    handicap_siaes = 0
+    siaes_with_super_badge = 0
+    employees_insertion_count = 0
+    employees_permanent_count = 0
+    for siae in siaes:
+        if siae.kind in KIND_INSERTION_LIST:
+            insertion_siaes += 1
+            employees_insertion_count += siae.c2_etp_count or 0
+        elif siae.kind in KIND_HANDICAP_LIST:
+            handicap_siaes += 1
+            employees_insertion_count += siae.employees_insertion_count or 0
+
+        if siae.super_badge:
+            siaes_with_super_badge += 1
+
+        employees_permanent_count += siae.employees_permanent_count or 0
+
+    siaes_count = siaes.count()
+    analysis_data = {}
+    if budget:
+        # Get all valid CA values from siaes and calculate the average manually to avoid to many fat queries
+        ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
+        if ca_values:
+            analysis_data["ca_average"] = round(sum(ca_values) / len(ca_values))
+            analysis_data["eco_dependency"] = round(budget / analysis_data["ca_average"] * 100)
+
+        if siaes_count > 30:
+            if "eco_dependency" in analysis_data and analysis_data["eco_dependency"] < 30:
+                recommendation = RECOMMENDATIONS["reservation"].copy()
+            else:
+                recommendation = RECOMMENDATIONS["lot"].copy()
+        elif siaes_count > 10:
+            recommendation = RECOMMENDATIONS["lot"].copy()
+        elif siaes_count > 1:
+            recommendation = RECOMMENDATIONS["clause"].copy()
+        else:
+            recommendation = RECOMMENDATIONS["aucun"].copy()
+
+        # check if eco_dependency and ca_average exist as they are needed to format the explanation
+        recommendation["explanation"] = (
+            recommendation["explanation"].format(
+                siaes_count=siaes_count,
+                eco_dependency=analysis_data["eco_dependency"],
+                ca_average=analysis_data["ca_average"],
+            )
+            if "eco_dependency" in analysis_data and "ca_average" in analysis_data
+            else None
+        )
+        analysis_data["recommendation"] = recommendation
+
+    return (
+        PotentialData(
+            potential_siaes=siaes_count,
+            insertion_siaes=insertion_siaes,
+            handicap_siaes=handicap_siaes,
+            siaes_with_super_badge=siaes_with_super_badge,
+            employees_insertion_count=employees_insertion_count,
+            employees_permanent_count=employees_permanent_count,
+        ),
+        analysis_data,
+    )

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -26,8 +26,8 @@ class InclusivePotentialView(APIView):
             "insertion_siaes": potential_data.insertion_siaes,
             "handicap_siaes": potential_data.handicap_siaes,
             "siaes_with_super_badge": potential_data.siaes_with_super_badge,
-            "employees_insertion": potential_data.employees_insertion_count,
-            "employees_permanent": potential_data.employees_permanent_count,
+            "employees_insertion_average": potential_data.employees_insertion_average,
+            "employees_permanent_average": potential_data.employees_permanent_average,
         }
         if budget:
             data.update(analysis_data)

--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -2,78 +2,32 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from lemarche.api.inclusive_potential.constants import RECOMMENDATIONS
 from lemarche.api.inclusive_potential.serializers import InclusivePotentialQuerySerializer
-from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
-from lemarche.siaes.models import Siae
+from lemarche.api.inclusive_potential.utils import get_inclusive_potential_data
 
 
 class InclusivePotentialView(APIView):
 
     @extend_schema(exclude=True)
-    def get(self, request):  # noqa: C901
+    def get(self, request):
         serializer = InclusivePotentialQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
         sector = serializer.validated_data.get("sector")
         perimeter = serializer.validated_data.get("perimeter")
         budget = serializer.validated_data.get("budget")
-
-        siaes = Siae.objects.filter_with_potential_through_activities(sector, perimeter)
-
-        insertion_siaes = 0
-        handicap_siaes = 0
-        siaes_with_super_badge = 0
-        for siae in siaes:
-            if siae.kind in KIND_INSERTION_LIST:
-                insertion_siaes += 1
-            elif siae.kind in KIND_HANDICAP_LIST:
-                handicap_siaes += 1
-
-            if siae.super_badge:
-                siaes_with_super_badge += 1
-
-        siaes_count = siaes.count()
-        analysis_data = {}
-        if budget:
-            # Get all valid CA values from siaes and calculate the average manually to avoid to many fat queries
-            ca_values = [siae.ca or siae.api_entreprise_ca for siae in siaes if siae.ca or siae.api_entreprise_ca]
-            if ca_values:
-                analysis_data["ca_average"] = round(sum(ca_values) / len(ca_values))
-                analysis_data["eco_dependency"] = round(budget / analysis_data["ca_average"] * 100)
-
-            if siaes_count > 30:
-                if "eco_dependency" in analysis_data and analysis_data["eco_dependency"] < 30:
-                    recommendation = RECOMMENDATIONS["reservation"].copy()
-                else:
-                    recommendation = RECOMMENDATIONS["lot"].copy()
-            elif siaes_count > 10:
-                recommendation = RECOMMENDATIONS["lot"].copy()
-            elif siaes_count > 1:
-                recommendation = RECOMMENDATIONS["clause"].copy()
-            else:
-                recommendation = RECOMMENDATIONS["aucun"].copy()
-
-            # check if eco_dependency and ca_average exist as they are needed to format the explanation
-            recommendation["explanation"] = (
-                recommendation["explanation"].format(
-                    siaes_count=siaes_count,
-                    eco_dependency=analysis_data["eco_dependency"],
-                    ca_average=analysis_data["ca_average"],
-                )
-                if "eco_dependency" in analysis_data and "ca_average" in analysis_data
-                else None
-            )
-            analysis_data["recommendation"] = recommendation
+        potential_data, analysis_data = get_inclusive_potential_data(sector, perimeter, budget)
 
         data = {
             "sector_name": sector.name,
             "perimeter_name": perimeter.name if perimeter else None,
             "perimeter_kind": perimeter.kind if perimeter else None,
-            "potential_siaes": siaes_count,
-            "insertion_siaes": insertion_siaes,
-            "handicap_siaes": handicap_siaes,
-            "siaes_with_super_badge": siaes_with_super_badge,
+            "potential_siaes": potential_data.potential_siaes,
+            "insertion_siaes": potential_data.insertion_siaes,
+            "handicap_siaes": potential_data.handicap_siaes,
+            "siaes_with_super_badge": potential_data.siaes_with_super_badge,
+            "employees_insertion": potential_data.employees_insertion_count,
+            "employees_permanent": potential_data.employees_permanent_count,
         }
         if budget:
             data.update(analysis_data)


### PR DESCRIPTION
### Quoi ?

Ajout du nombre moyen d'employé en insertion et permanent.

### Pourquoi ?

Pour étoffer le potentiel inclusif de chiffre d'ETP (Équivalent temps plein).

### Comment ?

Nombre d’ETP insertion de l’ensemble des fournisseurs potentiels / nombre de fournisseurs potentiels

Avec prise en compte de `C2 ETP` pour les SIAE (EI,ETTI,AI et ACI) et `Employees Insertion` pour les EA/EA et EATT

### Autre

J'en ai profité pour séparer les calculs de la vue.