### PR TITLE
fix: L'inscription avec une adresse déjà enregistrée causait un bug

### DIFF
--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -146,7 +146,8 @@ class CustomSignupForm(SignupForm, DsfrBaseForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        if self.cleaned_data["kind"] == User.KIND_BUYER:
+        # email is not in cleaned data when detected as duplicated
+        if self.cleaned_data["kind"] == User.KIND_BUYER and cleaned_data.get("email"):
             try:
                 professional_email_validator(cleaned_data["email"])
             except ValidationError as e:


### PR DESCRIPTION
### Quoi ?

La validation des emails dupliqués faisait qu'ils n'était plus présent dans `cleaned_data`