### PR TITLE
chore: Masquer les sorties des commandes lors des tests

### DIFF
--- a/lemarche/cms/tests/test_commands.py
+++ b/lemarche/cms/tests/test_commands.py
@@ -1,4 +1,5 @@
 import json
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import Client, TestCase
@@ -38,7 +39,7 @@ class CreateContentPagesCommandTest(TestCase):
         with open("lemarche/fixtures/cms_content_pages.json") as f:
             pages_data = json.load(f)
 
-        call_command("create_content_pages")
+        call_command("create_content_pages", stdout=StringIO())
 
         for page_data in pages_data:
             slug = page_data["slug"]
@@ -64,7 +65,7 @@ class CreateContentPagesCommandTest(TestCase):
         """Test the command does not create duplicate pages"""
         self.home_page.add_child(instance=ContentPage(slug="mentions-legales", title="Mentions légales"))
 
-        call_command("create_content_pages")
+        call_command("create_content_pages", stdout=StringIO())
 
         self.assertEqual(
             ContentPage.objects.filter(slug="mentions-legales").count(),

--- a/lemarche/crm/management/commands/crm_brevo_sync_companies.py
+++ b/lemarche/crm/management/commands/crm_brevo_sync_companies.py
@@ -61,4 +61,4 @@ class Command(BaseCommand):
             if (index % 10) == 0:  # avoid API rate-limiting
                 time.sleep(1)
             if (index % 500) == 0:
-                print(f"{index}...")
+                self.stdout.write(f"{index}...")

--- a/lemarche/crm/tests.py
+++ b/lemarche/crm/tests.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -105,7 +104,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
     @patch("lemarche.utils.apis.api_brevo.create_or_update_company")
     def test_new_siaes_are_synced_in_brevo(self, mock_create_or_update_company):
         """Test new siaes are synced in brevo"""
-        call_command("crm_brevo_sync_companies", stdout=StringIO())
+        call_command("crm_brevo_sync_companies", stdout=None)
 
         self.assertEqual(mock_create_or_update_company.call_count, 3)
 
@@ -130,7 +129,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
         self.siae_with_user.extra_data = initial_extra_data
         self.siae_with_user.save(update_fields=["extra_data"])
 
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
 
         self.siae_with_user.refresh_from_db()
 
@@ -152,7 +151,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
 
     def test_siae_extra_data_is_not_updated_if_no_changes(self):
         """Test siae.extra_data is not updated if no changes."""
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
 
         self.siae_with_brevo_id.refresh_from_db()
         self.assertEqual(
@@ -170,7 +169,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
             detail_contact_click_date=now,
         )
 
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
 
         self.siae_with_brevo_id_all_stats = (
             Siae.objects.with_tender_stats().filter(id=self.siae_with_brevo_id.id).first()

--- a/lemarche/crm/tests.py
+++ b/lemarche/crm/tests.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -104,7 +105,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
     @patch("lemarche.utils.apis.api_brevo.create_or_update_company")
     def test_new_siaes_are_synced_in_brevo(self, mock_create_or_update_company):
         """Test new siaes are synced in brevo"""
-        call_command("crm_brevo_sync_companies")
+        call_command("crm_brevo_sync_companies", stdout=StringIO())
 
         self.assertEqual(mock_create_or_update_company.call_count, 3)
 
@@ -129,7 +130,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
         self.siae_with_user.extra_data = initial_extra_data
         self.siae_with_user.save(update_fields=["extra_data"])
 
-        call_command("crm_brevo_sync_companies", recently_updated=True)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_user.refresh_from_db()
 
@@ -151,7 +152,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
 
     def test_siae_extra_data_is_not_updated_if_no_changes(self):
         """Test siae.extra_data is not updated if no changes."""
-        call_command("crm_brevo_sync_companies", recently_updated=True)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_brevo_id.refresh_from_db()
         self.assertEqual(
@@ -169,7 +170,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
             detail_contact_click_date=now,
         )
 
-        call_command("crm_brevo_sync_companies", recently_updated=True)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_brevo_id_all_stats = (
             Siae.objects.with_tender_stats().filter(id=self.siae_with_brevo_id.id).first()

--- a/lemarche/crm/tests.py
+++ b/lemarche/crm/tests.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -104,7 +105,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
     @patch("lemarche.utils.apis.api_brevo.create_or_update_company")
     def test_new_siaes_are_synced_in_brevo(self, mock_create_or_update_company):
         """Test new siaes are synced in brevo"""
-        call_command("crm_brevo_sync_companies", stdout=None)
+        call_command("crm_brevo_sync_companies", stdout=StringIO())
 
         self.assertEqual(mock_create_or_update_company.call_count, 3)
 
@@ -129,7 +130,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
         self.siae_with_user.extra_data = initial_extra_data
         self.siae_with_user.save(update_fields=["extra_data"])
 
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_user.refresh_from_db()
 
@@ -151,7 +152,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
 
     def test_siae_extra_data_is_not_updated_if_no_changes(self):
         """Test siae.extra_data is not updated if no changes."""
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_brevo_id.refresh_from_db()
         self.assertEqual(
@@ -169,7 +170,7 @@ class CrmBrevoSyncCompaniesCommandTest(TestCase):
             detail_contact_click_date=now,
         )
 
-        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=None)
+        call_command("crm_brevo_sync_companies", recently_updated=True, stdout=StringIO())
 
         self.siae_with_brevo_id_all_stats = (
             Siae.objects.with_tender_stats().filter(id=self.siae_with_brevo_id.id).first()

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -450,7 +450,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
         # Wet run
-        call_command("update_api_entreprise_fields", wet_run=True, stdout=StringIO())
+        call_command("update_api_entreprise_fields", wet_run=True, stdout=None)
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertEqual(self.siae.api_entreprise_employees_year_reference, "2024")
@@ -492,7 +492,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         self.mock_return_value["results"][0]["finances"] = None
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertIsNone(self.siae.api_entreprise_ca)
@@ -510,7 +510,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 
@@ -526,7 +526,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -55,7 +55,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         # Verify SIAE was created
         self.assertEqual(Siae.objects.count(), 1)
@@ -102,7 +102,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         # Verify SIAE was updated
         self.assertEqual(Siae.objects.count(), 1)
@@ -119,7 +119,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
 
         # Run command
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         # Verify SIAE was updated
         self.assertEqual(Siae.objects.count(), 1)
@@ -162,7 +162,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command (should not raise exception)
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         # Verify warning was logged
         self.assertIn("Brand name is already used by another SIAE during creation", log.output[0])
@@ -233,7 +233,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command (should not raise exception)
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         # Verify warning was logged
         self.assertIn("Brand name is already used by another SIAE during update", log.output[0])
@@ -298,7 +298,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         ]
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion")
+            call_command("sync_with_emplois_inclusion", stdout=None)
 
         self.assertIn("Kind not supported: FAKE", log.output[0])
 
@@ -344,7 +344,7 @@ class SiaeUpdateCountFieldsCommandTest(TransactionTestCase):
         self.assertEqual(siae_2.user_count, 0)
         self.assertEqual(siae_2.sector_count, 0)
 
-        call_command("update_siae_count_fields")
+        call_command("update_siae_count_fields", stdout=StringIO())
         siae_1.refresh_from_db()
         self.assertEqual(siae_1.user_count, 3)
         self.assertEqual(siae_1.sector_count, 2)
@@ -370,7 +370,7 @@ class SiaeUpdateCountFieldsCommandTest(TransactionTestCase):
             siae_not_updated.users.add(user)
         SiaeActivityFactory.create_batch(2, siae=siae_not_updated)
 
-        call_command("update_siae_count_fields", id=siae_to_update.id)
+        call_command("update_siae_count_fields", id=siae_to_update.id, stdout=StringIO())
         siae_to_update.refresh_from_db()
         self.assertEqual(siae_to_update.user_count, 3)
         self.assertEqual(siae_to_update.sector_count, 2)
@@ -544,5 +544,5 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
             "total_pages": 1,
         }
         out = StringIO()
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, sttdout=out)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=out)
         self.assertIn("SIRET not found", out.getvalue())

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -55,7 +55,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         # Verify SIAE was created
         self.assertEqual(Siae.objects.count(), 1)
@@ -102,7 +102,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         # Verify SIAE was updated
         self.assertEqual(Siae.objects.count(), 1)
@@ -119,7 +119,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
 
         # Run command
         with self.assertNoLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion"):
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         # Verify SIAE was updated
         self.assertEqual(Siae.objects.count(), 1)
@@ -162,7 +162,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command (should not raise exception)
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         # Verify warning was logged
         self.assertIn("Brand name is already used by another SIAE during creation", log.output[0])
@@ -233,7 +233,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         # Run command (should not raise exception)
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         # Verify warning was logged
         self.assertIn("Brand name is already used by another SIAE during update", log.output[0])
@@ -298,7 +298,7 @@ class SyncWithEmploisInclusionCommandTest(TransactionTestCase):
         ]
         os.environ["API_EMPLOIS_INCLUSION_TOKEN"] = "test"
         with self.assertLogs("lemarche.siaes.management.commands.sync_with_emplois_inclusion", level="ERROR") as log:
-            call_command("sync_with_emplois_inclusion", stdout=None)
+            call_command("sync_with_emplois_inclusion", stdout=StringIO())
 
         self.assertIn("Kind not supported: FAKE", log.output[0])
 
@@ -450,7 +450,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
         # Wet run
-        call_command("update_api_entreprise_fields", wet_run=True, stdout=None)
+        call_command("update_api_entreprise_fields", wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertEqual(self.siae.api_entreprise_employees_year_reference, "2024")
@@ -492,7 +492,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         self.mock_return_value["results"][0]["finances"] = None
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertIsNone(self.siae.api_entreprise_ca)
@@ -510,7 +510,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 
@@ -526,7 +526,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=None)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 

--- a/lemarche/siaes/tests/test_commands.py
+++ b/lemarche/siaes/tests/test_commands.py
@@ -450,7 +450,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
         # Wet run
-        call_command("update_api_entreprise_fields", wet_run=True)
+        call_command("update_api_entreprise_fields", wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertEqual(self.siae.api_entreprise_employees_year_reference, "2024")
@@ -492,7 +492,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         self.mock_return_value["results"][0]["finances"] = None
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_employees, "250 à 499 salariés")
         self.assertIsNone(self.siae.api_entreprise_ca)
@@ -510,7 +510,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 
@@ -526,7 +526,7 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
         }
         mock_requests_get.return_value.json.return_value = self.mock_return_value
 
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=StringIO())
         self.siae.refresh_from_db()
         self.assertEqual(self.siae.api_entreprise_ca, 12345678)
 
@@ -544,5 +544,5 @@ class SiaeUpdateApiEntrepriseFieldsCommandTest(TestCase):
             "total_pages": 1,
         }
         out = StringIO()
-        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, stdout=out)
+        call_command("update_api_entreprise_fields", siret=self.siae.siret, wet_run=True, sttdout=out)
         self.assertIn("SIRET not found", out.getvalue())

--- a/lemarche/tenders/tests/test_commands.py
+++ b/lemarche/tenders/tests/test_commands.py
@@ -293,7 +293,6 @@ class UpdateTenderCountFieldsCommandTest(TestCase):
 
         std_out = StringIO()
         call_command("update_tender_count_fields", stdout=std_out)
-        print(std_out.getvalue())
         self.assertIn("Done! Processed 1 tenders", std_out.getvalue())
 
         tender.refresh_from_db()

--- a/lemarche/utils/tests_commands.py
+++ b/lemarche/utils/tests_commands.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from unittest.mock import patch
 
 from django.core.files.storage import default_storage
@@ -26,7 +27,7 @@ class AntivirusScanCommandTest(TransactionTestCase):
         mock_shutil_chown.return_value = None
         mock_os_chmod.return_value = None
 
-        call_command("antivirus_scan")
+        call_command("antivirus_scan", stdout=StringIO())
 
         # Check that the scan command was called
         self.assertEqual(mock_subprocess_run.call_count, 1)
@@ -48,7 +49,7 @@ class AntivirusScanCommandTest(TransactionTestCase):
 
         attachment = self.tender.attachment_one
 
-        call_command("antivirus_scan")
+        call_command("antivirus_scan", stdout=StringIO())
 
         # Check that the scan command was called
         self.assertEqual(mock_subprocess_run.call_count, 1)


### PR DESCRIPTION
### Quoi ?

Les commandes django produisent beaucoup d'écriture en sortie standard, cette PR à pour but de les masquer lors des tests.
Il faut aussi supprimer les vieux prints qui trainent, qui sont mélangés avec les logs, les `stdout`...

### Pourquoi ?

Cela pollue la lecture des tests, rend plus difficile leur lecture

### Comment ?

Rediriger la sortie vers `StringIO()`
