### PR TITLE
fix(Dépôt de besoin): Mise à jour de la date des transactions pour toutes les réponses

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -754,7 +754,7 @@ class Tender(models.Model):
         """
         for field_name in self.TRACK_UPDATE_FIELDS:
             previous_field_name = f"__previous_{field_name}"
-            if getattr(self, field_name) and getattr(self, field_name) != getattr(self, previous_field_name):
+            if getattr(self, field_name) != getattr(self, previous_field_name):
                 try:
                     setattr(self, f"{field_name}_last_updated", timezone.now())
                 except AttributeError:  # TRACK_UPDATE_FIELDS without last_updated fields

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1729,6 +1729,7 @@ class TenderDetailSurveyTransactionedViewTest(TestCase):
         self.assertContains(response, "Votre réponse a déjà été prise en compte")
         self.assertEqual(t.survey_transactioned_answer, constants.YES)
         self.assertTrue(t.siae_transactioned)
+        self.assertIsNotNone(t.siae_transactioned_last_updated)
 
     def test_update_tender_stats_on_tender_survey_transactioned_answer_false(self):
         # load with answer False: partial form
@@ -1738,6 +1739,7 @@ class TenderDetailSurveyTransactionedViewTest(TestCase):
         t = Tender.objects.get(id=self.tender.id)
         self.assertEqual(t.survey_transactioned_answer, constants.NO)
         self.assertFalse(t.siae_transactioned)
+        self.assertIsNotNone(t.siae_transactioned_last_updated)
         # fill in form
         response = self.client.post(url, data={"survey_transactioned_feedback": "Feedback"}, follow=True)
         self.assertEqual(response.status_code, 200)  # redirect
@@ -1764,6 +1766,7 @@ class TenderDetailSurveyTransactionedViewTest(TestCase):
         t = Tender.objects.get(id=self.tender.id)
         self.assertEqual(t.survey_transactioned_answer, constants.DONT_KNOW)
         self.assertIsNone(t.siae_transactioned)
+        self.assertIsNone(t.siae_transactioned_last_updated)
         # fill in form
         response = self.client.post(url, data={"survey_transactioned_feedback": "Feedback"}, follow=True)
         self.assertEqual(response.status_code, 200)  # redirect


### PR DESCRIPTION
### Quoi ?

Mise à jour de la date des transactions pour toutes les réponses

### Pourquoi ?

Certains changements d'état ne mettent pas à jour la date.

### Comment ?

Mettre à jour pour tout changement, même si le champ est `None` ou `False`.