### PR TITLE
feat(Tenders): Afficher les fournisseurs locaux

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -509,6 +509,9 @@ class SiaeQuerySet(models.QuerySet):
         )
 
     def with_is_local(self, tender):
+        """Annotate queryset with is_local
+        is_local is True if a match is between the location perimeter of the tender and the different geographic fields
+        from each Siae"""
         if tender.location:
             if tender.location.kind == Perimeter.KIND_CITY:
                 return self.annotate(
@@ -521,7 +524,7 @@ class SiaeQuerySet(models.QuerySet):
             elif tender.location.kind == Perimeter.KIND_DEPARTMENT:
                 return self.annotate(
                     is_local=Case(
-                        When(departement=tender.location.name, then=Value(True)),
+                        When(department=tender.location.insee_code, then=Value(True)),
                         default=Value(False),
                         output_field=models.BooleanField(),
                     )

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -544,6 +544,16 @@ class SiaeQuerySet(models.QuerySet):
         else:
             return self.annotate(is_local=Value(False))
 
+    def with_is_local_display(self, tender):
+        """Transform the bool of is_local to a display a yes / no charfield"""
+        return self.with_is_local(tender).annotate(
+            is_local_display=Case(
+                When(is_local=True, then=Value("Oui")),
+                default=Value("Non"),
+                output_field=models.CharField(),
+            ),
+        )
+
 
 class Siae(models.Model):
     FIELDS_FROM_C1 = [

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -532,7 +532,7 @@ class SiaeQuerySet(models.QuerySet):
             elif tender.location.kind == Perimeter.KIND_REGION:
                 return self.annotate(
                     is_local=Case(
-                        When(city=tender.location.name, then=Value(True)),
+                        When(region=tender.location.name, then=Value(True)),
                         default=Value(False),
                         output_field=models.BooleanField(),
                     )

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -537,12 +537,7 @@ class SiaeQuerySet(models.QuerySet):
                         output_field=models.BooleanField(),
                     )
                 )
-            else:
-                return self.annotate(is_local=Value(False))
-        elif tender.is_country_area:
-            return self.annotate(is_local=Value(False))
-        else:
-            return self.annotate(is_local=Value(False))
+        return self.annotate(is_local=Value(False))
 
     def with_is_local_display(self, tender):
         """Transform the bool of is_local to a display a yes / no charfield"""

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -22,6 +22,7 @@ from django.db.models import (
     Q,
     Subquery,
     Sum,
+    Value,
     When,
 )
 from django.db.models.functions import Greatest, Round
@@ -507,8 +508,14 @@ class SiaeQuerySet(models.QuerySet):
             "-super_badge", "-tender_detail_contact_click_count", "-tender_detail_display_count", "-completion_rate"
         )
 
-    def with_is_local(self, perimeters):
-        return self.annotate(is_local=F("name"))
+    def with_is_local(self, tender):
+        if tender.location:
+            if tender.location.kind == Perimeter.KIND_CITY:
+                return self.annotate(is_local=Value(True))
+        elif tender.is_country_area:
+            return self.annotate(is_local=Value(False))
+        else:
+            return self.annotate(is_local=Value(False))
 
 
 class Siae(models.Model):

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -507,6 +507,9 @@ class SiaeQuerySet(models.QuerySet):
             "-super_badge", "-tender_detail_contact_click_count", "-tender_detail_display_count", "-completion_rate"
         )
 
+    def with_is_local(self, perimeters):
+        return self.annotate(is_local=F("name"))
+
 
 class Siae(models.Model):
     FIELDS_FROM_C1 = [

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -511,7 +511,31 @@ class SiaeQuerySet(models.QuerySet):
     def with_is_local(self, tender):
         if tender.location:
             if tender.location.kind == Perimeter.KIND_CITY:
-                return self.annotate(is_local=Value(True))
+                return self.annotate(
+                    is_local=Case(
+                        When(city=tender.location.name, then=Value(True)),
+                        default=Value(False),
+                        output_field=models.BooleanField(),
+                    )
+                )
+            elif tender.location.kind == Perimeter.KIND_DEPARTMENT:
+                return self.annotate(
+                    is_local=Case(
+                        When(departement=tender.location.name, then=Value(True)),
+                        default=Value(False),
+                        output_field=models.BooleanField(),
+                    )
+                )
+            elif tender.location.kind == Perimeter.KIND_REGION:
+                return self.annotate(
+                    is_local=Case(
+                        When(city=tender.location.name, then=Value(True)),
+                        default=Value(False),
+                        output_field=models.BooleanField(),
+                    )
+                )
+            else:
+                return self.annotate(is_local=Value(False))
         elif tender.is_country_area:
             return self.annotate(is_local=Value(False))
         else:

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -26,8 +26,14 @@
                                   aria-hidden="true">Ce fournisseur a déjà travaillé pour votre organisation.</span>
                         {% endif %}
                         {% if siae.is_local %}
-                            <span class="fr-tag lemarche--float-right">
+                            <span class="fr-tag lemarche--float-right"
+                                  aria-describedby="tooltip-local-match-{{ siae.pk }}">
                                 Fournisseur local
+                            </span>
+                            <span class="fr-tooltip fr-placement"
+                                  id="tooltip-local-match-{{ siae.pk }}"
+                                  role="tooltip"
+                                  aria-hidden="true">Ce fournisseur est basé dans le territoire de votre demande.
                             </span>
                         {% endif %}
                         <h2>{{ siae.name_display }}</h2>

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -26,7 +26,7 @@
                                   aria-hidden="true">Ce fournisseur a déjà travaillé pour votre organisation.</span>
                         {% endif %}
                         {% if siae.is_local %}
-                            <span class="fr-tag fr-tag lemarche--float-right">
+                            <span class="fr-tag lemarche--float-right">
                                 Fournisseur local
                             </span>
                         {% endif %}

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -25,6 +25,11 @@
                                   role="tooltip"
                                   aria-hidden="true">Ce fournisseur a déjà travaillé pour votre organisation.</span>
                         {% endif %}
+                        {% if siae.is_local %}
+                            <span class="fr-tag fr-tag lemarche--float-right">
+                                Fournisseur local
+                            </span>
+                        {% endif %}
                         <h2>{{ siae.name_display }}</h2>
                         {% include "includes/_super_badge.html" with siae=siae %}
                     </div>

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -488,6 +488,7 @@ class SiaeSelectFieldsForm(forms.Form):
             ("contact_last_name", None),
             ("contact_email", None),
             ("contact_phone", None),
+            ("is_local_display", "Fournisseur local"),  # from annotation
             ("siae_answers", "Réponse aux questions"),
         ]
         # Set label from model if not provided in tuple

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2422,8 +2422,8 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
     def test_local_badge_from_city(self):
 
         # Buyer chose a city in when creating the tender
-        brest_perimeter = PerimeterFactory(name="Brest", kind=Perimeter.KIND_CITY, department_code=35)
-        self.tender_1.perimeters.set([brest_perimeter])
+        self.tender_1.location = PerimeterFactory(name="Brest", kind=Perimeter.KIND_CITY, department_code=35)
+        self.tender_1.save()
 
         # Add a siae that should flagged as 'local'
         siae_2 = SiaeFactory(
@@ -2449,4 +2449,4 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         val_list = list(response.context["siaes"].order_by("name").values_list("is_local", flat=True))
-        self.assertEqual(val_list, ["siae_1", "siae_2", "siae_3"])
+        self.assertEqual(val_list, [False, True, False])

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2397,3 +2397,24 @@ class TenderSiaeDownloadViewTestCase(TestCase):
             self.assertEqual(sheet["A2"].value, "siae_1")
             self.assertEqual(sheet["A3"].value, "siae_2")
             self.assertIsNone(sheet["A4"].value)
+
+
+class TenderSiaeListLocalSiaeTestCase(TestCase):
+
+    def setUp(self):
+        buyer = UserFactory(kind=User.KIND_BUYER)
+        self.client.force_login(buyer)
+
+        self.siae_1 = SiaeFactory(name="siae_1")
+        self.tender_1 = TenderFactory(author=buyer)
+        TenderSiaeFactory(siae=self.siae_1, tender=self.tender_1, email_send_date=timezone.now())
+
+    def test_display_all_tenders_from_user(self):
+        siae_2 = SiaeFactory(name="siae_2")
+        TenderSiaeFactory(siae=siae_2, tender=self.tender_1, email_send_date=timezone.now())
+
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertQuerySetEqual([self.siae_1, siae_2], response.context["siaes"], ordered=False)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -2409,10 +2409,10 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
 
     def test_display_all_tenders_from_user(self):
         siae_1 = SiaeFactory(name="siae_1")
-        TenderSiaeFactory(siae=siae_1, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_1, tender=self.tender_1)
 
         siae_2 = SiaeFactory(name="siae_2")
-        TenderSiaeFactory(siae=siae_2, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_2, tender=self.tender_1)
 
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
@@ -2443,7 +2443,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="29",
             region="Bretagne",
         )
-        TenderSiaeFactory(siae=siae_local, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_local, tender=self.tender_1)
 
         # Same department, but different city
         siae_near = SiaeFactory(
@@ -2453,7 +2453,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="29",
             region="Bretagne",
         )
-        TenderSiaeFactory(siae=siae_near, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_near, tender=self.tender_1)
 
         siae_outside = SiaeFactory(
             name="siae_4",
@@ -2462,7 +2462,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="13",
             region="Provence-Alpes-Côte d'Azur",
         )
-        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1)
 
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
@@ -2493,7 +2493,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="29",
             region="Bretagne",
         )
-        TenderSiaeFactory(siae=siae_local, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_local, tender=self.tender_1)
 
         # Add a siae that would be selected in a broader selection context,
         # Here same region but different department
@@ -2504,7 +2504,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="35",
             region="Bretagne",
         )
-        TenderSiaeFactory(siae=siae_near, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_near, tender=self.tender_1)
 
         siae_outside = SiaeFactory(
             name="siae_4",
@@ -2513,7 +2513,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="13",
             region="Provence-Alpes-Côte d'Azur",
         )
-        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1)
 
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
@@ -2544,7 +2544,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="29",
             region="Bretagne",
         )
-        TenderSiaeFactory(siae=siae_local, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_local, tender=self.tender_1)
 
         siae_outside = SiaeFactory(
             name="siae_3",
@@ -2553,7 +2553,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="13",
             region="Provence-Alpes-Côte d'Azur",
         )
-        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1)
 
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
@@ -2574,7 +2574,7 @@ class TenderSiaeListLocalSiaeTestCase(TestCase):
             department="13",
             region="Provence-Alpes-Côte d'Azur",
         )
-        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1, email_send_date=timezone.now())
+        TenderSiaeFactory(siae=siae_outside, tender=self.tender_1)
 
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -26,11 +26,6 @@ urlpatterns = [
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),
     path("statut/<status>", TenderListView.as_view(), name="list"),
     path("", TenderListView.as_view(), name="list"),
-    path(
-        "<str:slug>/structures-interessees",
-        RedirectView.as_view(pattern_name="tenders:detail-siae-list", permanent=True),
-        name="detail-siae-list-old",
-    ),  # TODO: delete in 2024
     path("<str:slug>/prestataires/statut/<status>", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path(

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -775,6 +775,7 @@ class TenderSiaeInterestedDownloadView(TenderAuthorOrAdminRequiredMixin, DetailV
             SiaeFilterForm(data=self.request.GET)
             .filter_queryset(Siae.objects.filter(tendersiae__tender=self.object))
             .filter_with_tender_tendersiae_status(tender=self.object, tendersiae_status=self.status)
+            .with_is_local_display(tender=self.object)
             .prefetch_related(
                 Prefetch(
                     "questionanswer_set",

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -720,7 +720,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
                 to_attr="questions_for_tender",
             )
         )
-        qs = qs.with_is_local(perimeters=self.tender.perimeters.all())
+        qs = qs.with_is_local(tender=self.tender)
         return qs
 
     def get(self, request, status=None, *args, **kwargs):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -720,6 +720,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
                 to_attr="questions_for_tender",
             )
         )
+        qs = qs.with_is_local(perimeters=self.tender.perimeters.all())
         return qs
 
     def get(self, request, status=None, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

# Problèmes rencontrés

Le modèle Tender dispose des champs `location` (qui contient un périmètre, utilisé par le formulaire de dépôt de besoin), un champ `is_country_area`, utilisé par le formulaire, mais aussi `perimeters` et `distance_location`, qui sont utilisés seulement par l'API.