### PR TITLE
fix(API): correction de la mise en forme de l'accueil API

### DIFF
--- a/lemarche/utils/remove_beta_redirect_middleware.py
+++ b/lemarche/utils/remove_beta_redirect_middleware.py
@@ -4,23 +4,23 @@ from django.http import HttpResponsePermanentRedirect
 class RemoveBetaRedirectMiddleware:
     """
     Middleware to permanently redirect all requests from hosts containing '.beta'
-    to the same URL on the main domain, except for API requests.
+    to the same URL on the main domain, except for API requests (home page API only).
     """
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        # Check if the host contains '.beta'
-        if ".beta." in request.get_host():
-            # Don't redirect API requests to give users time to make the switch
-            if not (request.path.startswith("/api/") and len(request.path) > 5):
-                # Get the main domain by removing '.beta' from the host
-                main_host = request.get_host().replace(".beta", "")
 
-                # Build the redirect URL
-                redirect_url = f"https://{main_host}{request.get_full_path()}"
+        # If the host does not contain '.beta.', don't redirect
+        if ".beta." not in request.get_host():
+            return self.get_response(request)
 
-                return HttpResponsePermanentRedirect(redirect_url)
+        # Don't redirect API requests, just home page API, to give users time to make the switch
+        if request.path.startswith("/api/") and request.path != "/api/":
+            return self.get_response(request)
 
-        return self.get_response(request)
+        # Get the main domain by removing '.beta' from the host
+        main_host = request.get_host().replace(".beta", "")
+        redirect_url = f"https://{main_host}{request.get_full_path()}"
+        return HttpResponsePermanentRedirect(redirect_url)

--- a/lemarche/utils/remove_beta_redirect_middleware.py
+++ b/lemarche/utils/remove_beta_redirect_middleware.py
@@ -14,7 +14,7 @@ class RemoveBetaRedirectMiddleware:
         # Check if the host contains '.beta'
         if ".beta." in request.get_host():
             # Don't redirect API requests to give users time to make the switch
-            if not request.path.startswith("/api/"):
+            if not (request.path.startswith("/api/") and len(request.path) > 5):
                 # Get the main domain by removing '.beta' from the host
                 main_host = request.get_host().replace(".beta", "")
 

--- a/lemarche/utils/tests/tests_remove_beta_redirect_middleware.py
+++ b/lemarche/utils/tests/tests_remove_beta_redirect_middleware.py
@@ -48,6 +48,15 @@ class RemoveBetaRedirectMiddlewareTest(TestCase):
         self.assertEqual(response.url, "https://example.com/search/?q=test&page=2")
 
     @override_settings(ALLOWED_HOSTS=["example.com", "example.beta.com"])
+    def test_api_home_request_is_redirected(self):
+        """Test that API home request is redirected"""
+        request = self.factory.get("/api/", HTTP_HOST="example.beta.com")
+        response = self.middleware(request)
+
+        self.assertIsInstance(response, HttpResponsePermanentRedirect)
+        self.assertEqual(response.url, "https://example.com/api/")
+
+    @override_settings(ALLOWED_HOSTS=["example.com", "example.beta.com"])
     def test_api_requests_not_redirected(self):
         """Test that API requests are not redirected"""
         request = self.factory.get("/api/users/", HTTP_HOST="example.beta.com")


### PR DESCRIPTION
### Quoi ?

L'accueil de l'API n'est plus mis en forme depuis le changement de domaine.

### Pourquoi ?

La page en elle-même n'est pas redirigé, mais les css et js, si.

### Comment ?

Redirection de l'accueil API comme les autres pages, https://lemarche.inclusion.beta.gouv.fr/api/ > https://lemarche.inclusion.gouv.fr/api/ 

### Captures d'écran

Cassée : 
<img width="1291" height="1000" alt="image" src="https://github.com/user-attachments/assets/aca8dbf9-6fe6-4623-a372-03d7fb9fa75c" />

Normale : 
<img width="1257" height="923" alt="image" src="https://github.com/user-attachments/assets/cf55e075-ebf6-4e98-b081-42d47b02c24c" />
