### PR TITLE
feat(Structure): Ajout du badge Hosmoz

### DIFF
--- a/lemarche/fixtures/django/0a_networks.json
+++ b/lemarche/fixtures/django/0a_networks.json
@@ -142,5 +142,17 @@
             "created_at": "2021-07-01T12:47:25Z",
             "updated_at": "2021-10-26T22:26:47.604Z"
         }
+    },
+    {
+        "model": "networks.network",
+        "pk": 14,
+        "fields": {
+            "name": "Hosmoz",
+            "slug": "hosmoz",
+            "brand": "",
+            "website": "https://www.hosmoz.fr/",
+            "created_at": "2025-08-13T12:47:25Z",
+            "updated_at": "2025-08-13T22:26:47.604Z"
+        }
     }
 ]

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -5,7 +5,8 @@ $yellow-super-badge--borders-color: #fcc63a;
 
 .lemarche {
     &--align-right {
-        float: right;
+        display: flex;
+        justify-content: flex-end;
     }
 
     &-super-badge {
@@ -242,7 +243,7 @@ p.fr-tag--green-emeraude {
 }
 
 .fr-background-alt--white {
-    background:  #ffffff;
+    background: #ffffff;
 }
 
 .rounded-iframe {
@@ -281,7 +282,7 @@ p.fr-tag--green-emeraude {
 }
 
 .center-text {
-  //height: 100vh;
-  line-height: 1vh;
-  text-align: center;
+    //height: 100vh;
+    line-height: 1vh;
+    text-align: center;
 }

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -28,6 +28,12 @@
                                 {% endif %}
                             </h1>
                             {% include "includes/_super_badge.html" with siae=siae %}
+                            {% if siae.is_in_the_hosmoz_network %}
+                                <a class="fr-tag"
+                                   href="{% url 'siae:search_results' %}?networks=hosmoz"
+                                   target="_blank"
+                                   title="Fait partie du réseau Hosmoz">Hosmoz</a>
+                            {% endif %}
                             <p class="fr-text--sm">
                                 <i>(Dernière activité il y a {{ siae.latest_activity_at|timesince }})</i>
                             </p>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -32,6 +32,14 @@
                 <div class="fr-col-12 fr-col-lg-4">
                     <ul class="fr-tags-group lemarche--align-right">
                         <li>{% include "includes/_super_badge.html" with siae=siae %}</li>
+                        {% if siae.is_in_the_hosmoz_network %}
+                            <li>
+                                <a class="fr-tag"
+                                   href="{% url 'siae:search_results' %}?networks=hosmoz"
+                                   target="_blank"
+                                   title="Fait partie du réseau Hosmoz">Hosmoz</a>
+                            </li>
+                        {% endif %}
                         {% if siae.is_qpv %}
                             <li>
                                 <span class="fr-tag"

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -50,6 +50,26 @@ class SiaeSearchDisplayResultsTest(TestCase):
         self.assertContains(response, "pas encore inscrite")
 
 
+class SiaeSearchHosmozNetworkTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.network = NetworkFactory(slug="hosmoz")
+
+    def test_search_hosmoz_badge_should_be_displayed_if_siae_is_in_hosmoz_network(self):
+        siae = SiaeFactory()
+        siae.networks.add(self.network)
+
+        url = reverse("siae:search_results")
+        response = self.client.get(url)
+        self.assertContains(response, "Hosmoz")
+
+    def test_search_hosmoz_badge_should_not_be_displayed_if_siae_is_not_in_hosmoz_network(self):
+        SiaeFactory()
+        url = reverse("siae:search_results")
+        response = self.client.get(url)
+        self.assertNotContains(response, "Hosmoz")
+
+
 class SiaeSearchNumQueriesTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1169,3 +1189,13 @@ class SiaeDetailTest(TestCase):
         self.client.force_login(self.user_admin)
         response = self.client.get(url)
         self.assertContains(response, "Informations Admin")
+
+    def test_should_display_hosmoz_badge(self):
+        url = reverse("siae:detail", args=[self.siae.slug])
+        # anonymous
+        response = self.client.get(url)
+        self.assertNotContains(response, "Hosmoz")
+
+        NetworkFactory(slug="hosmoz", siaes=[self.siae])
+        response = self.client.get(url)
+        self.assertContains(response, "Hosmoz")


### PR DESCRIPTION
### Quoi ?

Ajout d'un badge Hosmoz pour les structures faisant partie du réseau.

### Pourquoi ?

Pour valoriser les structures rattachées au réseau Hozmoz

### Comment ?

Ajout d'un badge à côté de "Super prestataire" :
- dans la card fournisseur (résultats de recherche et favoris)
- dans la fiche commerciale (page détaillée du fournisseur)

### Captures d'écran

Sur les résultats de recherche : 
<img width="1305" height="1042" alt="image" src="https://github.com/user-attachments/assets/770ed8cd-1f04-4bdd-8d39-eac2f78667a3" />

Dans les favoris :
<img width="1247" height="918" alt="image" src="https://github.com/user-attachments/assets/5c7bd920-1d61-4c38-b4e1-da1f1a0182a7" />

Sur le détail d'un fournisseur :
<img width="823" height="514" alt="image" src="https://github.com/user-attachments/assets/55e2ff4e-13c7-4646-86a4-35884c1d7f08" />

### Autre

J'ai recalé à droite avec un flex pour éviter ça : 

<img width="970" height="527" alt="image" src="https://github.com/user-attachments/assets/a2006d51-11df-4fbc-8c79-5a5eccadb3d0" />


