### PR TITLE
fix(admin): Suppression de la possibilité d'ajouter dans l'admin des correspondances entre les références clients et les entreprises

### DIFF
--- a/lemarche/companies/admin.py
+++ b/lemarche/companies/admin.py
@@ -196,6 +196,9 @@ class CompanySiaeClientReferenceMatchAdmin(admin.ModelAdmin):
 
     actions = ["approve_matches", "reject_matches"]
 
+    def has_add_permission(self, request):
+        return False
+
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("company", "siae_client_reference", "moderated_by")
 


### PR DESCRIPTION
### Quoi ?

Suppression de la possibilité d'ajouter des "correspondances" dans l'admin, seule la commande doit pouvoir le faire.