### PR TITLE
fix: Correction de l'affichage des coordonnées sur un dépôt de besoin

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -338,10 +338,6 @@ USE_I18N = True
 
 USE_TZ = True
 
-# French number formatting (spaces for thousands)
-USE_THOUSAND_SEPARATOR = True
-NUMBER_GROUPING = 3
-
 SITE_ID = 1
 
 PHONENUMBER_DEFAULT_REGION = "FR"


### PR DESCRIPTION
### Quoi ?

Suppression du formatage automatique des nombres.

### Pourquoi ?

Le formatage des nombres avec des espaces (introduit dans la PR #1742 ) génère des erreurs dans les URL composées dans les templates.

### Comment ?

Suppression du formatage global pour éviter tout effet de bord.