### PR TITLE
chore(CI): Mise à jour du dépôt Please Release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c  # v4.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple


### PR DESCRIPTION
### Quoi ?

Mise à jour de la github action

### Pourquoi ?

Le projet a été migré : https://github.com/google-github-actions/release-please-action/tree/v4/?tab=readme-ov-file#migration

et les derniers job ont échoué : 

<img width="1032" height="607" alt="image" src="https://github.com/user-attachments/assets/79d78ac5-70de-454c-8ed1-e3a2fbb9ff77" />
