### PR TITLE
feat(Dépôt de besoin): Envoi d'un lien direct vers l'export xls des structures

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -402,8 +402,7 @@ class SiaeQuerySet(models.QuerySet):
             )
             qs = qs.order_by("-tendersiae__email_link_click_date")
         else:  # "ALL"
-            qs = qs.filter(tendersiae__tender=tender, tendersiae__email_send_date__isnull=False)
-            qs = qs.order_by("-tendersiae__email_send_date")
+            qs = qs.filter(tendersiae__tender=tender).order_by_super_siaes()  # same order as in send_validated_tender
 
         return qs.distinct()
 

--- a/lemarche/templates/tenders/_detail_admin_extra_info.html
+++ b/lemarche/templates/tenders/_detail_admin_extra_info.html
@@ -3,9 +3,7 @@
     <div class="fr-grid-row">
         <div class="fr-col-12">
             <ul>
-                <li class="fr-mt-2v">
-                    Publié le {{ tender.published_at|date }}
-                </li>
+                <li class="fr-mt-2v">Publié le {{ tender.published_at|date }}</li>
                 <li class="fr-mt-2v">
                     {% if tender.is_sent %}
                         Validé le {{ tender.first_sent_at|date }}
@@ -15,7 +13,7 @@
                 </li>
                 <li class="fr-mt-2v">
                     <i class="ri-focus-2-line"></i>
-                    {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
+                    {{ tender.siaes_count }} prestataire{{ tender.siaes_count|pluralize }} ciblé{{ tender.siaes_count|pluralize }}
                 </li>
                 <li class="fr-mt-2v">
                     <i class="ri-eye-line"></i>
@@ -40,7 +38,10 @@
                     </li>
                 {% endif %}
                 <li>
-                    <a href="{{ siae.get_admin_url }}" target="_blank" id="tender-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
+                    <a href="{{ siae.get_admin_url }}"
+                       target="_blank"
+                       id="tender-detail-admin-btn"
+                       class="btn btn-sm btn-outline-primary btn-ico">
                         <span>
                             Lien vers l'admin&nbsp;
                             <i class="ri-external-link-line" aria-hidden="true"></i>

--- a/lemarche/templates/tenders/_detail_side_infos_author.html
+++ b/lemarche/templates/tenders/_detail_side_infos_author.html
@@ -28,7 +28,7 @@
         </li>
         <li>
             <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEWED" %}"
-               id="show-tender-siae-list-from-detail-btn"
+               id="show-tender-siae-viewed-list-from-detail-btn"
                class="fr-btn fr-btn--icon-left fr-icon-eye-line">
                 {{ tender.siae_email_link_click_date_or_detail_display_date_count }} prestataire{{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize }} qui {{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize:'a,ont' }} vu
             </a>

--- a/lemarche/templates/tenders/_detail_side_infos_author.html
+++ b/lemarche/templates/tenders/_detail_side_infos_author.html
@@ -23,7 +23,7 @@
             <a href="{% url 'tenders:detail-siae-list' tender.slug %}"
                id="show-tender-siae-list-from-detail-btn"
                class="fr-btn fr-btn--icon-left fr-icon-signal-tower-line">
-                {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
+                {{ tender.siaes_count }} prestataire{{ tender.siaes_count|pluralize }} ciblé{{ tender.siaes_count|pluralize }}
             </a>
         </li>
         <li>

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -956,7 +956,7 @@ class Tender(models.Model):
             return True
         return False
 
-    @property
+    @cached_property
     def siaes_count(self):
         return self.tendersiae_set.count()
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -957,6 +957,10 @@ class Tender(models.Model):
         return False
 
     @property
+    def siaes_count(self):
+        return self.tendersiae_set.count()
+
+    @property
     def siae_detail_display_date_count(self):
         return self.tendersiae_set.filter(detail_display_date__isnull=False).count()
 

--- a/lemarche/utils/urls.py
+++ b/lemarche/utils/urls.py
@@ -66,7 +66,7 @@ def get_encoded_url_from_params(params: dict, encoding: str = "rot_13"):
     return codecs_encode(urlencode(params, quote_via=quote), encoding=encoding)
 
 
-def get_tender_siae_download_url(tender: Model, status: str = ""):
+def get_tender_siae_download_url(tender: Model, status: str = "") -> str:
     params = {  # use the params of form SiaeSelectFieldsForm
         "download_form-format": "xlsx",
         "tendersiae_status": status,

--- a/lemarche/utils/urls.py
+++ b/lemarche/utils/urls.py
@@ -67,8 +67,7 @@ def get_encoded_url_from_params(params: dict, encoding: str = "rot_13"):
 
 
 def get_tender_siae_download_url(tender: Model, status: str = ""):
-
-    params = {
+    params = {  # use the params of form SiaeSelectFieldsForm
         "download_form-format": "xlsx",
         "tendersiae_status": status,
         "download_form-selected_fields": [

--- a/lemarche/utils/urls.py
+++ b/lemarche/utils/urls.py
@@ -64,3 +64,33 @@ def get_object_admin_url(obj: Model):
 
 def get_encoded_url_from_params(params: dict, encoding: str = "rot_13"):
     return codecs_encode(urlencode(params, quote_via=quote), encoding=encoding)
+
+
+def get_tender_siae_download_url(tender: Model, status: str = ""):
+
+    params = {
+        "download_form-format": "xlsx",
+        "tendersiae_status": status,
+        "download_form-selected_fields": [
+            "name",
+            "siret",
+            "kind",
+            "address",
+            "city",
+            "post_code",
+            "region",
+            "department",
+            "ca",
+            "employees_insertion_count",
+            "contact_first_name",
+            "contact_last_name",
+            "contact_email",
+            "contact_phone",
+            "siae_answers",
+        ],
+    }
+    return (
+        f"https://{get_domain_url()}"
+        f"{reverse_lazy('tenders:download-siae-list', args=[tender.slug])}"
+        f"?{urlencode(params, doseq=True)}"
+    )

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -16,7 +16,12 @@ from lemarche.utils import constants
 from lemarche.utils.apis import api_slack
 from lemarche.utils.data import date_to_string
 from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
-from lemarche.utils.urls import get_domain_url, get_object_admin_url, get_object_share_url
+from lemarche.utils.urls import (
+    get_domain_url,
+    get_object_admin_url,
+    get_object_share_url,
+    get_tender_siae_download_url,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -398,6 +403,7 @@ def send_confirmation_published_email_to_author(tender: Tender):
             "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
             "TENDER_NB_MATCH": tender.siaes.count(),
             "TENDER_URL": get_object_share_url(tender),
+            "TENDER_SIAES_LIST_DOWNLOAD_URL": get_tender_siae_download_url(tender),
         }
 
         if not tender.contact_notifications_disabled:
@@ -465,6 +471,7 @@ def send_siae_interested_email_to_author(tender: Tender):
                 "TENDER_AUTHOR_ID": tender.author.id,
                 "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
                 "TENDER_SIAE_INTERESTED_LIST_URL": f"{get_object_share_url(tender)}/prestataires",  # noqa
+                "TENDER_SIAES_LIST_DOWNLOAD_URL": get_tender_siae_download_url(tender, status="INTERESTED"),
             }
 
             if not tender.contact_notifications_disabled:

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2210,6 +2210,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         siae_1 = SiaeFactory(name="siae_1", kind=siae_constants.KIND_ETTI)
         siae_2 = SiaeFactory(name="siae_2")
         siae_3 = SiaeFactory(name="siae_3")
+        siae_4 = SiaeFactory(name="siae_4")
 
         self.tender = TenderFactory(author=self.user)
         # INTERESTED
@@ -2226,7 +2227,9 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             detail_contact_click_date=timezone.now(),
         )
         # VIEWED
-        TenderSiaeFactory(tender=self.tender, siae=siae_3)
+        TenderSiaeFactory(tender=self.tender, siae=siae_3, detail_display_date=timezone.now())
+        # just TARGETED
+        TenderSiaeFactory(tender=self.tender, siae=siae_4)
 
         q1 = TenderQuestionFactory(tender=self.tender, text="question_1_title")
         q2 = TenderQuestionFactory(tender=self.tender, text="question_2_title")
@@ -2269,7 +2272,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
             rows = list(csv_reader)
-            self.assertEqual(len(rows), 3)
+            self.assertEqual(len(rows), 4)
 
         with self.subTest(status="VIEWED"):
             response = self.client.get(
@@ -2279,7 +2282,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
             rows = list(csv_reader)
-            self.assertEqual(len(rows), 2)
+            self.assertEqual(len(rows), 3)
 
         with self.subTest(status="INTERESTED"):
             response = self.client.get(

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2226,7 +2226,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             detail_contact_click_date=timezone.now(),
         )
         # VIEWED
-        TenderSiaeFactory(tender=self.tender, siae=siae_3, email_send_date=timezone.now())
+        TenderSiaeFactory(tender=self.tender, siae=siae_3)
 
         q1 = TenderQuestionFactory(tender=self.tender, text="question_1_title")
         q2 = TenderQuestionFactory(tender=self.tender, text="question_2_title")

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1632,11 +1632,6 @@ class TenderSiaeListView(TestCase):
             detail_display_date=timezone.now(),
             detail_contact_click_date=timezone.now() - timedelta(hours=1),
         )
-        cls.tendersiae_1_4 = TenderSiae.objects.create(
-            tender=cls.tender_1,
-            siae=cls.siae_3,
-            detail_display_date=timezone.now(),
-        )
         cls.tendersiae_1_5 = TenderSiae.objects.create(
             tender=cls.tender_1,
             siae=cls.siae_5,
@@ -1695,12 +1690,12 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 3)  # email_send_date
+        self.assertEqual(len(response.context["siaes"]), 4)
         # VIEWED
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "VIEWED"})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 4)  # email_link_click_date or detail_display_date
+        self.assertEqual(len(response.context["siaes"]), 3)  # email_link_click_date or detail_display_date
         # INTERESTED
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "INTERESTED"})
         response = self.client.get(url)
@@ -1727,7 +1722,7 @@ class TenderSiaeListView(TestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 2)  # email_send_date & located in Grenoble
+        self.assertEqual(len(response.context["siaes"]), 2)  # located in Grenoble
         url = (
             reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "INTERESTED"})
             + f"?locations={self.perimeter_city.slug}"
@@ -1742,7 +1737,7 @@ class TenderSiaeListView(TestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 1)  # email_send_date & ETTI
+        self.assertEqual(len(response.context["siaes"]), 2)  # ETTI
         url = (
             reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "INTERESTED"})
             + f"?kind={siae_constants.KIND_ETTI}"
@@ -1754,7 +1749,7 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug}) + "?territory=QPV"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 1)  # email_send_date & QPV
+        self.assertEqual(len(response.context["siaes"]), 1)  # QPV
         # filter by count of employees
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug}) + "?employees=50-99"
         response = self.client.get(url)
@@ -1773,7 +1768,7 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 3)
+        self.assertEqual(len(response.context["siaes"]), 4)
         self.assertNotContains(response, "Déjà référencé")
 
         # add a match between the company and the siae
@@ -1792,7 +1787,7 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 3)
+        self.assertEqual(len(response.context["siaes"]), 4)
         self.assertContains(response, "Déjà référencé", count=1)
 
 
@@ -2221,21 +2216,17 @@ class TenderSiaeDownloadViewTestCase(TestCase):
         TenderSiaeFactory(
             tender=self.tender,
             siae=siae_1,
-            email_send_date=timezone.now(),
             detail_display_date=timezone.now(),
             detail_contact_click_date=timezone.now(),
         )
         TenderSiaeFactory(
             tender=self.tender,
             siae=siae_2,
-            email_send_date=timezone.now(),
             detail_display_date=timezone.now(),
             detail_contact_click_date=timezone.now(),
         )
         # VIEWED
-        TenderSiaeFactory(
-            tender=self.tender, siae=siae_3, email_send_date=timezone.now(), detail_display_date=timezone.now()
-        )
+        TenderSiaeFactory(tender=self.tender, siae=siae_3, email_send_date=timezone.now())
 
         q1 = TenderQuestionFactory(tender=self.tender, text="question_1_title")
         q2 = TenderQuestionFactory(tender=self.tender, text="question_2_title")
@@ -2288,7 +2279,7 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             content = response.content.decode("utf-8")
             csv_reader = csv.DictReader(content.splitlines())
             rows = list(csv_reader)
-            self.assertEqual(len(rows), 3)
+            self.assertEqual(len(rows), 2)
 
         with self.subTest(status="INTERESTED"):
             response = self.client.get(

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -757,7 +757,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         return context
 
 
-class TenderSiaeInterestedDownloadView(LoginRequiredMixin, DetailView):
+class TenderSiaeInterestedDownloadView(TenderAuthorOrAdminRequiredMixin, DetailView):
     http_method_names = ["get"]
     model = Tender
 


### PR DESCRIPTION
### Quoi ?

Ajout d'une variable pour le template de mail contenant le lien direct vers le téléchargement direct de l'export xls.

### Pourquoi ?

Pour améliorer la visibilité et la compréhension par les acheteurs des retours des fournisseurs inclusifs intéressés par leur projet d’achat.

### Comment ?

Génération d'un lien direct en utilisant les paramètres du formulaire SiaeSelectFieldsForm et en l'ajoutant aux templates de mail envoyé à l'auteur d'un dépôt de besoin (lors de la validation et quand des structures montrent leur intérêt).

### Autre

Suppression du filtre sur la date d'envoi de mail qui créait un décalage depuis que l'envoi par lot est en place. On pouvait envoyer : "64 structures concernées" dans le mail alors que dans l'interface de suivi, il y avait qu'un lot (10 structures par défaut)  d'afficher dans les "structures ciblées".