### PR TITLE
fix: Ajout du template pour les erreurs 429

### DIFF
--- a/lemarche/templates/403.html
+++ b/lemarche/templates/403.html
@@ -1,33 +1,38 @@
 {% extends "layouts/base.html" %}
 {% load static %}
-{% block page_title %}Erreur 403{{ block.super }}{% endblock page_title %}
-
+{% block page_title %}
+    Erreur 403{{ block.super }}
+{% endblock page_title %}
 {% block breadcrumb %}
 {% endblock breadcrumb %}
-
 {% block content %}
-<div class="fr-container">
-    <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
-        <div class="fr-py-0 fr-col-12 fr-col-md-6">
-            <h1>Vous ne pouvez pas continuer</h1>
-            <p class="fr-text--sm fr-mb-3w">Erreur 403</p>
-            {% if exception %}
-                <p class="fr-text--sm fr-mb-3w">{{ exception }}</p>
-            {% else %}
-                <p class="fr-text--lead fr-mb-5w">Accès refusé</p>
-            {% endif %}
-        </div>
-        <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
-            <svg xmlns="http://www.w3.org/2000/svg" class="fr-responsive-img fr-artwork" aria-hidden="true" width="160" height="200" viewBox="0 0 160 200">
-                <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-motif' %}"></use>
-                <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-background' %}"></use>
-                <g transform="translate(40, 60)">
-                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg#artwork-decorative' %}"></use>
-                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg#artwork-minor' %}"></use>
-                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg#artwork-major' %}"></use>
-                </g>
-            </svg>
+    <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>Vous ne pouvez pas continuer</h1>
+                <p class="fr-text--sm fr-mb-3w">Erreur 403</p>
+                {% if exception %}
+                    <p class="fr-text--sm fr-mb-3w">{{ exception }}</p>
+                {% else %}
+                    <p class="fr-text--lead fr-mb-5w">Accès refusé</p>
+                {% endif %}
+            </div>
+            <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="fr-responsive-img fr-artwork"
+                     aria-hidden="true"
+                     width="160"
+                     height="200"
+                     viewBox="0 0 160 200">
+                    <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-motif"></use>
+                    <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-background"></use>
+                    <g transform="translate(40, 60)">
+                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg' %}#artwork-decorative"></use>
+                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg' %}#artwork-minor"></use>
+                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/padlock.svg' %}#artwork-major"></use>
+                    </g>
+                </svg>
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/lemarche/templates/403_csrf.html
+++ b/lemarche/templates/403_csrf.html
@@ -1,31 +1,36 @@
 {% extends "layouts/base.html" %}
 {% load static %}
-{% block page_title %}Erreur CSRF{{ block.super }}{% endblock page_title %}
-
+{% block page_title %}
+    Erreur CSRF{{ block.super }}
+{% endblock page_title %}
 {% block breadcrumb %}
 {% endblock breadcrumb %}
-
 {% block content %}
-<div class="fr-container">
-    <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
-        <div class="fr-py-0 fr-col-12 fr-col-md-6">
-            <h1>Erreur CSRF</h1>
-            <p class="fr-text--lead fr-mb-3w">Une erreur technique s'est produite.</p>
-            <p class="fr-text--sm fr-mb-5w">
-                Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.
-            </p>
-        </div>
-        <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
-            <svg xmlns="http://www.w3.org/2000/svg" class="fr-responsive-img fr-artwork" aria-hidden="true" width="160" height="200" viewBox="0 0 160 200">
-                <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-motif' %}"></use>
-                <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-background' %}"></use>
-                <g transform="translate(40, 60)">
-                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg#artwork-decorative' %}"></use>
-                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg#artwork-minor' %}"></use>
-                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg#artwork-major' %}"></use>
-                </g>
-            </svg>
+    <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>Erreur CSRF</h1>
+                <p class="fr-text--lead fr-mb-3w">Une erreur technique s'est produite.</p>
+                <p class="fr-text--sm fr-mb-5w">
+                    Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.
+                </p>
+            </div>
+            <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="fr-responsive-img fr-artwork"
+                     aria-hidden="true"
+                     width="160"
+                     height="200"
+                     viewBox="0 0 160 200">
+                    <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-motif"></use>
+                    <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-background"></use>
+                    <g transform="translate(40, 60)">
+                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg' %}#artwork-decorative"></use>
+                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg' %}#artwork-minor"></use>
+                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/connection-lost.svg' %}#artwork-major"></use>
+                    </g>
+                </svg>
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/lemarche/templates/404.html
+++ b/lemarche/templates/404.html
@@ -1,32 +1,37 @@
 {% extends "layouts/base.html" %}
 {% load static %}
-{% block page_title %}Erreur 404{{ block.super }}{% endblock page_title %}
-
+{% block page_title %}
+    Erreur 404{{ block.super }}
+{% endblock page_title %}
 {% block breadcrumb %}
 {% endblock breadcrumb %}
-
 {% block content %}
-<div class="fr-container">
-    <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
-        <div class="fr-py-0 fr-col-12 fr-col-md-6">
-            <h1>Page non trouvée</h1>
-            <p class="fr-text--sm fr-mb-3w">Erreur 404</p>
-            <p class="fr-text--lead fr-mb-3w">La page que vous cherchez est introuvable. Excusez-nous pour la gène occasionnée.</p>
-            <p class="fr-text--sm fr-mb-5w">
-                Si vous avez tapé l'adresse web dans le navigateur, vérifiez qu'elle est correcte. La page n’est peut-être plus disponible.
-            </p>
-        </div>
-        <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
-            <svg xmlns="http://www.w3.org/2000/svg" class="fr-responsive-img fr-artwork" aria-hidden="true" width="160" height="200" viewBox="0 0 160 200">
-                <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-motif' %}"></use>
-                <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg#artwork-background' %}"></use>
-                <g transform="translate(40, 60)">
-                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg#artwork-decorative' %}"></use>
-                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg#artwork-minor' %}"></use>
-                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg#artwork-major' %}"></use>
-                </g>
-            </svg>
+    <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>Page non trouvée</h1>
+                <p class="fr-text--sm fr-mb-3w">Erreur 404</p>
+                <p class="fr-text--lead fr-mb-3w">La page que vous cherchez est introuvable. Excusez-nous pour la gène occasionnée.</p>
+                <p class="fr-text--sm fr-mb-5w">
+                    Si vous avez tapé l'adresse web dans le navigateur, vérifiez qu'elle est correcte. La page n’est peut-être plus disponible.
+                </p>
+            </div>
+            <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="fr-responsive-img fr-artwork"
+                     aria-hidden="true"
+                     width="160"
+                     height="200"
+                     viewBox="0 0 160 200">
+                    <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-motif"></use>
+                    <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-background"></use>
+                    <g transform="translate(40, 60)">
+                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-decorative"></use>
+                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-minor"></use>
+                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-major"></use>
+                    </g>
+                </svg>
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/lemarche/templates/429.html
+++ b/lemarche/templates/429.html
@@ -1,0 +1,34 @@
+{% extends "layouts/base.html" %}
+{% load static %}
+{% block page_title %}
+    Erreur 429{{ block.super }}
+{% endblock page_title %}
+{% block breadcrumb %}
+{% endblock breadcrumb %}
+{% block content %}
+    <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>Erreur 429</h1>
+                <p class="fr-text--lead fr-mb-3w">Trop de tentatives de connexion.</p>
+                <p class="fr-text--sm fr-mb-5w">Veuillez réessayer plus tard.</p>
+            </div>
+            <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="fr-responsive-img fr-artwork"
+                     aria-hidden="true"
+                     width="160"
+                     height="200"
+                     viewBox="0 0 160 200">
+                    <use class="fr-artwork-motif" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-motif"></use>
+                    <use class="fr-artwork-background" href="{% static 'dsfr/dist/artwork/background/ovoid.svg' %}#artwork-background"></use>
+                    <g transform="translate(40, 60)">
+                    <use class="fr-artwork-decorative" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-decorative"></use>
+                    <use class="fr-artwork-minor" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-minor"></use>
+                    <use class="fr-artwork-major" href="{% static 'dsfr/dist/artwork/pictograms/system/technical-error.svg' %}#artwork-major"></use>
+                    </g>
+                </svg>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/lemarche/www/pages/urls.py
+++ b/lemarche/www/pages/urls.py
@@ -64,5 +64,6 @@ urlpatterns = [
     # Error pages
     path("403/", TemplateView.as_view(template_name="403.html"), name="403"),
     path("404/", TemplateView.as_view(template_name="404.html"), name="404"),
+    path("429/", TemplateView.as_view(template_name="429.html"), name="429"),
     path("500/", TemplateView.as_view(template_name="500.html"), name="500"),
 ]


### PR DESCRIPTION
### Quoi ?

Ajout d'un template pour l'erreur 429 (Too Many Requests).

### Pourquoi ?

Probablement des tentatives de DDOS insignifiantes, mais génère des erreurs à cause du template.

### Comment ?

Ajout d'un template.

Fixe au passage l'affichage des pictogrammes :

<img width="1246" height="715" alt="image" src="https://github.com/user-attachments/assets/59786217-dca9-4512-a447-e7ec8b31cd32" />


### Captures d'écran 

<img width="1314" height="698" alt="erreur-42" src="https://github.com/user-attachments/assets/81ef9200-731b-406f-9736-7cc597defad5" />
