### PR TITLE
feat: Bouton santé financière des structures

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1175,6 +1175,16 @@ class Siae(models.Model):
     def label_list_display(self) -> str:
         return ", ".join(self.siaelabel_set.values_list("label__name", flat=True))
 
+    @property
+    def is_kind_a_company(self) -> bool:
+        """Return True if the structure is a company, rather than an association"""
+        return self.kind in [
+            siae_constants.KIND_EI,
+            siae_constants.KIND_EA,
+            siae_constants.KIND_ETTI,
+            siae_constants.KIND_EATT,
+        ]
+
     def is_in_the_hosmoz_network(self):
         return self.networks.filter(slug="hosmoz").exists()
 

--- a/lemarche/templates/siaes/_annuaire_entreprises_button.html
+++ b/lemarche/templates/siaes/_annuaire_entreprises_button.html
@@ -1,5 +1,5 @@
 {% if siret %}
-    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ siret }}?mtm_campaign=le-marche-inclusion" target="_blank" id="siae-detail-annuaire-entreprises-btn" class="fr-btn fr-btn--icon-right fr-icon-newspaper-fill">
+    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ siret }}?mtm_campaign=le-marche-inclusion" target="_blank" id="siae-detail-annuaire-entreprises-btn" class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill">
         Voir plus d'informations légales
     </a>
 {% endif %}

--- a/lemarche/templates/siaes/_useful_infos.html
+++ b/lemarche/templates/siaes/_useful_infos.html
@@ -26,8 +26,14 @@
             <li>
                 <a href="https://annuaire-entreprises.data.gouv.fr/donnees-financieres/{{ siae.siren }}"
                    target="_blank"
-                   class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill fr-mb-2v">
+                   class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill fr-mb-2v"
+                   style="position: relative;"
+                >
                     Voir plus de données financières
+                    <span class="fr-badge fr-badge--sm fr-badge--new"
+                          style="position: absolute; top: -8px; right: -8px;">
+                        Nouveauté
+                    </span>
                 </a>
             </li>
             {% if siae.etablissement_count > 1 %}

--- a/lemarche/templates/siaes/_useful_infos.html
+++ b/lemarche/templates/siaes/_useful_infos.html
@@ -26,7 +26,7 @@
             <li>
                 <a href="https://annuaire-entreprises.data.gouv.fr/donnees-financieres/{{ siae.siren }}"
                    target="_blank"
-                   class="fr-btn fr-btn--icon-right fr-icon-newspaper-fill">
+                   class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill fr-mb-2v">
                     Voir plus de données financières
                 </a>
             </li>
@@ -78,7 +78,7 @@
                     </li>
                 {% endif %}
             {% endif %}
-            <li class="fr-mt-4v">{% include "siaes/_annuaire_entreprises_button.html" with siret=siae.siret %}</li>
+            <li class="fr-mt-2v">{% include "siaes/_annuaire_entreprises_button.html" with siret=siae.siret %}</li>
         </ul>
     </div>
     <!-- Second column -->

--- a/lemarche/templates/siaes/_useful_infos.html
+++ b/lemarche/templates/siaes/_useful_infos.html
@@ -23,19 +23,21 @@
                 <strong>Chiffre d'affaires :</strong>
                 <span>{{ siae.ca_display }}</span>
             </li>
-            <li>
-                <a href="https://annuaire-entreprises.data.gouv.fr/donnees-financieres/{{ siae.siren }}"
-                   target="_blank"
-                   class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill fr-mb-2v"
-                   style="position: relative;"
-                >
-                    Voir plus de données financières
-                    <span class="fr-badge fr-badge--sm fr-badge--new"
-                          style="position: absolute; top: -8px; right: -8px;">
-                        Nouveauté
-                    </span>
-                </a>
-            </li>
+            {% if siae.is_kind_a_company %}
+                <li>
+                    <a href="https://annuaire-entreprises.data.gouv.fr/donnees-financieres/{{ siae.siren }}"
+                       target="_blank"
+                       class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-newspaper-fill fr-mb-2v"
+                       style="position: relative;"
+                    >
+                        Voir plus de données financières
+                        <span class="fr-badge fr-badge--sm fr-badge--new"
+                              style="position: absolute; top: -8px; right: -8px;">
+                            Nouveauté
+                        </span>
+                    </a>
+                </li>
+            {% endif %}
             {% if siae.etablissement_count > 1 %}
                 <li>
                     <i class="fr-icon--sm fr-icon-building-4-line"></i>

--- a/lemarche/templates/siaes/_useful_infos.html
+++ b/lemarche/templates/siaes/_useful_infos.html
@@ -23,6 +23,13 @@
                 <strong>Chiffre d'affaires :</strong>
                 <span>{{ siae.ca_display }}</span>
             </li>
+            <li>
+                <a href="https://annuaire-entreprises.data.gouv.fr/donnees-financieres/{{ siae.siren }}"
+                   target="_blank"
+                   class="fr-btn fr-btn--icon-right fr-icon-newspaper-fill">
+                    Voir plus de données financières
+                </a>
+            </li>
             {% if siae.etablissement_count > 1 %}
                 <li>
                     <i class="fr-icon--sm fr-icon-building-4-line"></i>


### PR DESCRIPTION
### Quoi ?
<img width="1518" height="1423" alt="image" src="https://github.com/user-attachments/assets/282bd939-889a-4b66-84cf-d5baaa28c95a" />
Un lien sous forme de bouton est affiché pour rediriger vers https://annuaire-entreprises.data.gouv.fr/donnees-financieres/ directement avec le bon SIREN.
Le bouton est affiché seulement pour les structures de types entreprises, pas les associations.