### PR TITLE
feat: Import par lot d'utilisateurs de type partenaire pour les facilitateurs

### DIFF
--- a/lemarche/fixtures/tests/partners_import.csv
+++ b/lemarche/fixtures/tests/partners_import.csv
@@ -1,0 +1,4 @@
+FIRST_NAME,LAST_NAME,EMAIL,PHONE,POSITION
+Jean,Dupont,jean.dupont@facilitateur.fr,0123456789,Facilitateur clauses sociales
+Marie,Martin,marie.martin@accompagnement.fr,0987654321,Accompagnatrice insertion
+Pierre,Durand,pierre.durand@mediation.fr,0555666777,Médiateur social 

--- a/lemarche/users/management/commands/README.md
+++ b/lemarche/users/management/commands/README.md
@@ -1,0 +1,97 @@
+# Commandes d'import d'utilisateurs
+
+## Architecture
+
+### Classe de base : `BaseImportUsersCommand`
+
+La classe `BaseImportUsersCommand` fournit la logique commune pour toutes les commandes d'import :
+
+- **Lecture du fichier CSV** avec gestion d'erreurs
+- **Création/mise à jour d'utilisateurs** avec gestion des doublons
+- **Envoi de liens de réinitialisation de mot de passe** pour les nouveaux utilisateurs
+- **Hooks extensibles** pour les actions post-import
+
+### Méthodes à implémenter
+
+Les sous-classes doivent implémenter ces méthodes abstraites :
+
+- `get_user_kind()` : Type d'utilisateur (ex: `User.KIND_BUYER`)
+- `get_user_fields()` : Champs supplémentaires pour la création
+- `get_update_fields()` : Champs à mettre à jour pour les utilisateurs existants
+
+## Commandes disponibles
+
+### Import d'acheteurs : `import_buyers`
+
+```bash
+python manage.py import_buyers fichier.csv template_code company_slug brevo_contact_id
+```
+
+**Paramètres :**
+
+- `fichier.csv` : Fichier CSV avec les acheteurs
+- `company_slug` : Slug de l'entreprise
+- `template_code` : Code template Brevo pour l'invitation
+- `brevo_contact_id` : ID liste contact Brevo
+
+**Fonctionnalités spécifiques :**
+
+- Rattachement à une entreprise
+- Ajout à la liste Brevo
+- Ajout du domaine email à l'entreprise
+
+### Import de partenaires : `import_partners`
+
+```bash
+python manage.py import_partners fichier.csv template_code
+```
+
+**Paramètres :**
+
+- `fichier.csv` : Fichier CSV avec les partenaires
+- `template_code` : Code template Brevo pour l'invitation
+
+**Fonctionnalités spécifiques :**
+
+- Type de partenaire fixé à "Facilitateur"
+- Pas de rattachement à une entreprise
+- Pas d'ajout à Brevo
+
+## Format CSV
+
+Toutes les commandes utilisent le même format CSV avec ces en-têtes :
+
+```csv
+FIRST_NAME,LAST_NAME,EMAIL,PHONE,POSITION
+Jean,Dupont,jean.dupont@example.com,0123456789,Directeur
+Marie,Martin,marie.martin@example.com,0987654321,Responsable
+```
+
+## Exemples d'utilisation
+
+### Import de partenaires facilitateurs
+
+```bash
+python manage.py import_partners fixtures/tests/partners_import.csv welcome_partners
+```
+
+### Import d'acheteurs pour une entreprise
+
+```bash
+python manage.py import_buyers acheteurs.csv ma-entreprise welcome_buyers 123
+```
+
+## Gestion des erreurs
+
+- **Utilisateurs existants** : Mise à jour des champs spécifiques
+- **Erreurs de validation** : Affichage dans les logs, traitement continu
+- **Transactions** : Chaque utilisateur traité indépendamment
+
+## Extensibilité
+
+Pour créer une nouvelle commande d'import :
+
+1. Hériter de `BaseImportUsersCommand`
+2. Implémenter les méthodes abstraites
+3. Ajouter des arguments spécifiques si nécessaire
+4. Surcharger les hooks pour les actions post-import

--- a/lemarche/users/management/commands/base_import_users.py
+++ b/lemarche/users/management/commands/base_import_users.py
@@ -1,0 +1,119 @@
+import csv
+from abc import ABC, abstractmethod
+
+from django.core.management.base import BaseCommand
+from django.db import IntegrityError, transaction
+
+from lemarche.users.models import User
+from lemarche.www.auth.tasks import send_new_user_password_reset_link
+
+
+class BaseImportUsersCommand(BaseCommand, ABC):
+    """Base class for importing users from CSV files.
+
+    Subclasses must implement:
+    - get_user_kind(): return the user kind (e.g., User.KIND_BUYER)
+    - get_user_fields(): return dict of additional fields to set on user creation
+    - get_update_fields(): return list of fields to update for existing users
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "filename",
+            type=str,
+            help="Fichier csv contenant les utilisateurs à importer.",
+        )
+        parser.add_argument(
+            "template_code",
+            type=str,
+            help="Code de la template de mail Brevo enregistrée"
+            " dans la base pour envoyer l'invitation aux utilisateurs importés.",
+        )
+        # Subclasses can add more arguments by calling super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        # Subclasses can override this to add setup logic (e.g., get company)
+        with open(options["filename"], "r", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            imported_list = list(reader)
+
+        for imported_user in imported_list:
+            try:
+                with transaction.atomic():
+                    self._import_user(
+                        imported_user, template_code=options["template_code"], **self._get_extra_context(options)
+                    )
+                    self._post_import_user(imported_user, **self._get_extra_context(options))
+            except Exception as e:
+                self.stdout.write(f"Erreur lors de l'import de l'utilisateur {imported_user['EMAIL']}: {e}")
+
+    def _import_user(self, imported_user: dict, template_code: str, **kwargs) -> None:
+        """
+        Create a new user and send a password reset link to it.
+        If the user already exists, update its fields.
+        """
+        user_fields = self._get_base_user_fields(imported_user)
+        user_fields.update(self.get_user_fields(**kwargs))
+
+        try:
+            with transaction.atomic():
+                user = User.objects.create_user(**user_fields)
+        except IntegrityError:  # email already exists
+            update_fields = self.get_update_fields(**kwargs)
+            if update_fields:
+                user = User.objects.get(email=imported_user["EMAIL"])
+                for field, value in update_fields.items():
+                    setattr(user, field, value)
+                user.save(update_fields=list(update_fields.keys()))
+                self.stdout.write(
+                    f"L'utilisateur {imported_user['EMAIL']} est déjà inscrit, informations mises à jour."
+                )
+            else:
+                self.stdout.write(f"L'utilisateur {imported_user['EMAIL']} est déjà inscrit, aucune mise à jour.")
+        else:  # new user, send password reset link
+            send_new_user_password_reset_link(user, template_code=template_code)
+            self.stdout.write(f"L'utilisateur {imported_user['EMAIL']} a été inscrit avec succès.")
+
+        # Post-import actions (e.g., add to Brevo list)
+        self._post_import_user_actions(user, **kwargs)
+
+    def _get_base_user_fields(self, imported_user: dict) -> dict:
+        """Get the common fields for all user types."""
+        return {
+            "email": imported_user["EMAIL"],
+            "first_name": imported_user["FIRST_NAME"],
+            "last_name": imported_user["LAST_NAME"],
+            "phone": imported_user["PHONE"],
+            "kind": self.get_user_kind(),
+            "position": imported_user["POSITION"],
+            "accept_rgpd": True,
+            "accept_survey": True,
+            "password": None,
+        }
+
+    def _get_extra_context(self, options: dict) -> dict:
+        """Get extra context from options for subclasses."""
+        return {}
+
+    def _post_import_user(self, imported_user: dict, **kwargs) -> None:
+        """Hook for post-import actions that don't require the user object."""
+        pass
+
+    def _post_import_user_actions(self, user: User, **kwargs) -> None:
+        """Hook for post-import actions that require the user object."""
+        pass
+
+    @abstractmethod
+    def get_user_kind(self) -> str:
+        """Return the user kind (e.g., User.KIND_BUYER)."""
+        pass
+
+    @abstractmethod
+    def get_user_fields(self, **kwargs) -> dict:
+        """Return additional fields to set on user creation."""
+        pass
+
+    @abstractmethod
+    def get_update_fields(self, **kwargs) -> dict:
+        """Return fields to update for existing users."""
+        pass

--- a/lemarche/users/management/commands/import_buyers.py
+++ b/lemarche/users/management/commands/import_buyers.py
@@ -1,36 +1,21 @@
-import csv
-
-from django.core.management.base import BaseCommand
-from django.db import IntegrityError, transaction
-
 from lemarche.companies.models import Company
+from lemarche.users.management.commands.base_import_users import BaseImportUsersCommand
 from lemarche.users.models import User
 from lemarche.utils.emails import add_to_contact_list
-from lemarche.www.auth.tasks import send_new_user_password_reset_link
 
 
-class Command(BaseCommand):
+class Command(BaseImportUsersCommand):
     """Import new buyers from a csv file.
     The file should respect these headers:
         FIRST_NAME | LAST_NAME | EMAIL | PHONE | POSITION
     """
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "filename",
-            type=str,
-            help="Fichier csv contenant les acheteurs à importer.",
-        )
+        super().add_arguments(parser)
         parser.add_argument(
             "company_slug",
             type=str,
             help="Slug de la société à qui appartient les acheteurs importés.",
-        )
-        parser.add_argument(
-            "template_code",
-            type=str,
-            help="Code de la template de mail Brevo enregistrée"
-            " dans la base pour envoyer l'invitation aux acheteurs importés.",
         )
         parser.add_argument(
             "brevo_contact_id",
@@ -39,58 +24,37 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        company = Company.objects.get(slug=options["company_slug"])
+        # Get company before processing
+        print(options)
+        self.company = Company.objects.get(slug=options["company_slug"])
+        super().handle(*args, **options)
 
-        with open(options["filename"], "r", encoding="utf-8") as csvfile:
-            reader = csv.DictReader(csvfile)
-            imported_list = list(reader)
+    def _get_extra_context(self, options: dict) -> dict:
+        return {
+            "company": self.company,
+            "brevo_contact_id": options["brevo_contact_id"],
+        }
 
-        for imported_user in imported_list:
-            try:
-                with transaction.atomic():
-                    self._import_user(
-                        imported_user,
-                        company,
-                        template_code=options["template_code"],
-                        brevo_contact_id=options["brevo_contact_id"],
-                    )
-                    self._add_email_dns_to_company(email=imported_user["EMAIL"], company=company)
-            except Exception as e:
-                self.stdout.write(f"Erreur lors de l'import de l'acheteur {imported_user['EMAIL']}: {e}")
+    def _post_import_user(self, imported_user: dict, **kwargs) -> None:
+        """Add email domain to company."""
+        self._add_email_dns_to_company(email=imported_user["EMAIL"], company=kwargs["company"])
 
-    def _import_user(self, imported_user: dict, company: Company, template_code: str, brevo_contact_id: int) -> None:
-        """
-        Create a new user and send a password reset link to it.
-        If the user already exists, update its company.
-        Always add to Brevo contact list.
-        """
-        try:
-            with transaction.atomic():
-                user = User.objects.create_user(
-                    email=imported_user["EMAIL"],
-                    first_name=imported_user["FIRST_NAME"],
-                    last_name=imported_user["LAST_NAME"],
-                    phone=imported_user["PHONE"],
-                    kind=User.KIND_BUYER,
-                    company=company,
-                    company_name=company.name,
-                    position=imported_user["POSITION"],
-                    accept_rgpd=True,
-                    accept_survey=True,
-                    password=None,
-                )
-        except IntegrityError:  # email already exists
-            # Already registered users have their company updated
-            user = User.objects.get(email=imported_user["EMAIL"])
-            user.company = company
-            user.company_name = company.name
-            user.save(update_fields=["company", "company_name"])
-            self.stdout.write(f"L'acheteur {imported_user['EMAIL']} est déjà inscrit, entreprise mise à jour.")
-        else:  # new user, send password reset link
-            send_new_user_password_reset_link(user, template_code=template_code)
-            self.stdout.write(f"L'acheteur {imported_user['EMAIL']} a été inscrit avec succès.")
-        finally:  # add to Brevo contact list, even if user already exists or not
-            add_to_contact_list(user, contact_type=brevo_contact_id)
+    def _post_import_user_actions(self, user: User, **kwargs) -> None:
+        """Add user to Brevo contact list."""
+        add_to_contact_list(user, contact_type=kwargs["brevo_contact_id"])
+
+    def get_user_kind(self) -> str:
+        return User.KIND_BUYER
+
+    def get_user_fields(self, **kwargs) -> dict:
+        company = kwargs["company"]
+        return {
+            "company": company,
+            "company_name": company.name,
+        }
+
+    def get_update_fields(self, **kwargs) -> dict:
+        return self.get_user_fields(**kwargs)
 
     def _add_email_dns_to_company(self, email: str, company: Company) -> None:
         """If the email domain is not already in the company's email_domain_list, add it."""

--- a/lemarche/users/management/commands/import_partners.py
+++ b/lemarche/users/management/commands/import_partners.py
@@ -1,0 +1,21 @@
+from lemarche.users import constants as user_constants
+from lemarche.users.management.commands.base_import_users import BaseImportUsersCommand
+from lemarche.users.models import User
+
+
+class Command(BaseImportUsersCommand):
+    """Import new partners from a csv file.
+    The file should respect these headers:
+        FIRST_NAME | LAST_NAME | EMAIL | PHONE | POSITION
+    """
+
+    def get_user_kind(self) -> str:
+        return User.KIND_PARTNER
+
+    def get_user_fields(self, **kwargs) -> dict:
+        return {
+            "partner_kind": user_constants.PARTNER_KIND_FACILITATOR,
+        }
+
+    def get_update_fields(self, **kwargs) -> dict:
+        return False

--- a/lemarche/users/tests/test_commands.py
+++ b/lemarche/users/tests/test_commands.py
@@ -3,172 +3,18 @@ from io import StringIO
 from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
-from django.contrib.messages import get_messages
 from django.core.management import call_command
 from django.core.validators import validate_email
 from django.db.models import F
 from django.test import TestCase, override_settings
-from django.urls import reverse
 
 from lemarche.companies.factories import CompanyFactory
 from lemarche.conversations.factories import TemplateTransactionalFactory
 from lemarche.conversations.models import TemplateTransactional, TemplateTransactionalSendLog
-from lemarche.favorites.factories import FavoriteListFactory
 from lemarche.siaes.factories import SiaeFactory
-from lemarche.tenders.factories import TenderFactory
-from lemarche.users import constants as user_constants
+from lemarche.users.constants import PARTNER_KIND_FACILITATOR
 from lemarche.users.factories import UserFactory
 from lemarche.users.models import User
-
-
-class UserModelTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-
-    def test_str(self):
-        user = UserFactory(email="coucou@example.com")
-        self.assertEqual(str(user), "coucou@example.com")
-
-    def test_full_name(self):
-        user = UserFactory(first_name="Paul", last_name="Anploi")
-        self.assertEqual(user.full_name, "Paul Anploi")
-
-    def test_kind_detail_display(self):
-        user_siae = UserFactory(kind=user_constants.KIND_SIAE)
-        user_buyer = UserFactory(kind=user_constants.KIND_BUYER)
-        user_buyer_public = UserFactory(kind=user_constants.KIND_BUYER, buyer_kind=user_constants.BUYER_KIND_PUBLIC)
-        user_buyer_private_pme = UserFactory(
-            kind=user_constants.KIND_BUYER,
-            buyer_kind=user_constants.BUYER_KIND_PRIVATE,
-            buyer_kind_detail=user_constants.BUYER_KIND_DETAIL_PRIVATE_PME,
-        )
-        user_partner = UserFactory(kind=user_constants.KIND_PARTNER)
-        user_partner_facilitator = UserFactory(
-            kind=user_constants.KIND_PARTNER, partner_kind=user_constants.PARTNER_KIND_FACILITATOR
-        )
-        self.assertEqual(user_siae.kind_detail_display, "Structure")
-        self.assertEqual(user_buyer.kind_detail_display, "Acheteur")
-        self.assertEqual(user_partner.kind_detail_display, "Partenaire")
-        self.assertEqual(user_buyer_public.kind_detail_display, "Acheteur")
-        self.assertEqual(user_buyer_private_pme.kind_detail_display, "Acheteur : PME")
-        self.assertEqual(
-            user_partner_facilitator.kind_detail_display, "Partenaire : Facilitateur des clauses sociales"
-        )
-
-
-class UserModelQuerysetTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory()
-
-    def test_is_admin_bizdev(self):
-        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True)
-        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="BizDev")
-        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="Bizdev")
-        self.assertEqual(User.objects.count(), 1 + 3)
-        self.assertEqual(User.objects.is_admin_bizdev().count(), 2)
-
-    def test_has_company(self):
-        user_2 = UserFactory()
-        CompanyFactory(users=[user_2])
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.has_company().count(), 1)
-
-    def test_has_siae(self):
-        user_2 = UserFactory()
-        SiaeFactory(users=[user_2])
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.has_siae().count(), 1)
-
-    def test_has_tender(self):
-        user_2 = UserFactory()
-        TenderFactory(author=user_2)
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.has_tender().count(), 1)
-
-    def test_has_favorite_list(self):
-        user_2 = UserFactory()
-        FavoriteListFactory(user=user_2)
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.has_favorite_list().count(), 1)
-
-    def test_has_api_key(self):
-        UserFactory(api_key="coucou")
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.has_api_key().count(), 1)
-
-    def test_has_email_domain(self):
-        UserFactory(email="test@ain.fr")
-        UserFactory(email="test@plateau-urbain.fr")
-        self.assertEqual(User.objects.count(), 1 + 2)
-        for EMAIL_DOMAIN in ["ain.fr", "@ain.fr"]:
-            with self.subTest(email_domain=EMAIL_DOMAIN):
-                self.assertEqual(User.objects.has_email_domain(email_domain=EMAIL_DOMAIN).count(), 1)
-
-    def test_with_siae_stats(self):
-        user_2 = UserFactory()
-        SiaeFactory(users=[user_2])
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.with_siae_stats().filter(id=self.user.id).first().siae_count_annotated, 0)
-        self.assertEqual(User.objects.with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1)
-
-    def test_with_tender_stats(self):
-        user_2 = UserFactory()
-        TenderFactory(author=user_2)
-        self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.with_tender_stats().filter(id=self.user.id).first().tender_count_annotated, 0)
-        self.assertEqual(User.objects.with_tender_stats().filter(id=user_2.id).first().tender_count_annotated, 1)
-
-    def test_chain_querysets(self):
-        user_2 = UserFactory(api_key="chain")
-        siae = SiaeFactory()
-        siae.users.add(user_2)
-        self.assertEqual(
-            User.objects.has_api_key().with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1
-        )
-
-
-class UserModelSaveTest(TestCase):
-    def setUp(self):
-        pass
-
-    def test_update_last_updated_fields(self):
-        user = UserFactory()
-        self.assertIsNone(user.api_key)
-        self.assertIsNone(user.api_key_last_updated)
-        # new value: last_updated field will be set
-        user = User.objects.get(id=user.id)  # we need to fetch it again to pass through the __init__
-        user.api_key = "AZERTY"
-        user.save()
-        self.assertEqual(user.api_key, "AZERTY")
-        self.assertIsNotNone(user.api_key_last_updated)
-        api_key_last_updated = user.api_key_last_updated
-        # same value: last_updated field will not be updated
-        user = User.objects.get(id=user.id)
-        user.api_key = "AZERTY"
-        user.save()
-        self.assertEqual(user.api_key, "AZERTY")
-        self.assertEqual(user.api_key_last_updated, api_key_last_updated)
-        # updated value: last_updated field will be updated
-        user = User.objects.get(id=user.id)
-        user.api_key = "QWERTY"
-        user.save()
-        self.assertEqual(user.api_key, "QWERTY")
-        self.assertNotEqual(user.api_key_last_updated, api_key_last_updated)
-
-    def test_update_related_favorite_list_count_on_save(self):
-        user = UserFactory()
-        self.assertEqual(user.favorite_list_count, 0)
-        # create 2 lists
-        FavoriteListFactory(user=user)
-        FavoriteListFactory(user=user)
-        self.assertEqual(user.favorite_lists.count(), 2)
-        self.assertEqual(user.favorite_list_count, 2)
-        # delete 1 list
-        user.favorite_lists.first().delete()
-        self.assertEqual(user.favorite_lists.count(), 1)
-        self.assertEqual(user.favorite_list_count, 1)
 
 
 # To avoid different results when test will be run in the future, we patch
@@ -314,39 +160,6 @@ class UserAnonymizationTestCase(TestCase):
         self.assertFalse(TemplateTransactionalSendLog.objects.all())
 
 
-class UserAdminTestCase(TestCase):
-    def setUp(self):
-        UserFactory(is_staff=False, is_anonymized=False)
-        super_user = UserFactory(is_staff=True, is_superuser=True)
-        self.client.force_login(super_user)
-
-    def test_anonymize_action(self):
-        """Test the anonymize_users action from the admin"""
-
-        users_ids = User.objects.values_list("id", flat=True)
-        data = {
-            "action": "anonymize_users",
-            "_selected_action": users_ids,
-        }
-        # https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#reversing-admin-urls
-        change_url = reverse("admin:users_user_changelist")
-        response = self.client.post(path=change_url, data=data)
-
-        self.assertEqual(response.status_code, 302)
-
-        data_confirm = {"user_id": users_ids}
-
-        # click on confirm after seeing the confirmation page
-        response_confirm = self.client.post(response.url, data=data_confirm)
-        self.assertEqual(response.status_code, 302)
-
-        self.assertTrue(User.objects.filter(is_staff=False).first().is_anonymized)
-        self.assertFalse(User.objects.filter(is_staff=True).first().is_anonymized)
-
-        messages_strings = [str(message) for message in get_messages(response_confirm.wsgi_request)]
-        self.assertIn("L'anonymisation s'est déroulée avec succès", messages_strings)
-
-
 class UserBuyerImportTestCase(TestCase):
     """Test the import_buyers management command"""
 
@@ -358,8 +171,8 @@ class UserBuyerImportTestCase(TestCase):
         call_command(
             "import_buyers",
             "lemarche/fixtures/tests/acheteurs_import.csv",
-            "grosse-banque",
             "USER_IMPORT_BUYERS_BANQUE",
+            "grosse-banque",
             5,
             stdout=StringIO(),  # avoid polluting the logs in test execution
         )
@@ -394,14 +207,14 @@ class UserBuyerImportTestCase(TestCase):
         with (
             patch("lemarche.users.management.commands.import_buyers.add_to_contact_list") as mock_add_to_contact_list,
             patch(
-                "lemarche.users.management.commands.import_buyers.send_new_user_password_reset_link"
+                "lemarche.users.management.commands.base_import_users.send_new_user_password_reset_link"
             ) as mock_send_new_user_password_reset_link,
         ):
             call_command(
                 "import_buyers",
                 "lemarche/fixtures/tests/acheteurs_import.csv",
-                "grosse-banque",
                 "USER_IMPORT_BUYERS_BANQUE",
+                "grosse-banque",
                 5,
                 stdout=out,
             )
@@ -418,8 +231,10 @@ class UserBuyerImportTestCase(TestCase):
         duplicated_user = User.objects.get(email="dupont.lajoie@camping.fr")
         self.assertEqual(duplicated_user.company, self.company)
         self.assertEqual(duplicated_user.company_name, self.company.name)
-        self.assertIn("L'acheteur dupont.lajoie@camping.fr est déjà inscrit, entreprise mise à jour.", out.getvalue())
-        self.assertIn("L'acheteur françois.perrin@celc.test.fr a été inscrit avec succès.", out.getvalue())
+        self.assertIn(
+            "L'utilisateur dupont.lajoie@camping.fr est déjà inscrit, informations mises à jour.", out.getvalue()
+        )
+        self.assertIn("L'utilisateur françois.perrin@celc.test.fr a été inscrit avec succès.", out.getvalue())
 
     def test_email_dns_added(self):
         """Ensure that email domains are added to the company's email_domain_list, without duplicates."""
@@ -427,8 +242,8 @@ class UserBuyerImportTestCase(TestCase):
         call_command(
             "import_buyers",
             "lemarche/fixtures/tests/acheteurs_import.csv",
-            "grosse-banque",
             "USER_IMPORT_BUYERS_BANQUE",
+            "grosse-banque",
             5,
             stdout=StringIO(),
         )
@@ -439,8 +254,8 @@ class UserBuyerImportTestCase(TestCase):
         call_command(
             "import_buyers",
             "lemarche/fixtures/tests/acheteurs_import.csv",
-            "grosse-banque",
             "USER_IMPORT_BUYERS_BANQUE",
+            "grosse-banque",
             5,
             stdout=StringIO(),
         )
@@ -463,8 +278,8 @@ class UserBuyerImportTestCase(TestCase):
             call_command(
                 "import_buyers",
                 "lemarche/fixtures/tests/acheteurs_import.csv",
-                "grosse-banque",
                 "USER_IMPORT_BUYERS_BANQUE",
+                "grosse-banque",
                 5,
                 stdout=StringIO(),
             )
@@ -479,3 +294,79 @@ class UserBuyerImportTestCase(TestCase):
 
         self.company.refresh_from_db()
         self.assertEqual(self.company.email_domain_list, ["celc.test.fr"])
+
+
+class UserPartnerImportTestCase(TestCase):
+    """Test the import_partners management command"""
+
+    def setUp(self):
+        TemplateTransactionalFactory(code="USER_IMPORT_PARTNERS_FACILITATOR")
+
+    def test_import_partner(self):
+        with patch(
+            "lemarche.users.management.commands.base_import_users.send_new_user_password_reset_link"
+        ) as mock_send_new_user_password_reset_link:
+
+            call_command(
+                "import_partners",
+                "lemarche/fixtures/tests/partners_import.csv",
+                "USER_IMPORT_PARTNERS_FACILITATOR",
+                stdout=StringIO(),
+            )
+
+        self.assertEqual(mock_send_new_user_password_reset_link.call_count, 3)
+
+        self.assertQuerySetEqual(
+            User.objects.all(),
+            [
+                "<User: jean.dupont@facilitateur.fr>",
+                "<User: marie.martin@accompagnement.fr>",
+                "<User: pierre.durand@mediation.fr>",
+            ],
+            ordered=False,
+            transform=lambda x: repr(x),
+        )
+
+        self.assertQuerySetEqual(
+            User.objects.filter(partner_kind=PARTNER_KIND_FACILITATOR),
+            [
+                "<User: jean.dupont@facilitateur.fr>",
+                "<User: marie.martin@accompagnement.fr>",
+                "<User: pierre.durand@mediation.fr>",
+            ],
+            ordered=False,
+            transform=lambda x: repr(x),
+        )
+
+    def test_already_registered_partner(self):
+        """
+        Existing partner should not have its information updated and an error should be logged
+        """
+        UserFactory(email="jean.dupont@facilitateur.fr", kind=User.KIND_BUYER)
+        out = StringIO()
+        with patch(
+            "lemarche.users.management.commands.base_import_users.send_new_user_password_reset_link"
+        ) as mock_send_new_user_password_reset_link:
+            call_command(
+                "import_partners",
+                "lemarche/fixtures/tests/partners_import.csv",
+                "USER_IMPORT_PARTNERS_FACILITATOR",
+                stdout=out,
+            )
+            self.assertEqual(mock_send_new_user_password_reset_link.call_count, 2)
+
+        self.assertQuerySetEqual(
+            User.objects.all(),
+            [
+                "<User: jean.dupont@facilitateur.fr>",
+                "<User: marie.martin@accompagnement.fr>",
+                "<User: pierre.durand@mediation.fr>",
+            ],
+            ordered=False,
+            transform=lambda x: repr(x),
+        )
+        self.assertIn(
+            "L'utilisateur jean.dupont@facilitateur.fr est déjà inscrit, aucune mise à jour.", out.getvalue()
+        )
+        self.assertIn("L'utilisateur marie.martin@accompagnement.fr a été inscrit avec succès.", out.getvalue())
+        self.assertIn("L'utilisateur pierre.durand@mediation.fr a été inscrit avec succès.", out.getvalue())

--- a/lemarche/users/tests/test_models.py
+++ b/lemarche/users/tests/test_models.py
@@ -1,0 +1,194 @@
+from django.contrib.messages import get_messages
+from django.test import TestCase
+from django.urls import reverse
+
+from lemarche.companies.factories import CompanyFactory
+from lemarche.favorites.factories import FavoriteListFactory
+from lemarche.siaes.factories import SiaeFactory
+from lemarche.tenders.factories import TenderFactory
+from lemarche.users import constants as user_constants
+from lemarche.users.factories import UserFactory
+from lemarche.users.models import User
+
+
+class UserModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    def test_str(self):
+        user = UserFactory(email="coucou@example.com")
+        self.assertEqual(str(user), "coucou@example.com")
+
+    def test_full_name(self):
+        user = UserFactory(first_name="Paul", last_name="Anploi")
+        self.assertEqual(user.full_name, "Paul Anploi")
+
+    def test_kind_detail_display(self):
+        user_siae = UserFactory(kind=user_constants.KIND_SIAE)
+        user_buyer = UserFactory(kind=user_constants.KIND_BUYER)
+        user_buyer_public = UserFactory(kind=user_constants.KIND_BUYER, buyer_kind=user_constants.BUYER_KIND_PUBLIC)
+        user_buyer_private_pme = UserFactory(
+            kind=user_constants.KIND_BUYER,
+            buyer_kind=user_constants.BUYER_KIND_PRIVATE,
+            buyer_kind_detail=user_constants.BUYER_KIND_DETAIL_PRIVATE_PME,
+        )
+        user_partner = UserFactory(kind=user_constants.KIND_PARTNER)
+        user_partner_facilitator = UserFactory(
+            kind=user_constants.KIND_PARTNER, partner_kind=user_constants.PARTNER_KIND_FACILITATOR
+        )
+        self.assertEqual(user_siae.kind_detail_display, "Structure")
+        self.assertEqual(user_buyer.kind_detail_display, "Acheteur")
+        self.assertEqual(user_partner.kind_detail_display, "Partenaire")
+        self.assertEqual(user_buyer_public.kind_detail_display, "Acheteur")
+        self.assertEqual(user_buyer_private_pme.kind_detail_display, "Acheteur : PME")
+        self.assertEqual(
+            user_partner_facilitator.kind_detail_display, "Partenaire : Facilitateur des clauses sociales"
+        )
+
+
+class UserModelQuerysetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+
+    def test_is_admin_bizdev(self):
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True)
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="BizDev")
+        UserFactory(kind=user_constants.KIND_ADMIN, is_staff=True, position="Bizdev")
+        self.assertEqual(User.objects.count(), 1 + 3)
+        self.assertEqual(User.objects.is_admin_bizdev().count(), 2)
+
+    def test_has_company(self):
+        user_2 = UserFactory()
+        CompanyFactory(users=[user_2])
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_company().count(), 1)
+
+    def test_has_siae(self):
+        user_2 = UserFactory()
+        SiaeFactory(users=[user_2])
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_siae().count(), 1)
+
+    def test_has_tender(self):
+        user_2 = UserFactory()
+        TenderFactory(author=user_2)
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_tender().count(), 1)
+
+    def test_has_favorite_list(self):
+        user_2 = UserFactory()
+        FavoriteListFactory(user=user_2)
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_favorite_list().count(), 1)
+
+    def test_has_api_key(self):
+        UserFactory(api_key="coucou")
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.has_api_key().count(), 1)
+
+    def test_has_email_domain(self):
+        UserFactory(email="test@ain.fr")
+        UserFactory(email="test@plateau-urbain.fr")
+        self.assertEqual(User.objects.count(), 1 + 2)
+        for EMAIL_DOMAIN in ["ain.fr", "@ain.fr"]:
+            with self.subTest(email_domain=EMAIL_DOMAIN):
+                self.assertEqual(User.objects.has_email_domain(email_domain=EMAIL_DOMAIN).count(), 1)
+
+    def test_with_siae_stats(self):
+        user_2 = UserFactory()
+        SiaeFactory(users=[user_2])
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.with_siae_stats().filter(id=self.user.id).first().siae_count_annotated, 0)
+        self.assertEqual(User.objects.with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1)
+
+    def test_with_tender_stats(self):
+        user_2 = UserFactory()
+        TenderFactory(author=user_2)
+        self.assertEqual(User.objects.count(), 1 + 1)
+        self.assertEqual(User.objects.with_tender_stats().filter(id=self.user.id).first().tender_count_annotated, 0)
+        self.assertEqual(User.objects.with_tender_stats().filter(id=user_2.id).first().tender_count_annotated, 1)
+
+    def test_chain_querysets(self):
+        user_2 = UserFactory(api_key="chain")
+        siae = SiaeFactory()
+        siae.users.add(user_2)
+        self.assertEqual(
+            User.objects.has_api_key().with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1
+        )
+
+
+class UserModelSaveTest(TestCase):
+    def setUp(self):
+        pass
+
+    def test_update_last_updated_fields(self):
+        user = UserFactory()
+        self.assertIsNone(user.api_key)
+        self.assertIsNone(user.api_key_last_updated)
+        # new value: last_updated field will be set
+        user = User.objects.get(id=user.id)  # we need to fetch it again to pass through the __init__
+        user.api_key = "AZERTY"
+        user.save()
+        self.assertEqual(user.api_key, "AZERTY")
+        self.assertIsNotNone(user.api_key_last_updated)
+        api_key_last_updated = user.api_key_last_updated
+        # same value: last_updated field will not be updated
+        user = User.objects.get(id=user.id)
+        user.api_key = "AZERTY"
+        user.save()
+        self.assertEqual(user.api_key, "AZERTY")
+        self.assertEqual(user.api_key_last_updated, api_key_last_updated)
+        # updated value: last_updated field will be updated
+        user = User.objects.get(id=user.id)
+        user.api_key = "QWERTY"
+        user.save()
+        self.assertEqual(user.api_key, "QWERTY")
+        self.assertNotEqual(user.api_key_last_updated, api_key_last_updated)
+
+    def test_update_related_favorite_list_count_on_save(self):
+        user = UserFactory()
+        self.assertEqual(user.favorite_list_count, 0)
+        # create 2 lists
+        FavoriteListFactory(user=user)
+        FavoriteListFactory(user=user)
+        self.assertEqual(user.favorite_lists.count(), 2)
+        self.assertEqual(user.favorite_list_count, 2)
+        # delete 1 list
+        user.favorite_lists.first().delete()
+        self.assertEqual(user.favorite_lists.count(), 1)
+        self.assertEqual(user.favorite_list_count, 1)
+
+
+class UserAdminTestCase(TestCase):
+    def setUp(self):
+        UserFactory(is_staff=False, is_anonymized=False)
+        super_user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(super_user)
+
+    def test_anonymize_action(self):
+        """Test the anonymize_users action from the admin"""
+
+        users_ids = User.objects.values_list("id", flat=True)
+        data = {
+            "action": "anonymize_users",
+            "_selected_action": users_ids,
+        }
+        # https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#reversing-admin-urls
+        change_url = reverse("admin:users_user_changelist")
+        response = self.client.post(path=change_url, data=data)
+
+        self.assertEqual(response.status_code, 302)
+
+        data_confirm = {"user_id": users_ids}
+
+        # click on confirm after seeing the confirmation page
+        response_confirm = self.client.post(response.url, data=data_confirm)
+        self.assertEqual(response.status_code, 302)
+
+        self.assertTrue(User.objects.filter(is_staff=False).first().is_anonymized)
+        self.assertFalse(User.objects.filter(is_staff=True).first().is_anonymized)
+
+        messages_strings = [str(message) for message in get_messages(response_confirm.wsgi_request)]
+        self.assertIn("L'anonymisation s'est déroulée avec succès", messages_strings)


### PR DESCRIPTION
### Quoi ?

Import d'utilisateur de type "Partenaire"

### Pourquoi ?

Pour importer une liste de facilitateurs.

### Comment ?

En partant de la commande d'import des acheteurs, avec un bel héritage ;)

### Autre : 

Avant de lancer la commande (python manage.py import_partners partners_import.csv USER_IMPORT_PARTNER_KIND_FACILITATOR), penser à créer le template de mail avec les bonnes variables : 

```
variables = {
    "USER_ID":
    "USER_FIRST_NAME": ,
    "USER_EMAIL": ,
    "PASSWORD_RESET_LINK": ,
}
```

