### PR TITLE
fix: Chargement des comptes structures très lents

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -290,7 +290,7 @@ class TenderQuerySet(models.QuerySet):
             f"unread_count_{kind}_annotated": Count(Case(When(kind=kind, then=1), output_field=IntegerField()))
             for kind, _ in tender_constants.KIND_CHOICES
         }
-        return self.unread(user).aggregate(**aggregates)
+        return self.unread(user).values("id").aggregate(**aggregates)
 
     def with_network_siae_stats(self, network_siaes):
         return self.annotate(

--- a/lemarche/tenders/tests/test_models.py
+++ b/lemarche/tenders/tests/test_models.py
@@ -635,7 +635,8 @@ class TenderModelQuerysetUnreadStatsTest(TestCase):
         _ = TenderFactory(siaes=[siae_with_tender_1], deadline_date=date_tomorrow, kind=tender_constants.KIND_TENDER)
 
     def test_unread_stats(self):
-        stats = Tender.objects.unread_stats(user=self.user_siae)
+        with self.assertNumQueries(1):
+            stats = Tender.objects.unread_stats(user=self.user_siae)
         self.assertEqual(stats[f"unread_count_{tender_constants.KIND_TENDER}_annotated"], 1)
         self.assertEqual(stats[f"unread_count_{tender_constants.KIND_QUOTE}_annotated"], 2)
         self.assertEqual(stats[f"unread_count_{tender_constants.KIND_PROJECT}_annotated"], 0)

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -427,7 +427,7 @@ class User(AbstractUser):
     def tender_siae_unread_count(self):
         from lemarche.tenders.models import Tender
 
-        return Tender.objects.unread(self).count()
+        return Tender.objects.unread(self).values("id").count()
 
 
 @receiver(pre_save, sender=User)

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -437,6 +437,7 @@ class TenderFilterForm(forms.Form):
     )
 
     def __init__(self, user, *args, **kwargs):
+        """Adds a count of unread notifications to each sections in the dropdown for filtering tender types."""
         super().__init__(*args, **kwargs)
 
         stats = Tender.objects.unread_stats(user=user)


### PR DESCRIPTION
### Quoi ?

Certains comptes avec beaucoup de besoins mettaient très longtemps à charger (~30 sec)

### Pourquoi ?

Les modèles des besoins comportent trop de colonnes, certaines assez lourdes. Des requètes `count()` prenaient en compte toutes les colonnes du modèle.

### Comment ?

Effectuer les requêtes count seulement en sélectionnant les colonnes id.