### PR TITLE
feat: Sélection des colonnes exportables

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1108,6 +1108,14 @@ class Siae(models.Model):
             latest_activity_at = self.updated_at
         return latest_activity_at
 
+    @property
+    def client_reference_list_display(self) -> str:
+        return ", ".join(self.client_references.values_list("name", flat=True))
+
+    @property
+    def label_list_display(self) -> str:
+        return ", ".join(self.siaelabel_set.values_list("label__name", flat=True))
+
     def sector_groups_list_string(self, display_max=3):
         # Retrieve sectors from activities instead of directly from the sectors field
         sectors_name_list = list(set(self.activities.values_list("sector__group__name", flat=True)))

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -106,20 +106,61 @@
                                         <div class="fr-col-12 fr-col-lg-6">
                                             <ul class="fr-btns-group fr-btns-group--inline-md fr-btns-group--icon-left">
                                                 <li>
-                                                    <a href="{% url 'tenders:download-siae-list' slug=tender.slug %}?tendersiae_status={{ status|default:"" }}&{{ current_search_query }}&format=xlsx"
-                                                       id="tender-siae-interested-export-xls"
-                                                       class="fr-btn fr-btn--tertiary fr-icon-download-fill fr-btn--icon-left">
-                                                        Télécharger la liste (.xlsx)
-                                                    </a>
-                                                </li>
-                                                <li>
-                                                    <a href="{% url 'tenders:download-siae-list' slug=tender.slug %}?tendersiae_status={{ status|default:"" }}&{{ current_search_query }}&format=csv"
-                                                       id="tender-siae-interested-export-csv"
-                                                       class="fr-btn fr-btn--tertiary fr-icon-download-fill fr-btn--icon-left">
-                                                        Télécharger la liste (.csv)
-                                                    </a>
+                                                  <button type="button"
+                                                          class="fr-btn fr-btn--tertiary fr-icon-download-fill fr-btn--icon-left"
+                                                          data-fr-opened="false"
+                                                          aria-controls="fr-modal-download">
+                                                    Télécharger la liste
+                                                  </button>
                                                 </li>
                                             </ul>
+                                          <dialog aria-labelledby="fr-modal-download-title" role="dialog" id="fr-modal-download"
+                                                  class="fr-modal">
+                                            <div class="fr-container fr-container--fluid fr-container-md">
+                                              <div class="fr-grid-row fr-grid-row--center">
+                                                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                                                  <div class="fr-modal__body">
+                                                    <div class="fr-modal__header">
+                                                      <button class="fr-btn--close fr-btn" title="Fermer la fenêtre"
+                                                              aria-controls="fr-modal-download">Fermer
+                                                      </button>
+                                                    </div>
+                                                    <div class="fr-modal__content">
+                                                      <h1 id="fr-modal-download-title" class="fr-modal__title">Télécharger
+                                                        la liste </h1>
+                                                      <p>Voulez-vous télécharger la liste des prestataires ?
+                                                      </p>
+                                                      <form method="get"
+                                                            id="download-form"
+                                                            action="{% url 'tenders:download-siae-list' slug=tender.slug %}">
+                                                        {% dsfr_form download_form %}
+                                                        <input type="hidden" name="tendersiae_status" value="{{ status|default:"" }}">
+                                                      </form>
+
+                                                    </div>
+                                                    <div class="fr-modal__footer">
+                                                      <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+                                                        <li>
+                                                          <button
+                                                             class="fr-btn"
+                                                             type="submit"
+                                                             form="download-form"
+                                                             id="tender-siae-interested-export-xls">
+                                                            Télécharger
+                                                          </button>
+                                                        </li>
+                                                        <li>
+                                                          <button class="fr-btn fr-btn--secondary"
+                                                                  aria-controls="fr-modal">Annuler
+                                                          </button>
+                                                        </li>
+                                                      </ul>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </dialog>
                                         </div>
                                     </div>
                                     <div class="fr-grid-row fr-grid-row--gutters">

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -151,7 +151,7 @@
                                                         </li>
                                                         <li>
                                                           <button class="fr-btn fr-btn--secondary"
-                                                                  aria-controls="fr-modal">Annuler
+                                                                  aria-controls="fr-modal-download">Annuler
                                                           </button>
                                                         </li>
                                                       </ul>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -104,7 +104,7 @@
                                             <h1>{{ siaes.count }} prestataire{{ siaes.count|pluralize }}</h1>
                                         </div>
                                         <div class="fr-col-12 fr-col-lg-6">
-                                            <ul class="fr-btns-group fr-btns-group--inline-md fr-btns-group--icon-left">
+                                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-md fr-btns-group--icon-left">
                                                 <li>
                                                   <button type="button"
                                                           class="fr-btn fr-btn--tertiary fr-icon-download-fill fr-btn--icon-left"

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -133,8 +133,25 @@
                                                       <form method="get"
                                                             id="download-form"
                                                             action="{% url 'tenders:download-siae-list' slug=tender.slug %}">
-                                                        {% dsfr_form download_form %}
+                                                        {% dsfr_form_field download_form.format %}
+                                                        {# real checkbox are hidden here, they are used for form submission #}
+                                                        <div style="display:none;"> {{ download_form.selected_fields }} </div>
                                                         <input type="hidden" name="tendersiae_status" value="{{ status|default:"" }}">
+
+                                                        {# These clickable tags will act as checkboxes, and their value will be linked #}
+                                                        {# to the real checkboxes via js #}
+                                                        <ul class="fr-tags-group">
+                                                            {% for tag in download_form.selected_fields %}
+                                                            <li>
+                                                                <button class="fr-tag"
+                                                                        aria-pressed="{% if tag.data.selected %}true{% else %}false{% endif %}"
+                                                                        data-target-id="{{ tag.id_for_label }}">
+                                                                    {{ tag.choice_label }}
+                                                                </button>
+                                                            </li>
+                                                            {% endfor %}
+                                                        </ul>
+
                                                       </form>
 
                                                     </div>
@@ -194,4 +211,31 @@
         locationsAutoComplete.init();
     });
     </script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+          // Select all tags used to select exports
+          const tags = document.querySelectorAll('.fr-tags-group .fr-tag');
+
+          tags.forEach(tag => {
+              tag.addEventListener('click', function (event) {
+                  // Prevent form submission on button click
+                  event.preventDefault();
+
+                  // get checkbox id
+                  const targetId = this.dataset.targetId;
+                  if (!targetId) return;
+
+                  // Get hidden checkbox id
+                  const targetCheckbox = document.getElementById(targetId);
+                  if (!targetCheckbox) return;
+
+                  // Invert checkbox state
+                  targetCheckbox.checked = !targetCheckbox.checked;
+
+                  // Update visual state for tag
+                  this.setAttribute('aria-pressed', targetCheckbox.checked);
+              });
+          });
+      });
+      </script>
 {% endblock extra_js %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -134,23 +134,32 @@
                                                             id="download-form"
                                                             action="{% url 'tenders:download-siae-list' slug=tender.slug %}">
                                                         {% dsfr_form_field download_form.format %}
-                                                        {# real checkbox are hidden here, they are used for form submission #}
-                                                        <div style="display:none;"> {{ download_form.selected_fields }} </div>
                                                         <input type="hidden" name="tendersiae_status" value="{{ status|default:"" }}">
 
                                                         {# These clickable tags will act as checkboxes, and their value will be linked #}
                                                         {# to the real checkboxes via js #}
-                                                        <ul class="fr-tags-group">
-                                                            {% for tag in download_form.selected_fields %}
-                                                            <li>
-                                                                <button class="fr-tag"
-                                                                        aria-pressed="{% if tag.data.selected %}true{% else %}false{% endif %}"
-                                                                        data-target-id="{{ tag.id_for_label }}">
-                                                                    {{ tag.choice_label }}
-                                                                </button>
+                                                        <label class="fr-label">{{ download_form.selected_fields.label }}</label>
+
+                                                          <ul class="fr-tags-group">
+                                                            {% for value, label in download_form.selected_fields.field.choices %}
+                                                            <li x-data="{ {{ value }}: false }">
+                                                                {# real checkbox are hidden here, they are used for form submission #}
+                                                              <input type="checkbox"
+                                                                     name="{{ download_form.selected_fields.html_name }}"
+                                                                     value="{{ value }}"
+                                                                     x-model="{{ value }}"
+                                                                     style="display: none;"
+                                                              >
+
+                                                              <button type="button" class="fr-tag"
+                                                                      x-on:click="{{ value }} = !{{ value }}"
+                                                                      aria-pressed="false"
+                                                              >
+                                                                  {{ label }}
+                                                              </button>
                                                             </li>
                                                             {% endfor %}
-                                                        </ul>
+                                                          </ul>
 
                                                       </form>
 
@@ -211,31 +220,4 @@
         locationsAutoComplete.init();
     });
     </script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-          // Select all tags used to select exports
-          const tags = document.querySelectorAll('.fr-tags-group .fr-tag');
-
-          tags.forEach(tag => {
-              tag.addEventListener('click', function (event) {
-                  // Prevent form submission on button click
-                  event.preventDefault();
-
-                  // get checkbox id
-                  const targetId = this.dataset.targetId;
-                  if (!targetId) return;
-
-                  // Get hidden checkbox id
-                  const targetCheckbox = document.getElementById(targetId);
-                  if (!targetCheckbox) return;
-
-                  // Invert checkbox state
-                  targetCheckbox.checked = !targetCheckbox.checked;
-
-                  // Update visual state for tag
-                  this.setAttribute('aria-pressed', targetCheckbox.checked);
-              });
-          });
-      });
-      </script>
 {% endblock extra_js %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -220,4 +220,34 @@
         locationsAutoComplete.init();
     });
     </script>
+    <script>
+        /*Script to add the filter form parameter to the form used to download results in a file.
+        * Results in the file should be filtered just as the ones displayed on the page*/
+
+        // Get download-form
+        const downloadForm = document.getElementById('download-form');
+
+        // listen to submit button event
+        downloadForm.addEventListener('submit', function(event) {
+
+            // get current url param, used to filter results
+            const currentUrlParams = new URLSearchParams(window.location.search);
+
+            // create a hidden input in the download form for each url param
+            for (const [key, value] of currentUrlParams.entries()) {
+
+                // check if not empty
+                if (value) {
+                    const hiddenInput = document.createElement('input');
+                    hiddenInput.type = 'hidden';
+                    hiddenInput.name = key;
+                    hiddenInput.value = value;
+                    hiddenInput.className = 'filter-param'; // handy class
+                    // add to download-form
+                    this.appendChild(hiddenInput);
+                }
+            }
+            // submission will go on and params to url will be added according to the download form
+        });
+    </script>
 {% endblock extra_js %}

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -35,7 +35,8 @@ SIAE_CUSTOM_FIELDS = ["Inscrite", "Lien vers le marché"]
 
 
 def get_siae_fields(with_contact_info=False):
-    siae_field_list = SIAE_FIELDS_TO_EXPORT
+    # To not copy reference
+    siae_field_list = [] + SIAE_FIELDS_TO_EXPORT
     if with_contact_info:
         siae_field_list += SIAE_CONTACT_FIELDS
     siae_field_list += SIAE_CUSTOM_FIELDS

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -468,20 +468,25 @@ class SiaeSelectFieldsForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         fields = [
-            "name",
-            "siret",
-            "kind",
-            "address",
-            "region",
-            "department",
-            "ca",
-            # "client_references",
-            # "siaelabel_set",
-            "employees_insertion_count",
-            "employees_permanent_count",
+            ("name", None),
+            ("siret", None),
+            ("kind", None),
+            ("address", None),
+            ("city", None),
+            ("post_code", None),
+            ("region", None),
+            ("department", None),
+            ("ca", None),
+            ("client_reference_list_display", "Références client"),
+            ("label_list_display", "Certifications et labels"),
+            ("employees_insertion_count", None),
+            ("employees_permanent_count", None),
+            ("contact_first_name", None),
+            ("contact_last_name", None),
+            ("contact_email", None),
+            ("contact_phone", None),
         ]
 
-        for field_name in fields:
-            self.fields[field_name] = forms.BooleanField(
-                required=False, label=Siae._meta.get_field(field_name).verbose_name
-            )
+        for field_name, field_label in fields:
+            field_label = field_label if field_label else Siae._meta.get_field(field_name).verbose_name
+            self.fields[field_name] = forms.BooleanField(required=False, label=field_label)

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -463,11 +463,14 @@ class SiaeSelectFieldsForm(forms.Form):
     """Form used to select fields to appear in the downloaded file"""
 
     format = forms.ChoiceField(choices=(("xlsx", ".xlsx"), ("csv", ".csv")), label="Format")
+    selected_fields = forms.MultipleChoiceField(
+        label="Colonnes à sélectionner", widget=forms.CheckboxSelectMultiple, required=False
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        fields = [
+        selectable_fields = [
             ("name", None),
             ("siret", None),
             ("kind", None),
@@ -486,7 +489,10 @@ class SiaeSelectFieldsForm(forms.Form):
             ("contact_email", None),
             ("contact_phone", None),
         ]
+        # Set label from model if not provided in tuple
+        selectable_fields = [
+            (field_name, field_label if field_label else Siae._meta.get_field(field_name).verbose_name)
+            for field_name, field_label in selectable_fields
+        ]
 
-        for field_name, field_label in fields:
-            field_label = field_label if field_label else Siae._meta.get_field(field_name).verbose_name
-            self.fields[field_name] = forms.BooleanField(required=False, label=field_label)
+        self.fields["selected_fields"].choices = selectable_fields

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -488,6 +488,7 @@ class SiaeSelectFieldsForm(forms.Form):
             ("contact_last_name", None),
             ("contact_email", None),
             ("contact_phone", None),
+            ("siae_answers", "Réponse aux questions"),
         ]
         # Set label from model if not provided in tuple
         selectable_fields = [

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -457,3 +457,31 @@ class TenderDetailGetParams(forms.Form):
 
     siae_id = forms.ModelChoiceField(queryset=Siae.objects.all(), required=False)
     user_id = forms.ModelChoiceField(queryset=User.objects.all(), required=False)
+
+
+class SiaeSelectFieldsForm(forms.Form):
+    """Form used to select fields to appear in the downloaded file"""
+
+    format = forms.ChoiceField(choices=(("xlsx", ".xlsx"), ("csv", ".csv")), label="Format")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        fields = [
+            "name",
+            "siret",
+            "kind",
+            "address",
+            "region",
+            "department",
+            "ca",
+            # "client_references",
+            # "siaelabel_set",
+            "employees_insertion_count",
+            "employees_permanent_count",
+        ]
+
+        for field_name in fields:
+            self.fields[field_name] = forms.BooleanField(
+                required=False, label=Siae._meta.get_field(field_name).verbose_name
+            )

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2117,7 +2117,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         ):  # That status is implicit, it switches to targeted when no status is given
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=&format=csv"
+                + "?tendersiae_status=&download_form-format=csv&download_form-name=on"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2127,7 +2127,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         with self.subTest(status="VIEWED"):
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=VIEWED&format=csv"
+                + "?tendersiae_status=VIEWED&download_form-format=csv&download_form-name=on"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2137,7 +2137,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         with self.subTest(status="INTERESTED"):
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=INTERESTED&format=csv"
+                + "?tendersiae_status=INTERESTED&download_form-format=csv&download_form-name=on"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2147,7 +2147,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_csv(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?format=csv&tendersiae_status=INTERESTED"
+            + "?download_form-format=csv&tendersiae_status=INTERESTED&download_form-name=on"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
@@ -2173,7 +2173,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_xlsx(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?format=xlsx&tendersiae_status=INTERESTED"
+            + "?download_form-format=xlsx&tendersiae_status=INTERESTED&download_form-name=on"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
@@ -2191,10 +2191,10 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         self.assertEqual(sheet["A2"].value, "siae_1")
         self.assertEqual(sheet["A3"].value, "siae_2")
 
-        self.assertEqual(sheet["X1"].value, "question_1_title")
-        self.assertEqual(sheet["X2"].value, "answer_for_q1_from_siae_1")
-        self.assertEqual(sheet["X3"].value, "answer_for_q1_from_siae_2")
+        self.assertEqual(sheet["B1"].value, "question_1_title")
+        self.assertEqual(sheet["B2"].value, "answer_for_q1_from_siae_1")
+        self.assertEqual(sheet["B3"].value, "answer_for_q1_from_siae_2")
 
-        self.assertEqual(sheet["Y1"].value, "question_2_title")
-        self.assertEqual(sheet["Y2"].value, "answer_for_q2_from_siae_1")
-        self.assertEqual(sheet["Y3"].value, "answer_for_q2_from_siae_2")
+        self.assertEqual(sheet["C1"].value, "question_2_title")
+        self.assertEqual(sheet["C2"].value, "answer_for_q2_from_siae_1")
+        self.assertEqual(sheet["C3"].value, "answer_for_q2_from_siae_2")

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2159,7 +2159,8 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_csv(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?download_form-format=csv&tendersiae_status=INTERESTED&download_form-selected_fields=name"
+            + "?download_form-format=csv&tendersiae_status=INTERESTED"
+            "&download_form-selected_fields=name&download_form-selected_fields=siae_answers"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
@@ -2185,7 +2186,8 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_xlsx(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?download_form-format=xlsx&tendersiae_status=INTERESTED&download_form-selected_fields=name"
+            + "?download_form-format=xlsx&tendersiae_status=INTERESTED"
+            "&download_form-selected_fields=name&download_form-selected_fields=siae_answers"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2079,7 +2079,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def setUp(self):
         self.user = UserFactory(kind=User.KIND_BUYER)
 
-        siae_1 = SiaeFactory(name="siae_1")
+        siae_1 = SiaeFactory(name="siae_1", kind=siae_constants.KIND_ETTI)
         siae_2 = SiaeFactory(name="siae_2")
         siae_3 = SiaeFactory(name="siae_3")
 
@@ -2109,6 +2109,18 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         QuestionAnswerFactory(question=q2, siae=siae_2, answer="answer_for_q2_from_siae_2")
 
         self.client.force_login(self.user)
+
+    def test_filter_columns(self):
+        """Checks that the filtering form appearing on the tender siae list page is also filtering
+        results in downloaded tender siaes"""
+        response = self.client.get(
+            reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
+            + "?tendersiae_status=&download_form-format=csv&kind=ETTI"
+        )
+        content = response.content.decode("utf-8")
+        csv_reader = csv.DictReader(content.splitlines())
+        rows = list(csv_reader)
+        self.assertEqual(len(rows), 1)  # There is one kind ETTI siae in our sample data
 
     def test_filtering(self):
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2117,7 +2117,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         ):  # That status is implicit, it switches to targeted when no status is given
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=&download_form-format=csv&download_form-name=on"
+                + "?tendersiae_status=&download_form-format=csv&download_form-selected_fields=name"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2127,7 +2127,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         with self.subTest(status="VIEWED"):
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=VIEWED&download_form-format=csv&download_form-name=on"
+                + "?tendersiae_status=VIEWED&download_form-format=csv&download_form-selected_fields=name"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2137,7 +2137,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         with self.subTest(status="INTERESTED"):
             response = self.client.get(
                 reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-                + "?tendersiae_status=INTERESTED&download_form-format=csv&download_form-name=on"
+                + "?tendersiae_status=INTERESTED&download_form-format=csv&download_form-selected_fields=name"
             )
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
@@ -2147,7 +2147,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_csv(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?download_form-format=csv&tendersiae_status=INTERESTED&download_form-name=on"
+            + "?download_form-format=csv&tendersiae_status=INTERESTED&download_form-selected_fields=name"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
@@ -2173,7 +2173,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
     def test_download_xlsx(self):
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?download_form-format=xlsx&tendersiae_status=INTERESTED&download_form-name=on"
+            + "?download_form-format=xlsx&tendersiae_status=INTERESTED&download_form-selected_fields=name"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2115,7 +2115,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         results in downloaded tender siaes"""
         response = self.client.get(
             reverse("tenders:download-siae-list", kwargs={"slug": self.tender.slug})
-            + "?tendersiae_status=&download_form-format=csv&kind=ETTI"
+            + "?tendersiae_status=VIEWED&download_form-format=csv&download_form-selected_fields=name&kind=ETTI"
         )
         content = response.content.decode("utf-8")
         csv_reader = csv.DictReader(content.splitlines())

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -772,7 +772,7 @@ class TenderSiaeInterestedDownloadView(LoginRequiredMixin, DetailView):
         if form.is_valid():
             self.selected_fields = form.cleaned_data.get("selected_fields")
         else:
-            return None
+            return HttpResponse(400)
 
         question_list = TenderQuestion.objects.filter(tender=self.object).order_by("id").values_list("text", flat=True)
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -37,7 +37,7 @@ from lemarche.users.models import User
 from lemarche.utils import constants, settings_context_processors
 from lemarche.utils.data import get_choice
 from lemarche.utils.emails import add_to_contact_list
-from lemarche.utils.export import generate_header, generate_siae_row
+from lemarche.utils.export import generate_siae_row
 from lemarche.utils.mixins import (
     SesameSiaeMemberRequiredMixin,
     SesameTenderAuthorRequiredMixin,
@@ -770,7 +770,7 @@ class TenderSiaeInterestedDownloadView(LoginRequiredMixin, DetailView):
 
         question_list = TenderQuestion.objects.filter(tender=self.object).order_by("id").values_list("text", flat=True)
 
-        header_list = generate_header(self.get_selected_fields()) + list(question_list)
+        header_list = self.get_selected_fields_labels() + list(question_list)
 
         if self.request.GET.get("download_form-format") == "csv":
             return self.get_csv_response(siae_qs, header_list)
@@ -782,6 +782,17 @@ class TenderSiaeInterestedDownloadView(LoginRequiredMixin, DetailView):
         form = SiaeSelectFieldsForm(data=self.request.GET, prefix="download_form")
         if form.is_valid():
             return form.cleaned_data["selected_fields"]
+
+    def get_selected_fields_labels(self):
+        """For each selected siae field in the form, return the corresponding label"""
+        form = SiaeSelectFieldsForm(data=self.request.GET, prefix="download_form")
+        if form.is_valid():
+            selected_values = form.cleaned_data["selected_fields"]
+
+            choices_dict = dict(form.fields["selected_fields"].choices)
+            selected_labels = [choices_dict.get(value) for value in selected_values]
+
+            return selected_labels
 
     def get_filename(self, extension: str) -> str:
         """Get name for the exported file, according status and format."""

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -781,8 +781,7 @@ class TenderSiaeInterestedDownloadView(LoginRequiredMixin, DetailView):
         """Return the list of siae fields to be included as columns in the file"""
         form = SiaeSelectFieldsForm(data=self.request.GET, prefix="download_form")
         if form.is_valid():
-            selected_fields = [key for key, value in form.cleaned_data.items() if value and key != "format"]
-            return selected_fields
+            return form.cleaned_data["selected_fields"]
 
     def get_filename(self, extension: str) -> str:
         """Get name for the exported file, according status and format."""


### PR DESCRIPTION
### Quoi ?

Un popup permet à l'acheteur de sélectionner quelles colonnes il souhaite exporter, et sous quel format de fichier.
Les colonnes à sélectionner sont affichées sous forme de tags, et le formulaire de filtrage est aussi actif pour filtrer les données téléchargées.

### Difficultés rencontrées
Naturellement, le formulaires avec `action="get"` ne prennent pas en compte les paramêtres get fournis dans l'url. Un script a été créer pour récupérer ces champs de filtrations et les copier en hidden input dans le formulaire de téléchargement.
Des conflits de javascript sont présents au niveau des tags, il ne m'a pas été possible de désactiver le js du dsfr au niveau des tags bien qu'il ne soit pas nécessaire à leur fonctionnement.
Au final cela marche dans notre cas car l'information est bien propagée du tag vers le champs caché, mais pas dans l'autre sens.