### PR TITLE
feat: Onglet "Pas intéressé" pour les projets d'achats acheteurs

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -403,6 +403,8 @@ class SiaeQuerySet(models.QuerySet):
                 )
             )
             qs = qs.order_by("-tendersiae__email_link_click_date")
+        elif tendersiae_status == "NOT_INTERESTED":
+            qs = qs.filter(tendersiae__detail_not_interested_click_date__isnull=False)
         else:  # "ALL"
             qs = qs.filter(tendersiae__tender=tender).order_by_super_siaes()  # same order as in send_validated_tender
 

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -2,7 +2,7 @@
 <div class="fr-card fr-card--horizontal{% if siae.super_badge %} super-badge-card{% endif %}">
     <div class="fr-card__body">
         <div class="fr-card__content">
-            <div class="fr-card__desc" x-data="{ showQuestions: false }">
+            <div class="fr-card__desc" x-data="{ showQuestions: false, showNotInterested: false }">
                 <div class="fr-grid-row">
                     <div class="fr-col-auto">
                         {% if siae.logo_url %}
@@ -101,6 +101,23 @@
                                 <span x-show="!showQuestions" class="fr-icon-arrow-down-s-line"></span>
                                 <span x-show="showQuestions">Masquer les réponses aux questions</span>
                                 <span x-show="showQuestions" class="fr-icon-arrow-up-s-line"></span>
+                            </button>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if siae.prefetched_tendersiae.0.detail_not_interested_feedback %}
+                    <div x-show="showNotInterested" class="fr-mt-4w">
+                            <h4 class="fr-mb-1w">Ce fournisseur n'est pas intéressé car: </h4>
+                            <p>{{ siae.prefetched_tendersiae.0.detail_not_interested_feedback }}</p>
+                    </div>
+                    <div class="fr-grid-row fr-grid-row--center fr-mt-4w">
+                        <div class="fr-col-12 fr-col-md-4">
+                            <button @click="showNotInterested = !showNotInterested"
+                                    class="fr-btn fr-btn--secondary fr-btn--icon-left">
+                                <span x-show="!showNotInterested">Afficher pourquoi le fournisseur n'est pas intéressé</span>
+                                <span x-show="!showNotInterested" class="fr-icon-arrow-down-s-line"></span>
+                                <span x-show="showNotInterested">Masquer pourquoi le fournisseur n'est pas intéressé</span>
+                                <span x-show="showNotInterested" class="fr-icon-arrow-up-s-line"></span>
                             </button>
                         </div>
                     </div>

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -105,10 +105,11 @@
                         </div>
                     </div>
                 {% endif %}
-                {% if siae.prefetched_tendersiae.0.detail_not_interested_feedback %}
+
+                {% if siae.not_interested_feedback %}
                     <div x-show="showNotInterested" class="fr-mt-4w">
                             <h4 class="fr-mb-1w">Ce fournisseur n'est pas intéressé car: </h4>
-                            <p>{{ siae.prefetched_tendersiae.0.detail_not_interested_feedback }}</p>
+                            <p>{{ siae.not_interested_feedback }}</p>
                     </div>
                     <div class="fr-grid-row fr-grid-row--center fr-mt-4w">
                         <div class="fr-col-12 fr-col-md-4">

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -55,6 +55,7 @@
                                     {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
                                     {% url 'tenders:detail-siae-list' slug=tender.slug status="VIEWED" as TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL %}
                                     {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
+                                    {% url 'tenders:detail-siae-list' slug=tender.slug status="NOT_INTERESTED" as TENDER_SIAE_DETAIL_NOT_INTERESTED_URL %}
                                     <li role="presentation">
                                         <a role="button"
                                            hx-push-url="true"
@@ -94,6 +95,19 @@
                                             Prestataires intéressés
                                         </a>
                                     </li>
+                                    <li role="presentation">
+                                        <a role="button"
+                                           hx-push-url="true"
+                                           hx-target="#tenderSiaeList"
+                                           hx-swap="outerHTML"
+                                           class="fr-tabs__tab"
+                                           hx-get="{{ TENDER_SIAE_DETAIL_NOT_INTERESTED_URL }}?{{ current_search_query }}"
+                                           href="{{ TENDER_SIAE_DETAIL_NOT_INTERESTED_URL }}?{{ current_search_query }}"
+                                           aria-controls="tender_siae_list_panel_NOT_INTERESTED"
+                                           aria-selected="{% if request.path == TENDER_SIAE_DETAIL_NOT_INTERESTED_URL %}true{% else %}false{% endif %}">
+                                            Prestataires non intéressés
+                                        </a>
+                                    </li>
                                 </ul>
                                 <div id="tender_siae_list_panel_{{ status }}"
                                      class="fr-tabs__panel fr-tabs__panel--selected"
@@ -105,7 +119,7 @@
                                         </div>
                                         <div class="fr-col-12 fr-col-lg-6">
                                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-md fr-btns-group--icon-left">
-                                                {% if not status == 'INTERESTED' %}
+                                                {% if not status == 'INTERESTED' and not status == 'NOT_INTERESTED' %}
                                                 <li>
                                                      <span class="fr-tooltip fr-placement"
                                                           id="tooltip-reminder"

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1639,6 +1639,11 @@ class TenderSiaeListView(TestCase):
             detail_display_date=timezone.now(),
             detail_contact_click_date=timezone.now() - timedelta(hours=2),
         )
+        cls.tendersiae_1_not_interested = TenderSiae.objects.create(
+            tender=cls.tender_1,
+            siae=cls.siae_5,
+            detail_not_interested_click_date=timezone.now(),
+        )
         cls.tendersiae_2_1 = TenderSiae.objects.create(
             tender=cls.tender_2,
             siae=cls.siae_2,
@@ -1702,6 +1707,11 @@ class TenderSiaeListView(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["siaes"]), 3)  # detail_contact_click_date
+        # NOT_INTERESTED
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "NOT_INTERESTED"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["siaes"]), 1)  # detail_contact_click_date
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1711,7 +1711,8 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "NOT_INTERESTED"})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["siaes"]), 1)  # detail_contact_click_date
+        self.assertEqual(len(response.context["siaes"]), 1)  # detail_not_interested_click_date
+        self.assertEqual(response.context["siaes"][0], self.siae_5)
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1715,7 +1715,7 @@ class TenderSiaeListView(TestCase):
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default
-        self.assertEqual(self.tender_1.tendersiae_set.first().id, self.tendersiae_1_5.id)
+        self.assertEqual(self.tender_1.tendersiae_set.first().id, self.tendersiae_1_not_interested.id)
         # but TenderSiaeListView are ordered by -detail_contact_click_date
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "INTERESTED"})

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -10,7 +10,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.files.storage import FileSystemStorage
 from django.core.paginator import Paginator
 from django.db import IntegrityError, transaction
-from django.db.models import Prefetch
+from django.db.models import OuterRef, Prefetch, Subquery
 from django.forms import formset_factory
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -730,6 +730,8 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
                 to_attr="prefetched_tendersiae",
             ),
         )
+        tender_siae = TenderSiae.objects.filter(tender=self.tender, siae=OuterRef("pk"))
+        qs = qs.annotate(not_interested_feedback=Subquery(tender_siae.values("detail_not_interested_feedback")[:1]))
 
         qs = qs.with_is_local(perimeter=self.tender.location)
         return qs

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -723,8 +723,14 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
                 "questionanswer_set",
                 queryset=QuestionAnswer.objects.filter(question__tender=self.tender),
                 to_attr="questions_for_tender",
-            )
+            ),
+            Prefetch(
+                "tendersiae_set",
+                queryset=TenderSiae.objects.filter(tender=self.tender),
+                to_attr="prefetched_tendersiae",
+            ),
         )
+
         qs = qs.with_is_local(perimeter=self.tender.location)
         return qs
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -723,12 +723,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
                 "questionanswer_set",
                 queryset=QuestionAnswer.objects.filter(question__tender=self.tender),
                 to_attr="questions_for_tender",
-            ),
-            Prefetch(
-                "tendersiae_set",
-                queryset=TenderSiae.objects.filter(tender=self.tender),
-                to_attr="prefetched_tendersiae",
-            ),
+            )
         )
         tender_siae = TenderSiae.objects.filter(tender=self.tender, siae=OuterRef("pk"))
         qs = qs.annotate(not_interested_feedback=Subquery(tender_siae.values("detail_not_interested_feedback")[:1]))


### PR DESCRIPTION
### Quoi ?
Un nouvel onglet qui liste les fournisseurs ayant explicitement indiqué leur désintérêt pour le projet d’achat.
On affiche la raison du désintérêt dans le détail de la carte