### PR TITLE
fix: Bug d'instruction de DDB manquant pour l'API

### DIFF
--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -274,6 +274,18 @@ class TenderCreateApiTest(TestCase):
         self.assertEqual(author.kind, user_constants.KIND_BUYER)
         self.assertEqual(author.buyer_kind_detail, user_constants.BUYER_KIND_DETAIL_PUBLIC_ASSOCIATION)
 
+    def test_create_tender_without_constraint(self):
+        """An associated TenderInstruction does not exist but tender creation still proceed"""
+        tender_data = TENDER_JSON.copy()
+        tender_data["kind"] = "PROJ"
+        response = self.client.post(
+            self.url,
+            data=tender_data,
+            content_type="application/json",
+            headers={"authorization": f"Bearer {self.user_token}"},
+        )
+        self.assertEqual(response.status_code, 201)
+
 
 def test_create_tender_with_include_country_area(self):
     tender_data = TENDER_JSON.copy()

--- a/lemarche/fixtures/django/22_tender_instructions.json
+++ b/lemarche/fixtures/django/22_tender_instructions.json
@@ -43,6 +43,16 @@
     "model": "tenders.tenderinstruction",
     "pk": 5,
     "fields": {
+        "title": "Comment répondre à cet appel d'offre APProch",
+        "text": "<p>1. Cliquez sur “Accédez au lien\" afin d’obtenir le lien et les détails de ce sourcing sur APProch<br />\r\n<strong>2. Ce projet d’achat est relayé par la plateforme de l’Etat : APProch. Connectez-vous sur celle-ci en vous créant un identifiant, puis cliquez sur \"Ça m'intéresse\"</strong><br />\r\n3. Contactez-nous par mail commercial@lemarche.inclusion.beta.gouv.fr pour toute question</p>",
+        "tender_type": "TENDER",
+        "tender_source": "API"
+    }
+},
+{
+    "model": "tenders.tenderinstruction",
+    "pk": 5,
+    "fields": {
         "title": "Comment répondre à ce projet d'achat APProch",
         "text": "<p>1. Cliquez sur “Accédez au lien\" afin d’obtenir le lien et les détails de ce sourcing sur APProch<br />\r\n<strong>2. Ce projet d’achat est relayé par la plateforme de l’Etat : APProch. Connectez-vous sur celle-ci en vous créant un identifiant, puis cliquez sur \"Ça m'intéresse\"</strong><br />\r\n3. Contactez-nous par mail commercial@lemarche.inclusion.beta.gouv.fr pour toute question</p>",
         "tender_type": "PROJ",

--- a/lemarche/fixtures/django/22_tender_instructions.json
+++ b/lemarche/fixtures/django/22_tender_instructions.json
@@ -45,7 +45,7 @@
     "fields": {
         "title": "Comment répondre à ce projet d'achat APProch",
         "text": "<p>1. Cliquez sur “Accédez au lien\" afin d’obtenir le lien et les détails de ce sourcing sur APProch<br />\r\n<strong>2. Ce projet d’achat est relayé par la plateforme de l’Etat : APProch. Connectez-vous sur celle-ci en vous créant un identifiant, puis cliquez sur \"Ça m'intéresse\"</strong><br />\r\n3. Contactez-nous par mail commercial@lemarche.inclusion.beta.gouv.fr pour toute question</p>",
-        "tender_type": "TENDER",
+        "tender_type": "PROJ",
         "tender_source": "API"
     }
 }


### PR DESCRIPTION
### Quoi ?

Pour l'api l'instruction n'était pas dans la bonne catégorie. Approch crée des sourcings (`PROJ`) et des appels d'offres (`TENDER`).
Un bloc avec une exception à été créé pour éviter de bloquer la création des tenders via l'api s'il n'y a pas la bonne "notice"